### PR TITLE
fix(ci): Maestro E2E runtime fixes — bundling, routing, Clerk seed

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -218,8 +218,6 @@ jobs:
       #   which crash in embedded (offline) APKs.
       - name: Bundle JS for offline APK
         working-directory: apps/mobile
-        env:
-          EXPO_ROUTER_APP_ROOT: ./src/app
         run: |
           mkdir -p android/app/src/main/assets
 


### PR DESCRIPTION
## Summary
- Fix Maestro E2E CI runtime failures across multiple iterations
- Resolve drizzle-kit CJS import issues in test environment
- Inline EXPO_ROUTER_APP_ROOT in expo-router context file for offline APK
- Use absolute paths and --dev true for Maestro JS bundle
- Add Clerk publishable key for E2E auth screen rendering
- Phase 5 completion: seed scenarios, nightly flows, integration tests, CI schedule

## Test plan
- [ ] CI passes
- [ ] Maestro E2E smoke flows execute without bundling errors
- [ ] Seed endpoint creates deterministic test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)