### PR TITLE
fix(mobile): PR-08 mobile navigation safety nets — unstable_settings + AccordionTopicList cross-tab push fix

### DIFF
--- a/apps/mobile/src/app/(app)/child/[profileId]/_layout.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/_layout.tsx
@@ -1,6 +1,10 @@
 import { Stack } from 'expo-router';
 import { useThemeColors } from '../../../../lib/theme';
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 export default function ChildDetailLayout() {
   const colors = useThemeColors();
   return (

--- a/apps/mobile/src/app/(app)/progress/_layout.tsx
+++ b/apps/mobile/src/app/(app)/progress/_layout.tsx
@@ -1,6 +1,10 @@
 import { Stack } from 'expo-router';
 import { useThemeColors } from '../../../lib/theme';
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 export default function ProgressLayout(): React.JSX.Element {
   const colors = useThemeColors();
   return (

--- a/apps/mobile/src/app/(app)/quiz/_layout.tsx
+++ b/apps/mobile/src/app/(app)/quiz/_layout.tsx
@@ -27,6 +27,10 @@ interface QuizFlowContextType extends QuizFlowState {
   clear: () => void;
 }
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 const QuizFlowContext = createContext<QuizFlowContextType | null>(null);
 
 const INITIAL_STATE: QuizFlowState = {

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -2,10 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { AccordionTopicList } from './AccordionTopicList';
 
 const mockPush = jest.fn();
+const mockNavigate = jest.fn();
 const mockUseChildSubjectTopics = jest.fn();
 
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, navigate: mockNavigate }),
 }));
 
 jest.mock('../../hooks/use-dashboard', () => ({
@@ -177,6 +178,12 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/(app)/child/[profileId]',
+        params: { profileId: 'child-1' },
+      })
+    );
     expect(mockPush).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -2,11 +2,10 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { AccordionTopicList } from './AccordionTopicList';
 
 const mockPush = jest.fn();
-const mockNavigate = jest.fn();
 const mockUseChildSubjectTopics = jest.fn();
 
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ push: mockPush, navigate: mockNavigate }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 jest.mock('../../hooks/use-dashboard', () => ({
@@ -178,13 +177,16 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
-    expect(mockNavigate).toHaveBeenCalledWith(
+    expect(mockPush).toHaveBeenCalledTimes(2);
+    expect(mockPush).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]',
         params: { profileId: 'child-1' },
       })
     );
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -90,6 +90,10 @@ export function AccordionTopicList({
             key={topic.topicId}
             onPress={(event) => {
               event?.stopPropagation?.();
+              router.navigate({
+                pathname: '/(app)/child/[profileId]',
+                params: { profileId: childProfileId },
+              } as never);
               router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -90,7 +90,7 @@ export function AccordionTopicList({
             key={topic.topicId}
             onPress={(event) => {
               event?.stopPropagation?.();
-              router.navigate({
+              router.push({
                 pathname: '/(app)/child/[profileId]',
                 params: { profileId: childProfileId },
               } as never);


### PR DESCRIPTION
## Summary

Cleanup PR-08: `unstable_settings` on 3 layouts + `AccordionTopicList` cross-tab push fix

**Cluster**: C3 — Mobile navigation safety nets
**Phases**: P1 (unstable_settings on 3 layouts) + P2 (AccordionTopicList cross-tab push)
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: Add `unstable_settings = { initialRouteName: 'index' }` to `progress/_layout.tsx`, `quiz/_layout.tsx`, and `child/[profileId]/_layout.tsx` so cross-tab deep pushes synthesize a valid back-stack (commits: `62ecef87`)
- **P2**: Fix `AccordionTopicList` to push the full ancestor chain before the leaf route on cross-tab navigation, so `router.back()` returns to the expected parent instead of falling through to the Tabs root (commits: `4265ef5f`, `f445e3e4`)

## Verification

- [x] TypeCheck passes — all 6 projects clean (`pnpm exec nx run-many -t typecheck`)
- [x] Lint passes — 0 errors, 391 pre-existing warnings (none introduced)
- [x] AccordionTopicList tests pass — 6/6 (`AccordionTopicList.test.tsx`)
- [x] P1 `tsc --noEmit` clean on layout files
- [x] P2 cross-tab push tests pass

## Test Plan

- [ ] Verify no regressions in affected test suites
- [ ] Review diff against `docs/audit/cleanup-plan.md` PR-08 phase descriptions
- [ ] Confirm `unstable_settings` export is present in all 3 layout files
- [ ] Confirm AccordionTopicList pushes parent route before leaf on cross-tab nav

## References

- Cleanup plan: `docs/audit/cleanup-plan.md` → PR-08
- CLAUDE.md rule: `unstable_settings` requirement for nested layouts with index + dynamic children
- CLAUDE.md rule: cross-tab/cross-stack push must include full ancestor chain

---
Generated by Archon workflow `execute-cleanup-pr` (run `10ebe7b3033ef7d737066fe30fa735c8`)