### PR TITLE
cleanup(PR-13): declare @react-navigation/native + consolidate onlyBuiltDependencies [C5 P3+P7]

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "@react-native-community/datetimepicker": "^8.6.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@react-native-ml-kit/text-recognition": "^2.0.0",
+    "@react-navigation/native": "^7.1.28",
     "@sentry/react-native": "^8.1.0",
     "@tanstack/react-query": "^5.90.21",
     "expo": "~54.0.29",

--- a/package.json
+++ b/package.json
@@ -130,10 +130,6 @@
   },
   "packageManager": "pnpm@10.19.0",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ],
     "overrides": {
       "react": "19.1.0",
       "react-native-worklets": "0.7.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       '@react-native-ml-kit/text-recognition':
         specifier: ^2.0.0
         version: 2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      '@react-navigation/native':
+        specifier: ^7.1.28
+        version: 7.1.28(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@sentry/react-native':
         specifier: ^8.1.0
         version: 8.1.0(expo@54.0.29)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,6 @@ packages:
 
 onlyBuiltDependencies:
   - '@swc/core'
+  - esbuild
   - nx
+  - sharp


### PR DESCRIPTION
## Summary

Cleanup PR-13: Small dep fixes bundle — declare `@react-navigation/native`, consolidate `onlyBuiltDependencies`. (P4/P5 absorbed into PR-12. P6 verified: not orphan, kept.)

**Cluster**: C5 — Manifest & dep-declaration hygiene
**Phases**: P3 (Declare `@react-navigation/native`), P7 (Consolidate `onlyBuiltDependencies`)
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P3**: AUDIT-DEPENDENCY-DRIFT-2-1c — Declare `@react-navigation/native` in `apps/mobile/package.json` + update lockfile (`apps/mobile/package.json`, `pnpm-lock.yaml`) — commit 8c22e27e
- **P7**: AUDIT-DEPENDENCY-DRIFT-2-1g — Consolidate `onlyBuiltDependencies` (`package.json`, `pnpm-workspace.yaml`) — commit fb7a14b4

## Verification

- [x] TypeCheck passes (`pnpm exec nx run-many -t typecheck`) — 6 projects, exit 0
- [x] Lint passes (`pnpm exec nx run-many -t lint`) — exit 0, no new errors
- [x] Related tests pass — 0 suites for manifest/lockfile-only changes, `--passWithNoTests` exit 0
- [x] Phase-specific verification commands pass — P3 + P7 both reran typecheck, exit 0

## Test Plan

- [ ] Verify no regressions in affected test suites
- [ ] Review diff against cleanup-plan.md phase descriptions
- [ ] Confirm `@react-navigation/native` is correctly declared as a direct dependency in mobile
- [ ] Confirm `onlyBuiltDependencies` is unified into root workspace config without duplication

## References

- Cleanup plan: `docs/audit/cleanup-plan.md` -> PR-13
- Upstream dependency: PR-12 (C5 P1 — large manifest cleanup; should land before this)

---
Generated by Archon workflow `execute-cleanup-pr`