### PR TITLE
docs(epics): close F7 "Shorten interview" — already implemented [INTERACTION-DUR-L1-followup]

### DIFF
--- a/docs/specs/epics.md
+++ b/docs/specs/epics.md
@@ -6097,6 +6097,7 @@ Replace fragile free-text markers and JSON-in-text patterns with a typed respons
 | 18.13 | **F4 Interview escape button** — "I'm ready to start learning" skip button + `useForceCompleteInterview` | DONE |
 | 18.14 | **F5 Friendly error messages** — `format-api-error.ts` with `FRIENDLY_MESSAGE_MAP` for kid-friendly errors | DONE (partial — no recovery action buttons yet) |
 | 18.15 | **F8 Memory source schema** — `sourceSessionId`/`sourceEventId` fields on `MemoryBlockEntry` | DONE (schema only — all values `null`) |
+| 18.20 | **F7 Shorten interview** — soft target 3 via prompt (`interview-prompts.ts:9, 14-15`), hard cap 4 via `MAX_INTERVIEW_EXCHANGES` (`interview.ts:399`); per PM spec "3, worst case 4" | DONE |
 
 ### Remaining
 
@@ -6106,7 +6107,6 @@ Replace fragile free-text markers and JSON-in-text patterns with a typed respons
 | 18.17 | **F1.2+F1.3 Exchange envelope migration** — migrate `[PARTIAL_PROGRESS]` + `[NEEDS_DEEPENING]` to `signals.*` in main exchange loop | HIGH | 18.16 (reference implementation) |
 | 18.18 | **F2.1+F2.2 UI hints migration** — migrate `notePrompt` + `fluencyDrill` JSON-in-text to `ui_hints.*` | HIGH | 18.17 (same prompt rewrite) |
 | 18.19 | **P1 quiz_missed_items in prompts** — wire SRS missed items into quiz generation prompts | HIGH | None |
-| 18.20 | **F7 Shorten interview** — `MAX_INTERVIEW_EXCHANGES` from 6 to 3, adjust session analysis threshold | MEDIUM | None |
 | 18.21 | **F6 Confidence-aware UI** — surface low/medium confidence as "Is this right?" tap target on mobile | MEDIUM | None |
 | 18.22 | **F5 Recovery action buttons** — error messages include recovery buttons (retry, switch path, go home) | MEDIUM | None |
 | 18.23 | **Dictation review personalization** — inject `ageYears` + struggle history into review prompt | MEDIUM | None |


### PR DESCRIPTION
## Summary

Closes the F7 "Shorten interview" epic (18.20 in `docs/specs/epics.md`). PR #134 reconciled the doc references to `MAX_INTERVIEW_EXCHANGES = 4`; this PR closes the matching roadmap entry now that the PM has clarified intent.

## Context

**PM spec:** "3, worst case 4" — i.e., interviews should typically wrap by exchange 3, with a hard ceiling of 4.

**Verification — both halves are already in production:**

| PM spec | Where it lives today |
|---|---|
| **Soft target = 3** (typical wrap) | `apps/api/src/services/interview-prompts.ts:14` — *"After 2-3 exchanges when you have enough signal: wrap up..."* |
| **Hard cap = 4** (never exceed) | `apps/api/src/services/interview-prompts.ts:15` (model-side) + `MAX_INTERVIEW_EXCHANGES = 4` in `interview.ts:399` (server-side fail-safe), enforced at `interview.ts:532, 658` |
| **Range framing** | `interview-prompts.ts:9` — *"in 3-4 exchanges, assess..."* |

Both interview code paths (`processInterviewExchange:502`, `streamInterviewExchange:587`) consume the same prompt. The `[F-042]` break test in `interview.test.ts:234` continues to assert force-close past the cap.

The "session analysis threshold" clause of the original epic does not require a corresponding change — the prompt already targets the 3-4 range and the analysis pipeline downstream consumes whatever signal the interview produced.

## Change

| File | Edit |
|---|---|
| `docs/specs/epics.md` | Move row 18.20 from **Remaining** table to **Completed** table; rewrite scope cell to summarize the actual implementation (soft target via prompt, hard cap via constant) |

Net diff: 1 file, +1/-1 line.

## Test plan

- [x] No code changed — no lint/typecheck/test re-run required.
- [x] Existing `[F-042]` break test continues to assert the cap contract (force-close past `MAX_INTERVIEW_EXCHANGES`).
- [x] Manual: read `interview-prompts.ts:8-27` to confirm the 3-4 range and "never exceed 4" instruction are present and active.

## Audit trail

- `[AUDIT-INTERACTION-DUR-L1]` — original audit finding (PR #132 deferred this leftover; PR #134 reconciled doc values to 4; this PR closes the matching epic).
- See [PR #134](https://github.com/cognoco/eduagent-build/pull/134) for the doc-value reconciliation that this PR builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)