### PR TITLE
audit(eval): first runLive — exchanges flow [AUDIT-EVAL-2]

### DIFF
--- a/apps/api/eval-llm/README.md
+++ b/apps/api/eval-llm/README.md
@@ -17,7 +17,7 @@ See [`docs/specs/2026-04-18-llm-personalization-audit.md`](../../../docs/specs/2
 
 Use Tier 1 for prompt-regression checks on every push. Use Tier 2 for tuning sessions where you want to see how the model actually responds to personalization.
 
-> **Status note (2026-05-01 audit / [AUDIT-EVAL-1]):** Tier 2 is currently scaffolded but inert for every flow — no flow in this harness implements `runLive`, so `pnpm eval:llm --live` reports `runLive not implemented for this flow` for every flow. The `expectedResponseSchema` is wired on the `exchanges` flow (the largest prompt surface) and will activate envelope-shape validation automatically once a `runLive` is added. Implementing the first `runLive` is an architectural decision (where the LLM client comes from for the harness, streaming-vs-buffered output) and is tracked separately as a follow-up work item.
+> **Status note (2026-05-02 audit / [AUDIT-EVAL-2]):** The `exchanges` flow now implements `runLive` (the first in the harness) — running `pnpm eval:llm --flow exchanges --live` hits the production LLM router via `runner/llm-client.ts`, which tags telemetry with `flow: "eval-harness"` so dashboards can filter eval calls. `expectedResponseSchema: llmResponseEnvelopeSchema` and the per-sample envelope-drift metrics on `exchanges` are now both active. The remaining ~12 flows still report `runLive not implemented for this flow`; copy the `exchanges` pattern when wiring them up. There is one known prompt-fidelity divergence tracked as `AUDIT-EVAL-3`: production `processExchange` concatenates `buildOrphanSystemAddendum(...)` onto the system prompt; the harness does not (yet).
 
 ## Usage
 

--- a/apps/api/eval-llm/flows/exchanges.test.ts
+++ b/apps/api/eval-llm/flows/exchanges.test.ts
@@ -1,3 +1,16 @@
+// ---------------------------------------------------------------------------
+// runLive tests mock the harness LLM client wrapper (matches the inline
+// jest.mock pattern from apps/api/src/services/learner-profile.test.ts:19).
+// The mock factory returns a pass-through that captures all arguments so
+// each test can assert on the exact call shape forwarded to routeAndCall.
+// Hoisted to module top so the mock is registered before any import that
+// transitively pulls runner/llm-client.
+// ---------------------------------------------------------------------------
+const mockRunHarnessLlm = jest.fn();
+jest.mock('../runner/llm-client', () => ({
+  runHarnessLlm: (...args: unknown[]) => mockRunHarnessLlm(...args),
+}));
+
 import { exchangesFlow } from './exchanges';
 import { PROFILES, getProfile } from '../fixtures/profiles';
 import { buildMemoryBlock } from '../../src/services/learner-profile';
@@ -160,6 +173,66 @@ describe('exchangesFlow', () => {
       expect(messages.system.length).toBeGreaterThan(200);
       expect(messages.user).toBe('…still not clicking.');
       expect(messages.notes?.[0]).toContain('S5-rung5-exit');
+    });
+  });
+
+  describe('runLive [AUDIT-EVAL-2]', () => {
+    beforeEach(() => {
+      mockRunHarnessLlm.mockReset();
+    });
+
+    it('forwards system prompt, history, and escalationRung to the harness LLM client', async () => {
+      mockRunHarnessLlm.mockResolvedValue('mock response');
+      const scenarios =
+        exchangesFlow.enumerateScenarios?.(generalProfile) ?? [];
+      const s2 = scenarios.find((s) => s.scenarioId === 'S2-rung2-revisit');
+      if (!s2) throw new Error('S2 missing');
+
+      const messages = exchangesFlow.buildPrompt(s2.input);
+      await exchangesFlow.runLive?.(s2.input, messages);
+
+      expect(mockRunHarnessLlm).toHaveBeenCalledTimes(1);
+      const [chatMessages, escalationRung, options] =
+        mockRunHarnessLlm.mock.calls[0];
+
+      // Same escalation rung as production processExchange would receive
+      expect(escalationRung).toBe(s2.input.context.escalationRung);
+
+      // System prompt is the runner-passed `messages.system` — keeps
+      // Tier 1 ↔ Tier 2 prompt aligned (see runLive comment about
+      // AUDIT-EVAL-3 prompt-fidelity divergence).
+      expect(chatMessages[0]).toEqual({
+        role: 'system',
+        content: messages.system,
+      });
+
+      // The last message is the user turn produced by buildPrompt
+      expect(chatMessages[chatMessages.length - 1]).toEqual({
+        role: 'user',
+        content: messages.user ?? '',
+      });
+
+      // Profile-level personalization options propagate
+      expect(options).toMatchObject({
+        llmTier: s2.input.context.llmTier,
+        conversationLanguage: s2.input.context.conversationLanguage,
+        pronouns: s2.input.context.pronouns,
+      });
+      expect(options.ageBracket).toBeDefined();
+    });
+
+    it('returns the LLM response string verbatim', async () => {
+      mockRunHarnessLlm.mockResolvedValue(
+        '{"reply":"hi","signals":{},"ui_hints":{}}'
+      );
+      const scenarios =
+        exchangesFlow.enumerateScenarios?.(generalProfile) ?? [];
+      const s1 = scenarios[0];
+      const messages = exchangesFlow.buildPrompt(s1.input);
+
+      const response = await exchangesFlow.runLive?.(s1.input, messages);
+
+      expect(response).toBe('{"reply":"hi","signals":{},"ui_hints":{}}');
     });
   });
 

