### PR TITLE
refactor: Cleanup PR-08 — unstable_settings on 3 layouts + AccordionTopicList cross-tab push fix

### DIFF
--- a/apps/mobile/src/app/(app)/quiz/_layout.tsx
+++ b/apps/mobile/src/app/(app)/quiz/_layout.tsx
@@ -27,6 +27,10 @@ interface QuizFlowContextType extends QuizFlowState {
   clear: () => void;
 }
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 const QuizFlowContext = createContext<QuizFlowContextType | null>(null);
 
 const INITIAL_STATE: QuizFlowState = {

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -177,7 +177,16 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockPush).toHaveBeenCalledTimes(2);
+    expect(mockPush).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        pathname: '/(app)/child/[profileId]',
+        params: expect.objectContaining({ profileId: 'child-1' }),
+      })
+    );
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -91,6 +91,10 @@ export function AccordionTopicList({
             onPress={(event) => {
               event?.stopPropagation?.();
               router.push({
+                pathname: '/(app)/child/[profileId]',
+                params: { profileId: childProfileId },
+              } as never);
+              router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {
                   profileId: childProfileId,


### PR DESCRIPTION
## Summary

Cleanup PR-08: `unstable_settings` on 3 layouts + `AccordionTopicList` cross-tab push fix

**Cluster**: C3 — Mobile navigation safety nets
**Phases**: P1 — Add `unstable_settings` to 3 nested layouts; P2 — Fix `AccordionTopicList` cross-tab push to include parent chain
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: Add `unstable_settings = { initialRouteName: 'index' }` to nested mobile layouts where needed (`apps/mobile/src/app/(app)/quiz/_layout.tsx`; progress and child layouts already had the export)
- **P2**: Fix `AccordionTopicList` navigation so cross-tab pushes include the required parent chain (`apps/mobile/src/components/progress/AccordionTopicList.tsx`, `apps/mobile/src/components/progress/AccordionTopicList.test.tsx`)

## Verification

- [x] TypeCheck passes (`pnpm exec nx run-many -t typecheck`)
- [x] Lint passes (`pnpm exec nx run-many -t lint`)
- [x] Related tests pass
- [x] Phase-specific verification commands pass

## Test Plan

- [ ] Verify no regressions in affected test suites
- [ ] Review diff against cleanup-plan.md phase descriptions
- [ ] Check that resolved decisions (D-XXX) are implemented correctly

## References

- Cleanup plan: `docs/audit/cleanup-plan.md` → PR-08

---
Generated by Archon workflow `execute-cleanup-pr`
