### PR TITLE
cleanup(C6/P3): tsconfig.spec.json + jest config switch [PR-15]

### DIFF
--- a/apps/api/jest.config.cjs
+++ b/apps/api/jest.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   rootDir: '../..',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/apps/api/tsconfig.app.json' }],
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/apps/api/tsconfig.spec.json' }],
   },
   // Swap Neon HTTP driver for standard pg when DATABASE_URL points at
   // localhost (CI container). Unit tests override with their own jest.mock.

--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/jest",
+    "types": ["jest", "node", "@cloudflare/workers-types"],
+    "rootDir": "."
+  },
+  "include": ["jest.config.cjs", "src/**/*.ts", "eval-llm/**/*.ts"],
+  "references": [
+    {
+      "path": "../../packages/schemas/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/retention/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/database/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/test-utils/tsconfig.lib.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Cleanup PR-15: `tsconfig.spec.json` + jest config switch. Smoke run required.

**Cluster**: C6 — apps/api config & E2E symmetry
**Phases**: P3 — `tsconfig.spec.json` + jest config switch
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P3**: AUDIT-PACKAGE-SCRIPTS-2c — Create `apps/api/tsconfig.spec.json` and switch `apps/api/jest.config.cjs` to reference it instead of `tsconfig.app.json`. `tsconfig.json` project references were **not** updated — adding the reference exposed 846 pre-existing test type errors that require a separate cleanup PR. Core deliverable (jest uses the correct tsconfig) is complete.

  Files changed:
  - `apps/api/tsconfig.spec.json` (created)
  - `apps/api/jest.config.cjs` (updated — swapped `tsconfig.app.json` → `tsconfig.spec.json`)

## Verification

- [x] TypeCheck passes (`pnpm exec nx run-many -t typecheck`) — all 5 tasks passed via NX cache
- [x] Lint passes (`pnpm exec nx run-many -t lint`) — 0 errors, 336 pre-existing warnings
- [x] `apps/api/tsconfig.spec.json` structure mirrors `packages/database/tsconfig.spec.json` pattern
- [x] `apps/api/jest.config.cjs` reference correctly points to `tsconfig.spec.json`
- [ ] Smoke test (`pnpm exec nx run api:test`) — blocked in worktree by micromatch dot-path issue; must pass in CI clean checkout

## Test Plan

- [ ] Verify `pnpm exec nx run api:test` passes in CI (clean checkout, no dot-prefixed path)
- [ ] Review diff against cleanup-plan.md P3 description
- [ ] Confirm 846 pre-existing test type errors are tracked as a follow-up (deferred scope, not a regression)

## Known Scope Limitation

`apps/api/tsconfig.json` project references were intentionally NOT updated in this PR.
Adding `tsconfig.spec.json` to references surfaced 846 pre-existing test type errors.
This is not a regression — it is pre-existing drift that requires a dedicated sweep PR.

## References

- Cleanup plan: `docs/audit/cleanup-plan.md` → PR-15
- Decision D-C6-1: Switch jest to `tsconfig.spec.json` — standard pattern matching `packages/database` and `apps/mobile`, eliminates config split where typecheck and jest disagree on scope.

---
Generated by Archon workflow `execute-cleanup-pr` (b2e6490f9e2f71e16f226a306af98234)