--- a/apps/api/eval-llm/flows/exchanges.ts
+++ b/apps/api/eval-llm/flows/exchanges.ts
@@ -2,9 +2,12 @@ import {
   buildSystemPrompt,
   type ExchangeContext,
 } from '../../src/services/exchanges';
+import { resolveAgeBracket } from '../../src/services/exchange-prompts';
 import { buildMemoryBlock } from '../../src/services/learner-profile';
+import type { ChatMessage } from '../../src/services/llm/types';
 import { llmResponseEnvelopeSchema } from '@eduagent/schemas';
 import type { EvalProfile } from '../fixtures/profiles';
+import { runHarnessLlm } from '../runner/llm-client';
 import {
   HISTORY_S1_RUNG1,
   HISTORY_S2_RUNG2,
@@ -371,5 +374,54 @@ export const exchangesFlow: FlowDefinition<ExchangeScenarioInput> = {
     };
   },
 
-  // runLive not yet implemented for this flow — see eval-harness README for status.
+  // -------------------------------------------------------------------------
+  // [AUDIT-EVAL-2 / 2026-05-02] First runLive in the harness — sets the
+  // pattern for the other ~12 flows. Mirrors production processExchange
+  // (apps/api/src/services/exchanges.ts:301) — same routeAndCall signature,
+  // same per-context options (llmTier, ageBracket, conversationLanguage,
+  // pronouns), same escalationRung. The wrapper tags telemetry with
+  // flow: "eval-harness" so dashboards can filter eval calls out.
+  //
+  // Known divergence (tracked separately as AUDIT-EVAL-3): production
+  // concatenates `buildOrphanSystemAddendum(...)` onto the system prompt;
+  // this harness only sends `buildSystemPrompt(context)` (matching what
+  // buildPrompt above produces, and what the Tier-1 snapshot displays).
+  // We deliberately use messages.system here so the live call validates
+  // the same prompt the snapshot shows — fixing the addendum gap means
+  // updating buildPrompt too, which is its own scope.
+  // -------------------------------------------------------------------------
+  async runLive(
+    input: ExchangeScenarioInput,
+    messages: PromptMessages
+  ): Promise<string> {
+    const history = input.context.exchangeHistory;
+    // The runner-passed `messages.user` was extracted from the last user
+    // turn in history (see buildPrompt above). Send the rest of history as
+    // prior context so the LLM sees the same multi-turn shape production
+    // sees — otherwise envelope validation only covers single-turn replies.
+    const lastUserIndex = (() => {
+      for (let i = history.length - 1; i >= 0; i--) {
+        if (history[i].role === 'user') return i;
+      }
+      return -1;
+    })();
+    const priorTurns =
+      lastUserIndex >= 0 ? history.slice(0, lastUserIndex) : history;
+
+    const chatMessages: ChatMessage[] = [
+      { role: 'system', content: messages.system },
+      ...priorTurns.map((t) => ({
+        role: t.role,
+        content: t.content,
+      })),
+      { role: 'user' as const, content: messages.user ?? '' },
+    ];
+
+    return runHarnessLlm(chatMessages, input.context.escalationRung, {
+      llmTier: input.context.llmTier,
+      ageBracket: resolveAgeBracket(input.context.birthYear),
+      conversationLanguage: input.context.conversationLanguage,
+      pronouns: input.context.pronouns,
+    });
+  },
 };

