### PR TITLE
chore(eval-llm): post-merge cleanup from PR #139 [AUDIT-EVAL-2.1]

### DIFF
--- a/apps/api/eval-llm/flows/exchanges.test.ts
+++ b/apps/api/eval-llm/flows/exchanges.test.ts
@@ -218,7 +218,8 @@ describe('exchangesFlow', () => {
       mockRunHarnessLlm.mockResolvedValue('ok');
       const scenarios =
         exchangesFlow.enumerateScenarios?.(generalProfile) ?? [];
-      const s1 = scenarios[0];
+      const s1 = scenarios.find((s) => s.scenarioId === 'S1-rung1-teach-new');
+      if (!s1) throw new Error('S1 missing');
 
       const forgedInput = {
         ...s1.input,
@@ -252,16 +253,20 @@ describe('exchangesFlow', () => {
     it('throws when buildPrompt produces no user turn', async () => {
       const scenarios =
         exchangesFlow.enumerateScenarios?.(generalProfile) ?? [];
-      const s1 = scenarios[0];
+      const s1 = scenarios.find((s) => s.scenarioId === 'S1-rung1-teach-new');
+      if (!s1) throw new Error('S1 missing');
       const messages = exchangesFlow.buildPrompt(s1.input);
 
       await expect(exchangesFlow.runLive?.(s1.input, messages)).rejects.toThrow(
-        /messages\.user is undefined/
+        /messages\.user is undefined or empty/
       );
 
       await expect(
-        exchangesFlow.runLive?.(s1.input, { system: 'test', user: undefined })
-      ).rejects.toThrow(/messages\.user is undefined/);
+        exchangesFlow.runLive?.(s1.input, {
+          system: messages.system,
+          user: undefined,
+        })
+      ).rejects.toThrow(/messages\.user is undefined or empty/);
       expect(mockRunHarnessLlm).not.toHaveBeenCalled();
     });
 

--- a/apps/api/eval-llm/flows/exchanges.ts
+++ b/apps/api/eval-llm/flows/exchanges.ts
@@ -22,7 +22,6 @@ import {
   type HistoryTurn,
 } from '../fixtures/exchange-histories';
 import type { FlowDefinition, PromptMessages, Scenario } from '../runner/types';
-import { callLlm } from '../runner/llm-bootstrap';
 
 // ---------------------------------------------------------------------------
 // Flow adapter — Main tutoring loop (exchanges.buildSystemPrompt)
@@ -376,6 +375,22 @@ export const exchangesFlow: FlowDefinition<ExchangeScenarioInput> = {
     };
   },
 
+  // -------------------------------------------------------------------------
+  // [AUDIT-EVAL-2 / 2026-05-02] First runLive in the harness — sets the
+  // pattern for the other ~12 flows. Mirrors production processExchange
+  // (apps/api/src/services/exchanges.ts) — same routeAndCall signature,
+  // same per-context options (llmTier, ageBracket, conversationLanguage,
+  // pronouns), same escalationRung. The wrapper tags telemetry with
+  // flow: "eval-harness" so dashboards can filter eval calls out.
+  //
+  // Known divergence (tracked separately as AUDIT-EVAL-3): production
+  // concatenates `buildOrphanSystemAddendum(...)` onto the system prompt;
+  // this harness only sends `buildSystemPrompt(context)` (matching what
+  // buildPrompt above produces, and what the Tier-1 snapshot displays).
+  // We deliberately use messages.system here so the live call validates
+  // the same prompt the snapshot shows — fixing the addendum gap means
+  // updating buildPrompt too, which is its own scope.
+  // -------------------------------------------------------------------------
   async runLive(
     input: ExchangeScenarioInput,
     messages: PromptMessages
@@ -390,9 +405,10 @@ export const exchangesFlow: FlowDefinition<ExchangeScenarioInput> = {
     const priorTurns =
       lastUserIndex >= 0 ? history.slice(0, lastUserIndex) : history;
 
+    // Throw rather than silently forward an empty user turn — enforces buildPrompt contract for flows that copy this pattern.
     if (!messages.user) {
       throw new Error(
-        `runLive: messages.user is undefined for scenario ${input.scenarioId} — buildPrompt must produce a user turn`
+        `runLive: messages.user is undefined or empty for scenario ${input.scenarioId} — buildPrompt must produce a user turn`
       );
     }
 
@@ -400,6 +416,7 @@ export const exchangesFlow: FlowDefinition<ExchangeScenarioInput> = {
       { role: 'system', content: messages.system },
       ...priorTurns.map((t) => ({
         role: t.role,
+        // Mirror production sanitization: sanitizeUserContent in processExchange — strips <server_note> markers from fixture history.
         content: t.role === 'user' ? sanitizeUserContent(t.content) : t.content,
       })),
       { role: 'user' as const, content: sanitizeUserContent(messages.user) },

--- a/apps/api/eval-llm/flows/exchanges.ts
+++ b/apps/api/eval-llm/flows/exchanges.ts
@@ -375,22 +375,7 @@ export const exchangesFlow: FlowDefinition<ExchangeScenarioInput> = {
     };
   },
 
-  // -------------------------------------------------------------------------
-  // [AUDIT-EVAL-2 / 2026-05-02] First runLive in the harness — sets the
-  // pattern for the other ~12 flows. Mirrors production processExchange
-  // (apps/api/src/services/exchanges.ts) — same routeAndCall signature,
-  // same per-context options (llmTier, ageBracket, conversationLanguage,
-  // pronouns), same escalationRung. The wrapper tags telemetry with
-  // flow: "eval-harness" so dashboards can filter eval calls out.
-  //
-  // Known divergence (tracked separately as AUDIT-EVAL-3): production
-  // concatenates `buildOrphanSystemAddendum(...)` onto the system prompt;
-  // this harness only sends `buildSystemPrompt(context)` (matching what
-  // buildPrompt above produces, and what the Tier-1 snapshot displays).
-  // We deliberately use messages.system here so the live call validates
-  // the same prompt the snapshot shows — fixing the addendum gap means
-  // updating buildPrompt too, which is its own scope.
-  // -------------------------------------------------------------------------
+  // Uses messages.system as-is — production adds buildOrphanSystemAddendum but the harness omits it so the live run validates the same prompt the Tier-1 snapshot displays.
   async runLive(
     input: ExchangeScenarioInput,
     messages: PromptMessages


### PR DESCRIPTION
## Summary

PR #139 was closed in favor of [#141](https://github.com/cognoco/eduagent-build/pull/141), which merged a parallel branch. This carries over the polish from #139 that wasn't in #141.

The substantive `runLive` work — `if (!messages.user)` guard, `sanitizeUserContent` mirror, and the two new tests — already landed via #141. Nothing in this PR is required for correctness; it's strictly cleanup.

## Changes

- **`exchanges.ts`** — remove unused `callLlm` import (dead code from earlier cherry-pick).
- **`exchanges.ts`** — broaden `runLive` guard error message from `"is undefined"` to `"is undefined or empty"`. The guard uses `!messages.user` which catches both `undefined` and `''`, so the message now matches the actual semantics.
- **`exchanges.ts`** — replace line-number reference (`exchanges.ts:314`) in the sanitization comment with `sanitizeUserContent in processExchange`. Function-name pointers survive refactors; line numbers don't.
- **`exchanges.ts`** — add `AUDIT-EVAL-2` design-rationale banner above `runLive` documenting the intentional production divergence (`AUDIT-EVAL-3`) so the next ~12 flows that copy this pattern know why we don't include the orphan addendum here.
- **`exchanges.test.ts`** — replace `scenarios[0]` with `scenarios.find(s => s.scenarioId === 'S1-rung1-teach-new')` in the two new `runLive` tests. Matches the pattern used by the other seven tests in the file; fails readably if `SCENARIO_SPECS` is ever reordered.
- **`exchanges.test.ts`** — update the throw-test regex to match the broadened error message; replace the placeholder `{ system: 'test', user: undefined }` with `{ system: messages.system, user: undefined }` so the second assertion uses the real system prompt.

## Test plan

- [ ] CI gates run on this PR's commit (will run automatically)
- [x] No semantic change to runtime behavior — only error-message text and test wiring change
- [x] No new tests needed (refactors existing ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for empty or undefined message inputs with clearer error messages.

* **Tests**
  * Enhanced test robustness for message flow validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->