### PR TITLE
refactor(mobile): shared createQueryWrapper for hook tests [H3]

### DIFF
--- a/apps/mobile/src/hooks/use-account.test.ts
+++ b/apps/mobile/src/hooks/use-account.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useDeleteAccount,
   useCancelDeletion,
@@ -18,16 +18,9 @@ jest.mock('../lib/api-client', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useDeleteAccount', () => {

--- a/apps/mobile/src/hooks/use-account.test.ts
+++ b/apps/mobile/src/hooks/use-account.test.ts
@@ -20,7 +20,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useDeleteAccount', () => {

--- a/apps/mobile/src/hooks/use-all-books.test.ts
+++ b/apps/mobile/src/hooks/use-all-books.test.ts
@@ -82,7 +82,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/hooks/use-all-books.test.ts
+++ b/apps/mobile/src/hooks/use-all-books.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useAllBooks } from './use-all-books';
 
 // ---------------------------------------------------------------------------
@@ -80,16 +80,9 @@ function makeLibraryBooksResponse(subjects: SubjectFixture[]) {
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/hooks/use-assessments.test.ts
+++ b/apps/mobile/src/hooks/use-assessments.test.ts
@@ -26,7 +26,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useAssessment', () => {

--- a/apps/mobile/src/hooks/use-assessments.test.ts
+++ b/apps/mobile/src/hooks/use-assessments.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useAssessment,
   useCreateAssessment,
@@ -24,16 +24,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useAssessment', () => {

--- a/apps/mobile/src/hooks/use-books.test.ts
+++ b/apps/mobile/src/hooks/use-books.test.ts
@@ -3,8 +3,8 @@
 // ---------------------------------------------------------------------------
 
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useBooks,
   useBookWithTopics,
@@ -40,16 +40,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 const mockBooks = [

--- a/apps/mobile/src/hooks/use-books.test.ts
+++ b/apps/mobile/src/hooks/use-books.test.ts
@@ -42,7 +42,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 const mockBooks = [

--- a/apps/mobile/src/hooks/use-classify-subject.test.ts
+++ b/apps/mobile/src/hooks/use-classify-subject.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useClassifySubject } from './use-classify-subject';
 
 const mockFetch = jest.fn();
@@ -14,16 +14,9 @@ jest.mock('../lib/api-client', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useClassifySubject', () => {

--- a/apps/mobile/src/hooks/use-classify-subject.test.ts
+++ b/apps/mobile/src/hooks/use-classify-subject.test.ts
@@ -16,7 +16,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useClassifySubject', () => {

--- a/apps/mobile/src/hooks/use-consent.test.ts
+++ b/apps/mobile/src/hooks/use-consent.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   checkConsentRequirement,
   useRequestConsent,
@@ -28,16 +28,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('checkConsentRequirement', () => {

--- a/apps/mobile/src/hooks/use-consent.test.ts
+++ b/apps/mobile/src/hooks/use-consent.test.ts
@@ -30,7 +30,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('checkConsentRequirement', () => {

--- a/apps/mobile/src/hooks/use-curriculum.test.ts
+++ b/apps/mobile/src/hooks/use-curriculum.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useCurriculum,
   useSkipTopic,
@@ -39,16 +39,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 const mockCurriculum = {

--- a/apps/mobile/src/hooks/use-curriculum.test.ts
+++ b/apps/mobile/src/hooks/use-curriculum.test.ts
@@ -41,7 +41,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 const mockCurriculum = {

--- a/apps/mobile/src/hooks/use-dashboard.test.ts
+++ b/apps/mobile/src/hooks/use-dashboard.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useDashboard,
   useChildDetail,
@@ -36,16 +36,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useDashboard', () => {

--- a/apps/mobile/src/hooks/use-dashboard.test.ts
+++ b/apps/mobile/src/hooks/use-dashboard.test.ts
@@ -38,7 +38,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useDashboard', () => {

--- a/apps/mobile/src/hooks/use-dictation-api.test.ts
+++ b/apps/mobile/src/hooks/use-dictation-api.test.ts
@@ -28,7 +28,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('usePrepareHomework', () => {

--- a/apps/mobile/src/hooks/use-dictation-api.test.ts
+++ b/apps/mobile/src/hooks/use-dictation-api.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { usePrepareHomework, useGenerateDictation } from './use-dictation-api';
 
 const mockPreparePost = jest.fn();
@@ -26,16 +26,9 @@ jest.mock('../lib/assert-ok', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('usePrepareHomework', () => {

--- a/apps/mobile/src/hooks/use-interview.test.ts
+++ b/apps/mobile/src/hooks/use-interview.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useInterviewState,
   useSendInterviewMessage,
@@ -55,16 +55,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useInterviewState', () => {

--- a/apps/mobile/src/hooks/use-interview.test.ts
+++ b/apps/mobile/src/hooks/use-interview.test.ts
@@ -57,7 +57,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useInterviewState', () => {

--- a/apps/mobile/src/hooks/use-language-progress.test.ts
+++ b/apps/mobile/src/hooks/use-language-progress.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useLanguageProgress } from './use-language-progress';
 
 const mockFetch = jest.fn();
@@ -20,16 +20,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useLanguageProgress', () => {

--- a/apps/mobile/src/hooks/use-language-progress.test.ts
+++ b/apps/mobile/src/hooks/use-language-progress.test.ts
@@ -22,7 +22,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useLanguageProgress', () => {

--- a/apps/mobile/src/hooks/use-notes.test.ts
+++ b/apps/mobile/src/hooks/use-notes.test.ts
@@ -43,7 +43,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 const mockNotes = [

--- a/apps/mobile/src/hooks/use-notes.test.ts
+++ b/apps/mobile/src/hooks/use-notes.test.ts
@@ -3,8 +3,8 @@
 // ---------------------------------------------------------------------------
 
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useBookNotes,
   useCreateNote,
@@ -41,16 +41,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 const mockNotes = [

--- a/apps/mobile/src/hooks/use-profiles.test.ts
+++ b/apps/mobile/src/hooks/use-profiles.test.ts
@@ -35,7 +35,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useProfiles', () => {

--- a/apps/mobile/src/hooks/use-profiles.test.ts
+++ b/apps/mobile/src/hooks/use-profiles.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useProfiles, useUpdateProfileName } from './use-profiles';
 
 const mockFetch = jest.fn();
@@ -33,16 +33,9 @@ jest.mock('@clerk/clerk-expo', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useProfiles', () => {

--- a/apps/mobile/src/hooks/use-progress.test.ts
+++ b/apps/mobile/src/hooks/use-progress.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useSubjectProgress,
   useOverallProgress,
@@ -40,16 +40,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useSubjectProgress', () => {

--- a/apps/mobile/src/hooks/use-progress.test.ts
+++ b/apps/mobile/src/hooks/use-progress.test.ts
@@ -42,7 +42,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useSubjectProgress', () => {

--- a/apps/mobile/src/hooks/use-resolve-subject.test.ts
+++ b/apps/mobile/src/hooks/use-resolve-subject.test.ts
@@ -16,7 +16,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useResolveSubject', () => {

--- a/apps/mobile/src/hooks/use-resolve-subject.test.ts
+++ b/apps/mobile/src/hooks/use-resolve-subject.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useResolveSubject } from './use-resolve-subject';
 
 const mockFetch = jest.fn();
@@ -14,16 +14,9 @@ jest.mock('../lib/api-client', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useResolveSubject', () => {

--- a/apps/mobile/src/hooks/use-retention.test.ts
+++ b/apps/mobile/src/hooks/use-retention.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useRetentionTopics,
   useTopicRetention,
@@ -26,16 +26,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useRetentionTopics', () => {

--- a/apps/mobile/src/hooks/use-retention.test.ts
+++ b/apps/mobile/src/hooks/use-retention.test.ts
@@ -28,7 +28,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useRetentionTopics', () => {

--- a/apps/mobile/src/hooks/use-revenuecat.test.ts
+++ b/apps/mobile/src/hooks/use-revenuecat.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
 import { Platform } from 'react-native';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import Purchases from 'react-native-purchases';
 import {
   useRevenueCatIdentity,
@@ -99,16 +99,9 @@ jest.mock('../lib/revenuecat', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/hooks/use-revenuecat.test.ts
+++ b/apps/mobile/src/hooks/use-revenuecat.test.ts
@@ -101,7 +101,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/hooks/use-sessions.test.ts
+++ b/apps/mobile/src/hooks/use-sessions.test.ts
@@ -66,7 +66,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useStartSession', () => {

--- a/apps/mobile/src/hooks/use-sessions.test.ts
+++ b/apps/mobile/src/hooks/use-sessions.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useStartSession,
   useSetSessionInputMode,
@@ -64,16 +64,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useStartSession', () => {

--- a/apps/mobile/src/hooks/use-settings.test.ts
+++ b/apps/mobile/src/hooks/use-settings.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useNotificationSettings,
   useLearningMode,
@@ -40,16 +40,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useNotificationSettings', () => {

--- a/apps/mobile/src/hooks/use-settings.test.ts
+++ b/apps/mobile/src/hooks/use-settings.test.ts
@@ -42,7 +42,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useNotificationSettings', () => {

--- a/apps/mobile/src/hooks/use-streaks.test.ts
+++ b/apps/mobile/src/hooks/use-streaks.test.ts
@@ -34,7 +34,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useStreaks', () => {

--- a/apps/mobile/src/hooks/use-streaks.test.ts
+++ b/apps/mobile/src/hooks/use-streaks.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useStreaks, useXpSummary } from './use-streaks';
 
 const mockFetch = jest.fn();
@@ -32,16 +32,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useStreaks', () => {

--- a/apps/mobile/src/hooks/use-subjects.test.ts
+++ b/apps/mobile/src/hooks/use-subjects.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import { useSubjects, useCreateSubject } from './use-subjects';
 
 const mockFetch = jest.fn();
@@ -32,16 +32,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useSubjects', () => {

--- a/apps/mobile/src/hooks/use-subjects.test.ts
+++ b/apps/mobile/src/hooks/use-subjects.test.ts
@@ -34,7 +34,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useSubjects', () => {

--- a/apps/mobile/src/hooks/use-subscription.test.ts
+++ b/apps/mobile/src/hooks/use-subscription.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useSubscription,
   useUsage,
@@ -45,16 +45,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/hooks/use-subscription.test.ts
+++ b/apps/mobile/src/hooks/use-subscription.test.ts
@@ -47,7 +47,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/hooks/use-vocabulary.test.ts
+++ b/apps/mobile/src/hooks/use-vocabulary.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import React from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useVocabulary,
   useCreateVocabulary,
@@ -24,16 +24,9 @@ jest.mock('../lib/profile', () => ({
 let queryClient: QueryClient;
 
 function createWrapper() {
-  queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
-  };
+  const w = createQueryWrapper();
+  queryClient = w.queryClient;
+  return w.Wrapper;
 }
 
 describe('useVocabulary', () => {

--- a/apps/mobile/src/hooks/use-vocabulary.test.ts
+++ b/apps/mobile/src/hooks/use-vocabulary.test.ts
@@ -26,7 +26,7 @@ let queryClient: QueryClient;
 function createWrapper() {
   const w = createQueryWrapper();
   queryClient = w.queryClient;
-  return w.Wrapper;
+  return w.wrapper;
 }
 
 describe('useVocabulary', () => {

--- a/apps/mobile/src/test-utils/app-hook-test-utils.tsx
+++ b/apps/mobile/src/test-utils/app-hook-test-utils.tsx
@@ -12,23 +12,22 @@ import {
 
 process.env.EXPO_PUBLIC_API_URL ??= 'http://localhost:8787';
 
-/**
- * Lightweight QueryClient-only wrapper for hook tests that mock
- * `../lib/profile` directly (the dominant pattern across `hooks/*.test.ts`).
- *
- * Unlike `createHookWrapper`, this does NOT pull in `ProfileContext` —
- * that import would resolve to the test's `jest.mock('../lib/profile')`
- * shim and provide an undefined Provider. Use this helper when the
- * test already mocks the profile module.
- */
+// QueryClient-only wrapper for hook tests that already mock `../lib/profile`.
 export function createQueryWrapper(
   options: { queryClientOptions?: QueryClientConfig } = {}
 ) {
-  const queryClient = new QueryClient(
-    options.queryClientOptions ?? {
-      defaultOptions: { queries: { retry: false, gcTime: 0 } },
-    }
-  );
+  const userOpts = options.queryClientOptions ?? {};
+  const queryClient = new QueryClient({
+    ...userOpts,
+    defaultOptions: {
+      ...userOpts.defaultOptions,
+      queries: {
+        retry: false,
+        gcTime: 0,
+        ...userOpts.defaultOptions?.queries,
+      },
+    },
+  });
 
   function Wrapper({ children }: { children: ReactNode }) {
     return createElement(
@@ -38,7 +37,7 @@ export function createQueryWrapper(
     );
   }
 
-  return { queryClient, Wrapper };
+  return { queryClient, wrapper: Wrapper };
 }
 
 export function createTestProfile(overrides: Partial<Profile> = {}): Profile {

--- a/apps/mobile/src/test-utils/app-hook-test-utils.tsx
+++ b/apps/mobile/src/test-utils/app-hook-test-utils.tsx
@@ -1,5 +1,9 @@
 import { createElement, type ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryClientConfig,
+} from '@tanstack/react-query';
 import {
   ProfileContext,
   type Profile,
@@ -7,6 +11,35 @@ import {
 } from '../lib/profile';
 
 process.env.EXPO_PUBLIC_API_URL ??= 'http://localhost:8787';
+
+/**
+ * Lightweight QueryClient-only wrapper for hook tests that mock
+ * `../lib/profile` directly (the dominant pattern across `hooks/*.test.ts`).
+ *
+ * Unlike `createHookWrapper`, this does NOT pull in `ProfileContext` —
+ * that import would resolve to the test's `jest.mock('../lib/profile')`
+ * shim and provide an undefined Provider. Use this helper when the
+ * test already mocks the profile module.
+ */
+export function createQueryWrapper(
+  options: { queryClientOptions?: QueryClientConfig } = {}
+) {
+  const queryClient = new QueryClient(
+    options.queryClientOptions ?? {
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    }
+  );
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  }
+
+  return { queryClient, Wrapper };
+}
 
 export function createTestProfile(overrides: Partial<Profile> = {}): Profile {
   return {


### PR DESCRIPTION
## Summary

- Adds `createQueryWrapper` to `apps/mobile/src/test-utils/app-hook-test-utils.tsx` — a QueryClient-only wrapper for hook tests that mock `../lib/profile` directly. Unlike the existing `createHookWrapper`, it does not import `ProfileContext`, so the test's `jest.mock('../lib/profile')` doesn't collide with the helper's module graph.
- Migrates **23 hook test files** from the duplicated ad-hoc `function createWrapper()` pattern to the shared helper. **Net -128 lines** (-277 / +149) and removes the per-file `QueryClientProvider` import.

## Why this scope (not all 39)

The audit (`docs/plans/2026-05-03-governance-audit.md` H3) called out 39 files using ad-hoc `createWrapper`. Inspection showed 25 of them mock `../lib/profile` — those tests cannot use the existing `createHookWrapper` because the canonical helper imports `ProfileContext` from the mocked module. Hence the new sibling helper.

Screen tests under `app/**/*.test.tsx` are not in scope here — they either don't mock profile or need actual `ProfileContext` rendering, which is the job of the existing `createHookWrapper`. Migrating those is a follow-up PR.

Skipped (no `createWrapper` / no QueryClient setup): `use-rating-prompt`, `use-homework-ocr`, `use-parent-proxy`, `use-active-profile-role`.

## Test plan

- [x] `pnpm exec jest --testPathPattern='src/hooks' --no-coverage` — **335/335 pass** across 38 suites
- [x] `pnpm exec jest --findRelatedTests <23 migrated files>` via pre-commit hook — 203/203 pass
- [x] `pnpm exec nx run api:typecheck` — clean
- [ ] CI: lint, typecheck, full mobile test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal test infrastructure utilities for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->