--- a/apps/api/eval-llm/runner/llm-client.ts
+++ b/apps/api/eval-llm/runner/llm-client.ts
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------
+// Eval-LLM — Harness LLM client wrapper [AUDIT-EVAL-2 / 2026-05-02]
+//
+// Single seam between the eval harness and the production LLM router. Flow
+// adapters call `runHarnessLlm` from their `runLive` implementation; this
+// wrapper threads through to `routeAndCall` with one harness-specific
+// override:
+//
+//   - `flow: "eval-harness"` — tags the `llm.stop_reason` telemetry so
+//     dashboard queries (`count by stop_reason, flow over 24h` per
+//     services/llm/router.ts:27) can filter eval runs out of production
+//     metrics. The router's `flow` field already exists as a first-class
+//     dimension; tagging is the entire telemetry-isolation strategy. No
+//     "silent mode" plumbing is needed.
+//
+// Everything else mirrors production. Same provider, same model selection
+// (driven by `escalationRung`), same safety preamble. If `runLive` returned
+// a response that the production router would not have produced, the
+// downstream Tier 2 envelope-shape validation would be theater.
+// ---------------------------------------------------------------------------
+
+import { routeAndCall } from '../../src/services/llm/router';
+import type { ChatMessage, EscalationRung } from '../../src/services/llm/types';
+
+const HARNESS_FLOW_TAG = 'eval-harness';
+
+type RouteAndCallOptions = NonNullable<Parameters<typeof routeAndCall>[2]>;
+
+/** Options accepted by the harness wrapper — the same shape `routeAndCall`
+ *  accepts, minus `flow` (the wrapper hardcodes that). */
+export type HarnessLlmOptions = Omit<RouteAndCallOptions, 'flow'>;
+
+/**
+ * Run a real LLM call from the eval harness.
+ *
+ * Returns the raw response string — the runner handles JSON extraction
+ * and schema validation downstream (see runner/runner.ts:246).
+ */
+export async function runHarnessLlm(
+  messages: ChatMessage[],
+  escalationRung: EscalationRung,
+  options?: HarnessLlmOptions
+): Promise<string> {
+  const result = await routeAndCall(messages, escalationRung, {
+    ...options,
+    flow: HARNESS_FLOW_TAG,
+  });
+  return result.response;
+}


### PR DESCRIPTION
## Summary

First `runLive` adapter in the eval-llm harness. Activates the
`llmResponseEnvelopeSchema` validation that has been wired but inert on the
`exchanges` flow since the harness was created. PR #132 only documented the
gap; this implements it.

- **`runner/llm-client.ts`** (new, ~50 lines) — single seam between harness
  and production LLM router. Wraps `routeAndCall` with a hardcoded
  `flow: \"eval-harness\"` telemetry tag so dashboard queries
  (`count by stop_reason, flow over 24h` per `services/llm/router.ts:27`)
  can filter eval calls out of production metrics. No silent-mode plumbing
  needed — the router's `flow` field already exists as a first-class
  dimension.
- **`flows/exchanges.ts`** — `runLive` implementation mirrors production
  `processExchange` (`apps/api/src/services/exchanges.ts:301`): same
  `routeAndCall` signature, same per-context options (`llmTier`,
  `ageBracket`, `conversationLanguage`, `pronouns`), same
  `escalationRung`. Uses the runner-passed `messages.system` so Tier-1
  and Tier-2 stay aligned (the live response validates the same prompt
  that appears in the snapshot).
- **`flows/exchanges.test.ts`** — 2 new tests covering message-shape
  forwarding and verbatim response passthrough; mocks
  `runner/llm-client` inline (matches the pattern at
  `apps/api/src/services/learner-profile.test.ts:19`).
- **`README.md`** — status note updated.

## Why this is the first runLive

`exchanges` is the only flow with both `emitsEnvelope: true` AND
`expectedResponseSchema: llmResponseEnvelopeSchema` wired, so its
`runLive` activates two validation layers at once: per-sample envelope
shape validation + aggregate envelope-drift metrics. Every other flow
gets less leverage from a runLive implementation. This sets the pattern
the remaining ~12 flows will copy.

## Known divergence (out of scope, tagged AUDIT-EVAL-3)

Production `processExchange` concatenates `buildOrphanSystemAddendum(...)`
onto the system prompt; the harness `buildPrompt` does not. Fixing that
gap means changing `buildPrompt` and re-snapshotting all 37 exchanges
Tier-1 outputs — separate scope, separate PR. `runLive` deliberately
uses `messages.system` (the snapshot's prompt) rather than rebuilding to
match production, so Tier-1 and Tier-2 stay aligned in this PR.

## Test plan

- [x] `pnpm exec nx run api:typecheck` — pass
- [x] `pnpm exec nx run api:lint` — pass (no new warnings; only
      pre-existing warnings in other files)
- [x] `jest exchanges.test.ts` — 14/14 passing (12 existing + 2 new
      runLive tests). Note: jest invocation from inside a worktree on
      Windows requires `--testMatch` override because micromatch escapes
      `.claude` as `\.claude` in the resolved testMatch glob; this is
      an unrelated worktree-tooling issue, not introduced by this PR.
- [x] `pnpm eval:llm --flow exchanges` — Tier-1 snapshots byte-identical;
      no regression in the 37 generated snapshots
- [ ] Manual Tier-2 smoke (1 LLM call, requires Doppler):
      `doppler run -- pnpm eval:llm --flow exchanges --profile 09yo-dinosaurs --live --max-live-calls 1`
      — deferred for the reviewer; expected outcome:
      - Tier-2 snapshot for `09yo-dinosaurs` includes a real "Live LLM
        response" section
      - No "Schema violation" section if envelope shape matches
      - `llm.stop_reason flow=\"eval-harness\"` appears in stdout

## Audit context

This is the second piece of the artefact-consistency audit's open work.
Track A (PR #132, merged) shipped the four production-relevant code
fixes; Track B (PR #131, merged) covered docs cleanup; this PR is the
architectural follow-up that PR #132 deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)