### PR TITLE
Fix Claude Code install directory

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Claude Code install directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Claude Code install directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- create \$HOME/.local/bin\ before running Claude Code actions
- apply the same prep step to the review and interactive Claude workflows

## Validation
- \git diff --check\
- pre-commit hook ran; no TS files staged, so related tests were skipped

Note: PRs that modify Claude workflow files may still fail Claude's own validation until this workflow content exists on the default branch.