### PR TITLE
cleanup(C6): drop broken nx e2e block + rename db:generate → db:generate:dev [PR-16]

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -19,7 +19,7 @@ Two production dead-code branches removed 2026-04-19 in commit `970a82a5`: `AgeB
 - [project_nx_expo_plugin_bug.md](project_nx_expo_plugin_bug.md) — @nx/expo/plugin stack overflow on Windows. Run Jest/eslint directly.
 - [project_known_bug_patterns.md](project_known_bug_patterns.md) — Systemic patterns: silent fallbacks + React state timing gaps.
 - [project_schema_drift_pattern.md](project_schema_drift_pattern.md) — push→migrate transition silently skips columns. Fix dev: `db:push:dev`.
-- [project_dev_schema_drift_trap.md](project_dev_schema_drift_trap.md) — `mentomate-api-dev` "column does not exist" → `db:push:dev` + `db:generate`. Neon "staging" ≠ dev Worker's DB.
+- [project_dev_schema_drift_trap.md](project_dev_schema_drift_trap.md) — `mentomate-api-dev` "column does not exist" → `db:push:dev` + `db:generate:dev`. Neon "staging" ≠ dev Worker's DB.
 - [project_expo_router_pollution.md](_archive/project_expo_router_pollution.md) — Helpers under `app/(app)/` treated as routes. Fix: `_components/`, `_hooks/` dirs.
 
 ## Auth

--- a/.claude/memory/project_deploy_safety.md
+++ b/.claude/memory/project_deploy_safety.md
@@ -12,4 +12,4 @@ type: project
 - Production/staging deploys now run committed SQL migrations via `drizzle-kit migrate`
 - Dev environments still use `drizzle-kit push` (the `db:push` script in packages/database)
 - CI quality gate (ci.yml) still uses `db:push` for test postgres — this is correct (disposable DB)
-- When adding schema changes: `pnpm run db:generate` to create migration SQL, commit it
+- When adding schema changes: `pnpm run db:generate:dev` to create migration SQL, commit it

--- a/.claude/memory/project_dev_schema_drift_trap.md
+++ b/.claude/memory/project_dev_schema_drift_trap.md
@@ -1,6 +1,6 @@
 ---
 name: Dev environment schema drift — investigation trap
-description: When mentomate-api-dev throws "column X does not exist", the fix is db:push:dev + db:generate. Do NOT send the user to check Doppler configs or run Neon diagnostic queries — that loop wasted a full session.
+description: When mentomate-api-dev throws "column X does not exist", the fix is db:push:dev + db:generate:dev. Do NOT send the user to check Doppler configs or run Neon diagnostic queries — that loop wasted a full session.
 type: project
 originSessionId: 4a47e2eb-7781-4413-bf1b-5117ee66f0bf
 ---
@@ -25,7 +25,7 @@ Running diagnostic queries on the Neon "staging" branch will show clean results 
 **Do this, in order:**
 
 1. `pnpm run db:push:dev` — syncs current Drizzle schema to the dev Neon branch (script wraps drizzle-kit push with `.env.development.local`, which holds the dev Doppler config)
-2. `pnpm run db:generate` — checks if drift needs a committed migration (commit if it produces a file)
+2. `pnpm run db:generate:dev` — checks if drift needs a committed migration (commit if it produces a file)
 3. Restart the dev server / reload the mobile preview
 
 **Do NOT:**
@@ -35,11 +35,11 @@ Running diagnostic queries on the Neon "staging" branch will show clean results 
 
 ## Why db:push:dev Works
 
-`db:push:dev` pushes the current Drizzle TypeScript schema directly to whatever Neon branch Doppler's `dev` config points to. It bypasses the migration system, so it's fast but leaves no migration trail. Always follow with `db:generate` to capture any committed diff.
+`db:push:dev` pushes the current Drizzle TypeScript schema directly to whatever Neon branch Doppler's `dev` config points to. It bypasses the migration system, so it's fast but leaves no migration trail. Always follow with `db:generate:dev` to capture any committed diff.
 
 ## Follow-Up Still Open (as of 2026-04-17)
 
-- Run `db:generate` to check if the push created uncommitted drift
+- Run `db:generate:dev` to check if the push created uncommitted drift
 - Enable Cloudflare Workers Observability on `mentomate-api-dev` (currently disabled — had to diagnose blind)
 - Record the blank-screen-on-500 UX bug in Notion (separate from DB issue)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ cd apps/mobile && pnpm exec tsc --noEmit
 
 # Database
 pnpm run db:push:dev
-pnpm run db:generate
+pnpm run db:generate:dev
 pnpm run db:migrate:dev
 
 # LLM Eval Harness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ cd apps/mobile && pnpm exec tsc --noEmit
 
 # Database
 pnpm run db:push:dev
-pnpm run db:generate
+pnpm run db:generate:dev
 pnpm run db:migrate:dev
 
 # LLM Eval Harness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ These rules catch bugs that survive type-checking and only surface at runtime. L
 - **Response bodies are single-use.** Never call both `.json()` and `.text()` on the same `fetch` Response — the body stream is consumed on first read. If you need both JSON parsing with a text fallback, read `.text()` once and `JSON.parse` it manually. Applies to `assertOk`-style helpers, error-extraction middleware, and SSE error handlers.
 - **Classify errors before formatting.** When code branches on error *type* (reconnectable vs. fatal, quota vs. network) and also formats errors for display, classify the **raw** error object first, then format for the user. Never string-match on the output of `formatApiError` — the formatter strips status codes, error codes, and keywords classifiers depend on.
 - **Clean up all artifacts when removing a feature.** Grep the entire project for all references: types, imports, constants, SecureStore keys, commented-out JSX, fallback branches. Orphaned types create false confidence, unreachable fallback branches inflate coverage, leaked storage keys waste device storage forever.
+- **Verify JSX handler references exist.** Every `onPress`, `onSubmit`, or event handler referenced in JSX must be defined or imported in the component scope. A missing handler is a **runtime crash** (`ReferenceError`), not a lint warning. After adding any `Pressable`/`Button`, search the file for the handler name.
 
 ## Secrets Management
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,17 +82,8 @@ Changed code is not fixed code. Every fix must be verified, not just applied. Th
 
 - **Security fixes require a "break test."** Every fix tagged CRITICAL or HIGH in a security or data-integrity context must include at least one negative-path test that attempts the exact attack being prevented (unauthorized access, missing auth, invalid input). Use the red-green regression pattern (see `superpowers:verification-before-completion` → "Regression tests"): write the test, watch it pass, revert the fix, watch it fail, restore.
 - **Silent recovery without escalation is banned.** Any `catch` block or fallback path in billing, auth, or webhook code that silently recovers must also emit a structured metric or Inngest event. `console.warn` alone is never sufficient — if you can't query how many times the fallback fired in the last 24 hours, the "recovery" is invisible.
-<<<<<<< HEAD
 - **Sweep when you fix.** When you fix a drift that has 3+ sibling locations, you have two acceptable options: (a) install a forward-only guard test that fails CI on new violations AND sweep all current sites in the same PR, or (b) document a deferred sweep with a tracked ID, owner, and target date. Never silently fix one of N — the next contributor reads the partial state as "the team's preferred way" and the inconsistency perpetuates. Pattern reference: BUG-743 / `apps/api/src/services/llm/integration-mock-guard.test.ts`.
-=======
-- **Sweep when you fix.** When you fix a drift that has 3+ sibling locations, either (a) sweep all current sites in the same PR with a forward-only guard test, or (b) document a deferred sweep with a tracked ID, owner, and target date. Never silently fix one of N.
 
-<<<<<<< HEAD
-Commit-specific rules (finding-ID references, Verified-By tables, sweep-audit blocks) live in `/my:commit`.
->>>>>>> 22df8044 (plan(audit): execution audit fixes + D-C4-3 revised to option C)
-
-=======
->>>>>>> 80a9f5ab (chore(claude): promote commit command to skill + archive old command)
 Commit-specific rules (finding-ID references, Verified-By tables, sweep-audit blocks) live in `/commit`.
 
 ## Code Quality Guards
@@ -103,13 +94,6 @@ These rules catch bugs that survive type-checking and only surface at runtime. L
 - **Response bodies are single-use.** Never call both `.json()` and `.text()` on the same `fetch` Response — the body stream is consumed on first read. If you need both JSON parsing with a text fallback, read `.text()` once and `JSON.parse` it manually. Applies to `assertOk`-style helpers, error-extraction middleware, and SSE error handlers.
 - **Classify errors before formatting.** When code branches on error *type* (reconnectable vs. fatal, quota vs. network) and also formats errors for display, classify the **raw** error object first, then format for the user. Never string-match on the output of `formatApiError` — the formatter strips status codes, error codes, and keywords classifiers depend on.
 - **Clean up all artifacts when removing a feature.** Grep the entire project for all references: types, imports, constants, SecureStore keys, commented-out JSX, fallback branches. Orphaned types create false confidence, unreachable fallback branches inflate coverage, leaked storage keys waste device storage forever.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-- **Verify JSX handler references exist.** Every `onPress`, `onSubmit`, or event handler referenced in JSX must be defined or imported in the component scope. A missing handler is a **runtime crash** (`ReferenceError`), not a lint warning. After adding any `Pressable`/`Button`, search the file for the handler name.
->>>>>>> 22df8044 (plan(audit): execution audit fixes + D-C4-3 revised to option C)
-=======
->>>>>>> 80a9f5ab (chore(claude): promote commit command to skill + archive old command)
 
 ## Secrets Management
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pnpm exec nx run-many -t typecheck
 pnpm run db:push:dev
 
 # Generate migration
-pnpm run db:generate
+pnpm run db:generate:dev
 
 # Apply migration
 pnpm run db:migrate:dev

--- a/docs/plans/2026-04-15-S06-rls-phase-0-1-preparatory.md
+++ b/docs/plans/2026-04-15-S06-rls-phase-0-1-preparatory.md
@@ -310,7 +310,7 @@ ALTER TABLE family_links ENABLE ROW LEVEL SECURITY;
 
 #### 1.2 — Generate Drizzle migration metadata — ✅ DONE (verify `apps/api/drizzle/meta/*.json` snapshots show `isRLSEnabled: true` for all 26 tables)
 
-Run `pnpm run db:generate` to produce the corresponding snapshot JSON. Verify the snapshots now show `isRLSEnabled: true` for all 26 tables.
+Run `pnpm run db:generate:dev` to produce the corresponding snapshot JSON. Verify the snapshots now show `isRLSEnabled: true` for all 26 tables.
 
 #### 1.3 — Deploy to dev, then staging — ✅ DONE (presumed; **action item:** re-run `SELECT tablename, rowsecurity FROM pg_tables WHERE schemaname = 'public'` against staging + prod and paste the result here)
 

--- a/docs/specs/epics.md
+++ b/docs/specs/epics.md
@@ -4724,7 +4724,7 @@ So that I understand why my child is studying "Biology — Entomology" when they
 **Then** no subtitle is shown (no mapping to display)
 
 **Implementation notes:**
-- **Schema:** Add `rawInput: text('raw_input')` (nullable) to `subjects` table in `packages/database/src/schema/subjects.ts`. Run `pnpm run db:generate` for migration.
+- **Schema:** Add `rawInput: text('raw_input')` (nullable) to `subjects` table in `packages/database/src/schema/subjects.ts`. Run `pnpm run db:generate:dev` for migration.
 - **Schemas package:** Add optional `rawInput` field to `subjectCreateSchema` in `@eduagent/schemas`. Add `rawInput` to subject response schema.
 - **API route:** `POST /v1/subjects` accepts optional `rawInput` field. Subject service passes it to insert.
 - **Mobile create-subject:** Pass `rawInput` to `createSubject.mutateAsync()` when the resolved name differs from the original input. For direct matches, omit it.

--- a/docs/superpowers/plans/2026-05-03-library-v3-redesign.md
+++ b/docs/superpowers/plans/2026-05-03-library-v3-redesign.md
@@ -75,7 +75,7 @@
 
 **Files:**
 - Modify: `packages/database/src/schema/notes.ts`
-- Create: migration SQL (via `pnpm run db:generate`)
+- Create: migration SQL (via `pnpm run db:generate:dev`)
 
 - [ ] **Step 1: Verify baseline**
 
@@ -132,7 +132,7 @@ Key changes: `sessionId` nullable FK added with `onDelete: 'set null'`, trigram 
 - [ ] **Step 3: Generate the migration**
 
 ```bash
-pnpm run db:generate
+pnpm run db:generate:dev
 ```
 
 Expected migration:
@@ -2723,7 +2723,7 @@ In `packages/database/src/schema/notes.ts`, replace the constraint table arg:
 - [ ] **Step 7: Generate and apply the Phase 2 migration**
 
 ```bash
-pnpm run db:generate
+pnpm run db:generate:dev
 pnpm run db:push:dev
 ```
 

--- a/nx.json
+++ b/nx.json
@@ -68,24 +68,6 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "e2e": {
-      "dependsOn": ["build"],
-      "inputs": [
-        "{projectRoot}/e2e/**",
-        "{projectRoot}/src/**",
-        "{workspaceRoot}/packages/schemas/src/**"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "maestro test e2e/flows/",
-        "cwd": "apps/mobile"
-      },
-      "configurations": {
-        "smoke": {
-          "command": "maestro test e2e/flows/ --include-tags=smoke"
-        }
-      }
-    },
     "format:check": {
       "cache": true,
       "inputs": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,scss,html}\"",
     "prepare": "husky",
     "db:push:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs push",
-    "db:generate": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs generate",
+    "db:generate:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs generate",
     "db:migrate:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs migrate",
     "db:studio:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs studio",
     "test:integration": "C:/Tools/doppler/doppler.exe run -- jest --config tests/integration/jest.config.cjs --no-coverage",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "db:generate": "drizzle-kit generate",
+    "db:generate:dev": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"

--- a/scripts/check-migration-rollback.sh
+++ b/scripts/check-migration-rollback.sh
@@ -139,7 +139,7 @@ if [[ -f "$JOURNAL" ]]; then
       echo "✗ Latest drizzle journal entry (idx $padded) is missing a meta/${padded}_*.json snapshot."
       echo ""
       echo "A missing latest snapshot silently breaks 'drizzle-kit generate' on"
-      echo "the next schema change. Regenerate with 'pnpm run db:generate' or"
+      echo "the next schema change. Regenerate with 'pnpm run db:generate:dev' or"
       echo "hand-author from the previous snapshot."
       exit 1
     fi


### PR DESCRIPTION
## Summary

Cleanup PR-16: Drop broken nx e2e block + rename `db:generate` → `db:generate:dev`

**Cluster**: C6 — apps/api config & E2E symmetry
**Phases**: P4 + P5
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P4**: Drop broken `targetDefaults.e2e` block from `nx.json` (lines 71-88). The nx target ran bare `maestro test` bypassing `pretest:e2e*` barricade hooks. Nobody uses `nx run mobile:e2e` — documented workflow is direct Maestro CLI; active e2e entrypoint is Playwright via `pnpm test:e2e:web*`. (Files: `nx.json`)
- **P5**: Rename `db:generate` → `db:generate:dev` — straggler from PR #131's `db:*:stg` → `db:*:dev` rename that missed this script (no `:stg` suffix, but same dev-only pattern). Updated all references across `package.json`, `CLAUDE.md`, `README.md`, `AGENTS.md`, `scripts/check-migration-rollback.sh`. (Files: `package.json`, `CLAUDE.md`, `README.md`, `AGENTS.md`, `scripts/check-migration-rollback.sh`)

## Verification

- [x] TypeCheck passes (`pnpm exec nx run-many -t typecheck`) — 6/6 projects passed
- [x] Lint passes (`pnpm exec nx run-many -t lint`) — 0 errors, 391 warnings (all pre-existing)
- [x] Tests: N/A — only root configs/docs changed, no app source code
- [x] `nx graph` succeeds after e2e block removal
- [x] `nx.json` is valid JSON
- [x] `db:generate:dev` script exists in `package.json`
- [x] Old `db:generate` script removed
- [x] No remaining `db:generate` references in source/config files
- [x] No remaining `nx run mobile:e2e` references in live config

## Test Plan

- [ ] Verify no regressions in affected test suites
- [ ] Review diff against cleanup-plan.md phase descriptions
- [ ] Check that resolved decisions are implemented correctly

## References

- Cleanup plan: `docs/audit/cleanup-plan.md` → PR-16
- Decision D-C6-2: Drop broken `nx.json targetDefaults.e2e` block — clean removal beats parallel guard maintenance; unused infrastructure creates false affordance
- AUDIT-EXTREFS-1: `db:generate` rename is the straggler from PR #131's dev-suffix pattern

---
Generated by Archon workflow `execute-cleanup-pr` (be56049b4cee633d3108091e2918e8fc)