### PR TITLE
refactor(tests): address PR #155 deferred review findings

### DIFF
--- a/apps/api/src/inngest/functions/interview-persist-curriculum.integration.test.ts
+++ b/apps/api/src/inngest/functions/interview-persist-curriculum.integration.test.ts
@@ -14,23 +14,24 @@ import {
 import { eq, like } from 'drizzle-orm';
 import { PersistCurriculumError } from '@eduagent/schemas';
 
-// EXTERNAL boundary mock — routeAndCall is the LLM provider HTTP call. Per C1 D-MOCK-1 this is the formalized LLM external boundary.
-// routeAndCall is the true external boundary (provider API). Mock it here so
-// extractSignals and generateCurriculum run their real parsing/DB logic while
-// the network call is replaced with a deterministic fixture response.
+// EXTERNAL boundary mock (C1 D-MOCK-1) — routeAndCall is the LLM provider
+// HTTP call. Mocked here so extractSignals and generateCurriculum run their
+// real parsing/DB logic while the network call is replaced with a
+// deterministic fixture response.
 const mockRouteAndCall = jest.fn();
 jest.mock('../../services/llm', () => ({
   ...(jest.requireActual('../../services/llm') as Record<string, unknown>),
   routeAndCall: (...args: unknown[]) => mockRouteAndCall(...args),
 }));
 
-// EXTERNAL boundary mocks — sendPushNotification (Expo Push API) and sendEmail (Resend HTTP) are the network-egress boundaries. Per C1 D-MOCK-2, formatters/templating run real.
+// EXTERNAL boundary mock (C1 D-MOCK-2) — sendPushNotification is the
+// Expo Push API egress point. interview-persist-curriculum.ts only sends
+// a push (no email path), so we stub only sendPushNotification and let
+// the real formatters/templating in services/notifications run.
 const mockSendPush = jest.fn();
-const mockSendEmail = jest.fn();
 jest.mock('../../services/notifications', () => ({
   ...(jest.requireActual('../../services/notifications') as Record<string, unknown>),
   sendPushNotification: (...args: unknown[]) => mockSendPush(...args),
-  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
 }));
 
 const mockCaptureException = jest.fn();

--- a/apps/api/src/services/quiz/vocabulary.integration.test.ts
+++ b/apps/api/src/services/quiz/vocabulary.integration.test.ts
@@ -183,6 +183,7 @@ beforeEach(async () => {
   // in CI's PostgreSQL service container. The SM-2 assertions use the
   // same sm2() function as the production code, so both sides compute
   // from the same real Date and the assertions still match.
+  jest.clearAllMocks();
   await cleanupTestAccounts();
 });
 
@@ -251,9 +252,34 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
     });
 
     expect(round.questions).toHaveLength(VOCAB_ROUND_SIZE);
-    // The real LLM router ran: verify the provider boundary was reached exactly once
-    // (generateQuizRound makes one routeAndCall for the discovery questions).
+    // Break-test for D-MOCK-1: prove the real `buildVocabularyPrompt` and
+    // `generateQuizRound` orchestration ran before reaching the provider
+    // boundary. If `jest.requireActual` is dropped, the barrel becomes a
+    // bare stub, the real prompt builder no longer runs, and these
+    // content/shape assertions fail. A simple `toHaveBeenCalledTimes(1)`
+    // would pass even with a full barrel mock — these don't.
     expect(mockRouteAndCall).toHaveBeenCalledTimes(1);
+    expect(mockRouteAndCall).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'system',
+          content: expect.stringContaining('Activity: Vocabulary quiz'),
+        }),
+        expect.objectContaining({
+          role: 'user',
+          content: 'Generate the quiz round.',
+        }),
+      ]),
+      1,
+      expect.objectContaining({ ageBracket: expect.any(String) })
+    );
+    const [systemPrompt] = mockRouteAndCall.mock.calls[0][0] as Array<{
+      role: string;
+      content: string;
+    }>;
+    expect(systemPrompt.content).toContain(
+      `Maximum CEFR level: ${context.cefrCeiling}`
+    );
     const masteryQuestions = round.questions.filter(
       (question): question is Extract<QuizQuestion, { type: 'vocabulary' }> =>
         question.type === 'vocabulary' && question.isLibraryItem


### PR DESCRIPTION
## Summary

Follow-up to PR #155, addressing the four deferred Claude review findings.

- **vocabulary.integration.test.ts**: Replaced the weak `toHaveBeenCalledTimes(1)` break-test (which would have passed even with the pre-PR full barrel mock) with a content-shape assertion that proves the real `buildVocabularyPrompt` and `generateQuizRound` orchestration ran before reaching the provider boundary. Asserts the system prompt contains `Activity: Vocabulary quiz` and `Maximum CEFR level: <ceiling>`, plus the third-arg context object includes `ageBracket`. If `jest.requireActual` is dropped, these assertions fail. Also added `jest.clearAllMocks()` in `beforeEach` for consistency with the other integration tests.
- **interview-persist-curriculum.integration.test.ts**: Removed the dead `mockSendEmail` stub — the function only calls `sendPushNotification`, so the email mock added noise without protecting any path. Condensed the duplicate boundary-mock comments into single blocks that reference the D-MOCK-1 / D-MOCK-2 decision IDs.

Worktree was already on Hit list 2A (merged via PR #169) and Hit list 2D (`dictation.test.ts` rate-limit now uses `meteringFixture.setNotificationLogCount` against the real middleware) — both confirmed complete on main, so this PR contains only the deferred review findings from #155.

## Test plan

- [ ] CI: `nx run api:test:integration` (vocabulary + interview-persist suites)
- [ ] CI: typecheck + lint
- [ ] Manual: revert `requireActual` in vocabulary mock locally and confirm the new break-test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test infrastructure with improved mock management and more comprehensive assertion validation for system and user prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->