### PR TITLE
feat(api): shared withProfile() helper + RouteEnv type [H4]

### DIFF
--- a/apps/api/src/route-utils/route-context.ts
+++ b/apps/api/src/route-utils/route-context.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared Hono route environment types and context helpers.
+ *
+ * Removes the per-file boilerplate where every route file redeclares the
+ * same `Bindings` + `Variables` shapes, and the same `requireProfileId`
+ * unwrap in every handler. Routes that need additional variables (e.g.
+ * `account` on /account routes) extend `RouteVariables` locally.
+ *
+ * See docs/plans/2026-05-03-governance-audit.md item H4.
+ */
+
+import type { Context } from 'hono';
+import type { Database } from '@eduagent/database';
+import type { AuthUser } from '../middleware/auth';
+import { requireProfileId } from '../middleware/profile-scope';
+
+export interface RouteBindings {
+  DATABASE_URL: string;
+  CLERK_JWKS_URL?: string;
+}
+
+export interface RouteVariables {
+  user: AuthUser;
+  db: Database;
+  profileId: string | undefined;
+}
+
+export interface RouteEnv {
+  Bindings: RouteBindings;
+  Variables: RouteVariables;
+}
+
+/**
+ * Pull the common request-scoped values out of a Hono Context with
+ * profileId already validated. Replaces the per-handler 3-liner:
+ *
+ *     const db = c.get('db');
+ *     const profileId = requireProfileId(c.get('profileId'));
+ *     const user = c.get('user');
+ */
+export function withProfile<E extends RouteEnv>(c: Context<E>) {
+  return {
+    db: c.get('db'),
+    profileId: requireProfileId(c.get('profileId')),
+    user: c.get('user'),
+  };
+}

--- a/apps/api/src/routes/assessments.ts
+++ b/apps/api/src/routes/assessments.ts
@@ -5,9 +5,8 @@ import {
   quickCheckResponseSchema,
 } from '@eduagent/schemas';
 import type { Database } from '@eduagent/database';
-import type { AuthUser } from '../middleware/auth';
-import { requireProfileId } from '../middleware/profile-scope';
 import { assertNotProxyMode } from '../middleware/proxy-guard';
+import { withProfile, type RouteEnv } from '../route-utils/route-context';
 import {
   evaluateAssessmentAnswer,
   createAssessment,
@@ -20,21 +19,11 @@ import { insertSessionXpEntry } from '../services/xp';
 import { getSession } from '../services/session';
 import { notFound } from '../errors';
 
-type AssessmentRouteEnv = {
-  Bindings: { DATABASE_URL: string; CLERK_JWKS_URL?: string };
-  Variables: {
-    user: AuthUser;
-    db: Database;
-    profileId: string | undefined;
-  };
-};
-
-export const assessmentRoutes = new Hono<AssessmentRouteEnv>()
+export const assessmentRoutes = new Hono<RouteEnv>()
   // Start a topic completion assessment
   .post('/subjects/:subjectId/topics/:topicId/assessments', async (c) => {
     assertNotProxyMode(c);
-    const db = c.get('db');
-    const profileId = requireProfileId(c.get('profileId'));
+    const { db, profileId } = withProfile(c);
     const subjectId = c.req.param('subjectId');
     const topicId = c.req.param('topicId');
 
@@ -65,8 +54,7 @@ export const assessmentRoutes = new Hono<AssessmentRouteEnv>()
     '/assessments/:assessmentId/answer',
     zValidator('json', assessmentAnswerSchema),
     async (c) => {
-      const db = c.get('db');
-      const profileId = requireProfileId(c.get('profileId'));
+      const { db, profileId } = withProfile(c);
       const assessmentId = c.req.param('assessmentId');
       const { answer } = c.req.valid('json');
 
@@ -143,8 +131,7 @@ export const assessmentRoutes = new Hono<AssessmentRouteEnv>()
 
   // Get assessment state
   .get('/assessments/:assessmentId', async (c) => {
-    const db = c.get('db');
-    const profileId = requireProfileId(c.get('profileId'));
+    const { db, profileId } = withProfile(c);
     const assessmentId = c.req.param('assessmentId');
 
     const assessment = await getAssessment(db, profileId, assessmentId);
@@ -157,8 +144,7 @@ export const assessmentRoutes = new Hono<AssessmentRouteEnv>()
     '/sessions/:sessionId/quick-check',
     zValidator('json', quickCheckResponseSchema),
     async (c) => {
-      const db = c.get('db');
-      const profileId = requireProfileId(c.get('profileId'));
+      const { db, profileId } = withProfile(c);
       const sessionId = c.req.param('sessionId');
       const { answer } = c.req.valid('json');
 


### PR DESCRIPTION
## Summary

- Adds `apps/api/src/route-utils/route-context.ts` with `RouteBindings`, `RouteVariables`, `RouteEnv`, and `withProfile(c)`. Each route file currently re-declares the same Bindings + Variables block (~9 lines) and each handler repeats `const db = c.get('db'); const profileId = requireProfileId(c.get('profileId'));`. The helper collapses all of that.
- Converts `routes/assessments.ts` as the canary: removes the local `AssessmentRouteEnv` declaration and 5 copies of the db/profileId boilerplate.

## Why one canary, not all 40 route files

Establishing the helper + a working canary (with passing tests) is its own reviewable unit. Bulk migration of the remaining route files (each with slightly different Variables shape — some need `account`, some `profileMeta`) is a mechanical follow-up PR, kept separate so reviewers can audit the helper design independently from the bulk diff.

## Test plan

- [x] `pnpm exec nx run api:typecheck` — clean
- [x] `pnpm exec jest --findRelatedTests apps/api/src/routes/assessments.ts` — 467/467 across 22 suites
- [ ] CI: lint, typecheck, full repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)