### PR TITLE
docs(audit): artefact-consistency punch list + SCHEMA-2 plan

### DIFF
--- a/docs/audit/2026-05-02-artefact-consistency-punchlist.md
+++ b/docs/audit/2026-05-02-artefact-consistency-punchlist.md
@@ -66,6 +66,20 @@
     - 4 internal step-chaining signals (`filing.retry_completed`, `filing.auto_retry_attempted`, `session.completed_with_errors`, `session.filing_resolved`) — `step.sendEvent` not external Inngest emission
     - 3 infrastructure events (`idempotency.assistant_turn_lookup_failed`, `idempotency.mark_failed`, `idempotency.preflight_lookup_failed`) — instrumentation-only, intentional
 
+- **AUDIT-SPECS-2** RLS plan status-table refresh (escalated 2026-05-02 from unclassified after concrete recon)
+  - Severity: YELLOW (doc consistency — plan internally contradicts itself)
+  - Effort: ~30-40 min (verify each Phase row in the status table, refresh wording, archive stale "Implication" paragraph)
+  - Files: `docs/plans/2026-04-15-S06-rls-phase-0-1-preparatory.md`
+  - Concrete state vs plan claim:
+    | Phase | Plan table says (2026-04-27) | Code reality (verified 2026-05-02) | Action |
+    |---|---|---|---|
+    | 0.0 driver swap | NOT DONE | DONE — `client.ts` uses dual-driver `looksLikeNeon()` selector since PR #126 | Header at top already says this; refresh table row |
+    | 0.1 remove fallback | NOT DONE | DONE — `client.ts:60-62` explicitly: "The silent non-atomic fallback... has been removed" | Refresh table row |
+    | 0.3 integration test | NOT DONE | LIKELY DONE — `packages/database/src/rls.integration.test.ts` exists (content not verified in this recon) | Spot-check test content; refresh row |
+    | 1.3 deploy + verify | unverified | unverified — needs `pg_tables.rowsecurity` query against staging/prod | Run query, document |
+    | "Implication" paragraph | "ticking-bomb state" | Stale — header marks it stale but body unchanged | Move paragraph into a `## Historical context` section |
+  - Why it matters: plan's reconciliation in PR #131 added a "Phase 0.0 is DONE" header but didn't update the inline status table, creating an internal contradiction that confuses readers about RLS rollout state. Not security-critical (the wording is over-stated, not under-stated), but exactly the "team detects new drift, doesn't sweep backward" pattern this audit was meant to catch.
+
 ## Track C cleanups
 
 - **AUDIT-MIGRATIONS-1** Regenerate 10 missing snapshot files in `apps/api/drizzle/meta/`
@@ -96,11 +110,9 @@
 
 ## Findings I could not classify confidently (still)
 
-- **AUDIT-SPECS-2** RLS plan "ticking-bomb" wording — recon flagged YELLOW-leaning-RED but transcript also says "fix shipped in PR #126." If PR #126 actually fixed the underlying tickets, this is just stale wording (Track B/C); if the wording reflects an unresolved security issue still on the books, it's RED.
-  - Unclear: whether PR #126 closed the substantive issue or just the symptom
-  - Needed: read `docs/plans/2026-04-15-S06-rls-phase-0-1-preparatory.md` head-to-head against PR #126 diff
-
 _(AUDIT-INNGEST-2 recon completed 2026-05-02; promoted to Track B above with concrete file list.)_
+
+_(AUDIT-SPECS-2 recon completed 2026-05-02; promoted to Track B above with concrete scope.)_
 
 ---
 
@@ -108,4 +120,5 @@ _(AUDIT-INNGEST-2 recon completed 2026-05-02; promoted to Track B above with con
 
 1. Of the original 4 explicit `[AUDIT-*]` IDs in the recon transcript, all shipped in PR #132. Every other ID was synthesized post-hoc by the recon-replay agent (2026-05-02) and tagged `(synthesized)` where applicable.
 2. AUDIT-SCHEMA-2 was escalated from "unclassified" after concrete recon found 88% gap, not 25%. The original heatmap underweighted this finding; treat similar "we don't have a file list yet" entries with that caveat.
-3. AUDIT-INNGEST-2 was also escalated from "unclassified" after recon — original signal was real, found 3 confirmed orphans matching the same pattern PR #132 fixed for `app/payment.failed`. Two of three unclassified items have so far validated the original recon's signal.
+3. AUDIT-INNGEST-2 was also escalated from "unclassified" after recon — original signal was real, found 3 confirmed orphans matching the same pattern PR #132 fixed for `app/payment.failed`.
+4. AUDIT-SPECS-2 was also escalated from "unclassified" after recon — plan was partially reconciled in PR #131 (header) but not fully (inline status table), creating an internal contradiction. **All three originally-unclassified items validated the original recon's signal** — the unclassified bucket was real signal, not noise. Future "we don't have a file list yet" entries should be treated with that prior.

--- a/docs/audit/2026-05-02-artefact-consistency-punchlist.md
+++ b/docs/audit/2026-05-02-artefact-consistency-punchlist.md
@@ -1,0 +1,97 @@
+# Artefact-consistency audit — punch list
+
+**Source recon:** 9-agent audit, 2 rounds, 2026-05-01.
+**Last updated:** 2026-05-02 (post AUDIT-SCHEMA-2 recon).
+**Coordination branch:** `artefact-consistency` (carries audit-only tracking docs; not merged to main).
+
+---
+
+## Already shipped
+
+| ID | What | Where |
+|---|---|---|
+| AUDIT-INNGEST-1 | payment.failed observer | PR #132 (`4b63e4b4`) |
+| AUDIT-SCHEMA-1 | mobile aiFeedback nullability | PR #132 (`ba3db196`) |
+| AUDIT-SKILLS-1 | broken pre-commit hook removed | PR #132 (`11cd1346`) |
+| AUDIT-EVAL-1 | Tier 2 runLive inertness documented | PR #132 (`9a4af1d7`) |
+| AUDIT-EXTREFS-1 | `db:*:stg` → `db:*:dev` package.json rename | PR #131 |
+| AUDIT-GOVERNING-1a | CLAUDE.md Snapshot counts refreshed | PR #131 |
+| AUDIT-GOVERNING-1b | "Known Exceptions" subsection added | PR #131 |
+| AUDIT-GOVERNING-1c | `ux-dead-end-audit` skill citation removed | PR #131 |
+| AUDIT-ARCH-1 | architecture.md drizzle/AppType/route fixes | PR #131 |
+| AUDIT-SPECS-1 | plan-status refresh on 4 active plans | PR #131 |
+| AUDIT-MEMORY-1 | `dev_schema_drift_trap.md` self-contradiction healed | PR #131 |
+| INTERACTION-DUR-L1 | MAX_INTERVIEW_EXCHANGES docs → 4 | PR #134 |
+| AUDIT-MIGRATIONS-3 | Migration 0017 rollback notes | PR #135 |
+| AUDIT-WORKFLOW | `_wip/` gitignored | direct push to main (`55cd30df`) |
+
+## In flight
+
+| ID | What | Where |
+|---|---|---|
+| AUDIT-EVAL-2 | Implement `runLive` for one production flow | Branched session, worktree `audit-eval-runlive` |
+
+## Track B remaining
+
+- **AUDIT-GOVERNING-2** Resolve `apps/api/src/routes/sessions.ts` direct drizzle-orm import
+  - Severity: YELLOW (governance)
+  - Effort: hours (refactor) or 0 (already documented as exception in PR #131; this item is "decide if/when to refactor")
+  - Files: `apps/api/src/routes/sessions.ts`
+  - Why it matters: one of the non-negotiable engineering rules has a live exception; until refactor lands, every new contributor will ask whether the rule still applies
+
+- **AUDIT-GOVERNING-1d** CLAUDE.md `db:*` Handy Commands sweep
+  - Severity: YELLOW
+  - Effort: ~10 min
+  - Files: `CLAUDE.md` (Handy Commands block)
+  - Why it matters: PR #131 renamed scripts; need to confirm all CLAUDE.md `db:*` invocations still resolve
+
+- **AUDIT-SCHEMA-2** Response-schema gap — see [`2026-05-02-audit-schema-2-plan.md`](./2026-05-02-audit-schema-2-plan.md)
+  - Severity: **YELLOW-leaning-RED** (escalated 2026-05-02 from unclassified after concrete recon)
+  - Effort: multi-PR (~2-4 PRs over the course of the initiative)
+  - Why it matters: 36 of 41 route files (88%) violate the CLAUDE.md non-negotiable "`@eduagent/schemas` is the shared contract." Contract exists, ~50 response schemas defined, only `bookmarks.ts` actually uses them.
+
+## Track C cleanups
+
+- **AUDIT-MIGRATIONS-1** Regenerate 10 missing snapshot files in `apps/api/drizzle/meta/`
+  - Severity: YELLOW; Effort: ~1 hr
+  - Files: `apps/api/drizzle/meta/*.json` (snapshots for migrations 0006–0010, 0013, 0021, 0025, 0043, 0044)
+  - Why: silent time bomb for the next `drizzle-kit generate`
+
+- **AUDIT-MIGRATIONS-2** Backward sweep of non-monotonic `_journal.json` `when` timestamps
+  - Severity: YELLOW (audit-trail integrity, not runtime); Effort: ~30 min
+  - Files: `apps/api/drizzle/meta/_journal.json`
+  - Why: PR #129 only fixed entry 0044; backward sweep needed
+
+- **AUDIT-MEMORY-2** `.claude/memory/` ~96-file dedupe
+  - Severity: YELLOW (low-impact); Effort: ~1 hr
+
+- **AUDIT-SKILLS-2** Vendored `commands/bmad/` vs installed plugin — pick canonical
+  - Severity: YELLOW (cosmetic / maintenance); Effort: ~30 min
+
+- **AUDIT-EXTREFS-2** EduAgent → Mentomate naming sweep across docs/code (carefully — NOT `@eduagent/*` package names)
+  - Severity: YELLOW (cosmetic); Effort: ~1 hr
+
+- **AUDIT-EXTREFS-3** Per-package READMEs for `apps/api/`, `apps/mobile/`, `packages/*`
+  - Severity: YELLOW (helpful but not urgent); Effort: ~2 hr
+
+- **AUDIT-MIGRATIONS-3-SWEEP** (synthesized) Sweep all destructive migrations for missing `## Rollback` sections
+  - Severity: YELLOW; Effort: ~2 hr (PR #135 only fixed migration 0017; broader audit pending)
+  - Why: closes the CLAUDE.md "Schema And Deploy Safety" rule across history
+
+## Findings I could not classify confidently (still)
+
+- **AUDIT-SPECS-2** RLS plan "ticking-bomb" wording — recon flagged YELLOW-leaning-RED but transcript also says "fix shipped in PR #126." If PR #126 actually fixed the underlying tickets, this is just stale wording (Track B/C); if the wording reflects an unresolved security issue still on the books, it's RED.
+  - Unclear: whether PR #126 closed the substantive issue or just the symptom
+  - Needed: read `docs/plans/2026-04-15-S06-rls-phase-0-1-preparatory.md` head-to-head against PR #126 diff
+
+- **AUDIT-INNGEST-2** Telemetry-only event handler audit — recon flagged ambiguous "telemetry-only events with no Inngest handler" comments, but never enumerated the events or verified each had either a handler or a documented "by design no handler" rationale.
+  - Unclear: are these documented terminuses (fine) or undocumented orphans (need observers)?
+  - Status: **scheduled for recon next** — fork to enumerate emit-vs-handle cross-reference; will replace this entry with a concrete per-event table when done.
+
+---
+
+## Audit honesty disclosures
+
+1. Of the original 4 explicit `[AUDIT-*]` IDs in the recon transcript, all shipped in PR #132. Every other ID was synthesized post-hoc by the recon-replay agent (2026-05-02) and tagged `(synthesized)` where applicable.
+2. AUDIT-SCHEMA-2 was escalated from "unclassified" after concrete recon found 88% gap, not 25%. The original heatmap underweighted this finding; treat similar "we don't have a file list yet" entries with that caveat.
+3. AUDIT-INNGEST-2 may turn out similarly underweighted — recon underway.

--- a/docs/audit/2026-05-02-artefact-consistency-punchlist.md
+++ b/docs/audit/2026-05-02-artefact-consistency-punchlist.md
@@ -50,6 +50,22 @@
   - Effort: multi-PR (~2-4 PRs over the course of the initiative)
   - Why it matters: 36 of 41 route files (88%) violate the CLAUDE.md non-negotiable "`@eduagent/schemas` is the shared contract." Contract exists, ~50 response schemas defined, only `bookmarks.ts` actually uses them.
 
+- **AUDIT-INNGEST-2** Inngest event orphan sweep (escalated 2026-05-02 from unclassified after concrete recon)
+  - Severity: YELLOW (silent recovery without escalation per CLAUDE.md)
+  - Effort: ~10 min, single PR
+  - Files: 2 new observer functions in `apps/api/src/inngest/functions/` (mirror `payment-failed-observe.ts`), wire into `inngest/index.ts`
+  - Concrete orphans found:
+    | Event | Emitted at | Observer to ship |
+    |---|---|---|
+    | `app/ask.gate_decision` | `routes/sessions.ts:260` | `ask-gate-observe.ts` (handles both ask.gate_* events) |
+    | `app/ask.gate_timeout` | `routes/sessions.ts:274` | (same observer as above) |
+    | `app/email.bounced` | `routes/resend-webhook.ts:199` | `email-bounced-observe.ts` |
+  - Why it matters: same "consumed by observability tooling but no consumer exists" pattern PR #132 fixed for `app/payment.failed`. The team caught the new drift in #132 but didn't sweep backward; these three are the leftovers.
+  - Explicitly cleared as fine (do not re-audit):
+    - 27 properly-handled events (full table in `_wip/audit-inngest-2-recon.md` if needed)
+    - 4 internal step-chaining signals (`filing.retry_completed`, `filing.auto_retry_attempted`, `session.completed_with_errors`, `session.filing_resolved`) — `step.sendEvent` not external Inngest emission
+    - 3 infrastructure events (`idempotency.assistant_turn_lookup_failed`, `idempotency.mark_failed`, `idempotency.preflight_lookup_failed`) — instrumentation-only, intentional
+
 ## Track C cleanups
 
 - **AUDIT-MIGRATIONS-1** Regenerate 10 missing snapshot files in `apps/api/drizzle/meta/`
@@ -84,9 +100,7 @@
   - Unclear: whether PR #126 closed the substantive issue or just the symptom
   - Needed: read `docs/plans/2026-04-15-S06-rls-phase-0-1-preparatory.md` head-to-head against PR #126 diff
 
-- **AUDIT-INNGEST-2** Telemetry-only event handler audit — recon flagged ambiguous "telemetry-only events with no Inngest handler" comments, but never enumerated the events or verified each had either a handler or a documented "by design no handler" rationale.
-  - Unclear: are these documented terminuses (fine) or undocumented orphans (need observers)?
-  - Status: **scheduled for recon next** — fork to enumerate emit-vs-handle cross-reference; will replace this entry with a concrete per-event table when done.
+_(AUDIT-INNGEST-2 recon completed 2026-05-02; promoted to Track B above with concrete file list.)_
 
 ---
 
@@ -94,4 +108,4 @@
 
 1. Of the original 4 explicit `[AUDIT-*]` IDs in the recon transcript, all shipped in PR #132. Every other ID was synthesized post-hoc by the recon-replay agent (2026-05-02) and tagged `(synthesized)` where applicable.
 2. AUDIT-SCHEMA-2 was escalated from "unclassified" after concrete recon found 88% gap, not 25%. The original heatmap underweighted this finding; treat similar "we don't have a file list yet" entries with that caveat.
-3. AUDIT-INNGEST-2 may turn out similarly underweighted — recon underway.
+3. AUDIT-INNGEST-2 was also escalated from "unclassified" after recon — original signal was real, found 3 confirmed orphans matching the same pattern PR #132 fixed for `app/payment.failed`. Two of three unclassified items have so far validated the original recon's signal.

--- a/docs/audit/2026-05-02-audit-schema-2-plan.md
+++ b/docs/audit/2026-05-02-audit-schema-2-plan.md
@@ -1,0 +1,119 @@
+# AUDIT-SCHEMA-2 — response-schema migration plan
+
+**Filed:** 2026-05-02 by recon agent during artefact-consistency audit.
+**Severity:** YELLOW-leaning-RED (escalated from "unclassified" after concrete enumeration).
+**Status:** Plan only — no PRs opened yet.
+
+## The finding (concrete, post-recon)
+
+36 of 41 API route files (88%) call `c.json(result)` without runtime validation against a Zod response schema. This violates the CLAUDE.md non-negotiable: "`@eduagent/schemas` is the shared contract."
+
+The contract is **not missing** — `@eduagent/schemas` already exports ~50 response schemas (e.g., `bookmarkListResponseSchema`, `checkoutResponseSchema`, `filingResponseSchema`, `quickCheckResponseSchema`). They go unused. Only `bookmarks.ts` calls `responseSchema.parse(...)` before `c.json(...)`. Several files (`assessments.ts`, `consent.ts`, `billing.ts`) **import** response schemas but never call `.parse()` on them — strong evidence that a migration was started and abandoned.
+
+TypeScript types still flow correctly via return-type inference and `satisfies` clauses, which is why this stayed invisible: the type-system report says "fine"; only runtime validation is missing.
+
+## File-by-file classification (recon 2026-05-02)
+
+| File | c.json count | Class | Notes |
+|---|---|---|---|
+| learner-profile.ts | 22 | RAW | Core profile data; impacts mobile home screen |
+| sessions.ts | 18 | RAW | Core learning flow; `.parse()` exists but only for Inngest events |
+| dashboard.ts | 16 | RAW | Parent-facing analytics |
+| billing.ts | 15 | RAW | Imports schemas but never uses |
+| test-seed.ts | 13 | RAW | Test surface — lower priority |
+| settings.ts | 12 | RAW | |
+| retention.ts | 11 | RAW | |
+| quiz.ts | 9 | RAW | |
+| progress.ts | 8 | RAW | |
+| interview.ts | 8 | RAW | `.parse()` is for SSE frames, not responses |
+| consent.ts | 8 | RAW | Imports `consentResponseSchema` but doesn't use it |
+| subjects.ts | 7 | RAW | |
+| curriculum.ts | 7 | RAW | |
+| books.ts | 7 | RAW | |
+| onboarding.ts | 6 | RAW | |
+| revenuecat-webhook.ts | 5 | RAW | `.safeParse()` is for input validation |
+| profiles.ts | 5 | RAW | |
+| dictation.ts | 5 | RAW | |
+| vocabulary.ts | 4 | RAW | |
+| snapshot-progress.ts | 4 | RAW | |
+| notes.ts | 4 | RAW | |
+| filing.ts | 4 | RAW | |
+| assessments.ts | 4 | RAW | Imports schemas but doesn't use |
+| parking-lot.ts | 3 | RAW | |
+| celebrations.ts | 3 | TRIVIAL | Literal `{ celebrationUnlocked }` |
+| **bookmarks.ts** | **3** | **VALIDATED** | Only file using `responseSchema.parse()` |
+| auth.ts | 3 | RAW | |
+| account.ts | 3 | RAW | |
+| streaks.ts | 2 | RAW | |
+| homework.ts | 2 | RAW | |
+| feedback.ts | 2 | TRIVIAL | `{ ok: true }` returns |
+| book-suggestions.ts | 2 | RAW | |
+| topic-suggestions.ts | 1 | RAW | |
+| support.ts | 1 | RAW | |
+| stripe-webhook.ts | 1 | TRIVIAL | `{ received: true }` ack |
+| resend-webhook.ts | 1 | TRIVIAL | Webhook ack |
+| language-progress.ts | 1 | RAW | |
+| health.ts | 1 | RAW | Literal `{ status, timestamp, llm }` |
+| coaching-card.ts | 1 | RAW | |
+| inngest.ts | 0 | ZERO | No c.json calls |
+| consent-web.ts | 0 | ZERO | No c.json calls |
+
+**Totals:** 36 RAW, 1 VALIDATED, 4 TRIVIAL, 0 MIXED, 2 ZERO. **88% gap.**
+
+## Migration pattern (mechanical)
+
+For each route file:
+
+1. Identify whether a corresponding response schema already exists in `@eduagent/schemas`. Most do.
+2. Wrap each `c.json(result)` with the corresponding schema's `.parse()`:
+   ```ts
+   // Before
+   return c.json({ profile });
+
+   // After
+   import { learnerProfileResponseSchema } from '@eduagent/schemas';
+   return c.json(learnerProfileResponseSchema.parse({ profile }));
+   ```
+3. If no schema exists for a response shape, define one in `@eduagent/schemas/src/[domain].ts` first (mirror the pattern in `bookmarks.ts`).
+4. Don't touch TRIVIAL files — wrapping `{ ok: true }` is over-engineering.
+5. Webhook handlers' `{ received: true }` acks fall under TRIVIAL too.
+
+**Out-of-scope for this initiative:** behavioral changes, response shape changes, request validation (already handled via `zValidator`), error response shapes (separate concern).
+
+## PR shape (proposed)
+
+| PR | Scope | Goal | Effort |
+|---|---|---|---|
+| **PR 1** | Top-3 files: `learner-profile.ts`, `sessions.ts`, `dashboard.ts` (56 calls). Plus a custom ESLint rule that flags new bare `c.json(...)` without nearby `.parse()`. | Establish the pattern; prevent regression on future PRs. | ~3-4 hr |
+| **PR 2** | Files 4-13 by call count: `billing.ts`, `test-seed.ts`, `settings.ts`, `retention.ts`, `quiz.ts`, `progress.ts`, `interview.ts`, `consent.ts`, `subjects.ts`, `curriculum.ts` (~98 calls) | Bulk sweep of the next-most-used surfaces | ~4 hr |
+| **PR 3** | Remaining 23 RAW files (~78 calls) | Finish the sweep | ~3 hr |
+| (Stretch) **PR 4** | Define any missing response schemas in `@eduagent/schemas` discovered during PRs 1-3 | Close the contract gap | TBD |
+
+## Verification per-PR
+
+- **No behavioral test changes expected.** If `responseSchema.parse(result)` throws, the existing route returned a shape that the schema didn't anticipate — that's a real bug, fix the schema or fix the response, do not loosen the schema to silence it.
+- Run targeted tests for the changed route groups: `pnpm exec jest --findRelatedTests apps/api/src/routes/[file].ts --no-coverage`
+- Run `pnpm exec nx run api:typecheck` and `pnpm exec nx run api:lint`
+- Run integration tests for the changed surfaces (mobile may already exercise these via `apiClient` calls).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `responseSchema.parse(...)` throws in production for a payload the schema didn't allow → 500 to user | Use `safeParse` initially; log discrepancies; promote to throwing parse only after observation window. Or: schema-out-strict per file, with a runtime audit metric on each PR. |
+| Existing schemas are wrong or outdated | First step in each PR is to read the existing schema and reconcile against actual responses. Schema fixes go in the same PR as their wrapping. |
+| Mobile contract drift | Mobile already uses `@eduagent/schemas` types via `AppType` for type-checking. Adding runtime validation on the API side does not change the wire shape — only enforces it. |
+| Performance overhead | Zod parse on every response. Acceptable for non-hot paths; benchmark hot paths (sessions stream, dashboard) before merging PR 1. |
+
+## Why this is a separate initiative, not "Track C"
+
+- 232 c.json calls across 36 files is too much for one PR
+- Violates a CLAUDE.md non-negotiable, not a stylistic concern
+- Has its own architectural decisions (safeParse vs parse; how to surface schema mismatches)
+- Worth a Notion ticket or its own multi-PR thread, separate from the audit punch list once PR 1 lands
+
+## Open decisions before PR 1
+
+1. **`safeParse` + log vs. `parse` + throw?** Conservative path: safeParse + structured log + observability metric for ~1 week, then promote to throwing parse.
+2. **Where does the lint rule live?** Custom `eslint-plugin-eduagent` (does that already exist?) or one-off rule in repo `.eslintrc`.
+3. **Who owns the response-schema definitions when missing?** Whoever opens the PR for that file, or batched into the stretch PR 4.


### PR DESCRIPTION
## Summary
- Promote artefact-consistency punch list from working doc to audit/
- Promote AUDIT-INNGEST-2 from unclassified to Track B
- Add SCHEMA-2 plan for schema consistency

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added audit documentation and process planning guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->