### PR TITLE
refactor: Cleanup PR-08 — unstable_settings on 3 layouts + AccordionTopicList cross-tab push fix

### DIFF
--- a/apps/mobile/src/app/(app)/quiz/_layout.tsx
+++ b/apps/mobile/src/app/(app)/quiz/_layout.tsx
@@ -8,6 +8,10 @@ import type {
 import { useThemeColors } from '../../../lib/theme';
 import { useParentProxy } from '../../../hooks/use-parent-proxy';
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 interface QuizFlowState {
   activityType: QuizActivityType | null;
   subjectId: string | null;

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -177,12 +177,8 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
-    expect(mockPush).toHaveBeenNthCalledWith(1, {
-      pathname: '/(app)/child/[profileId]',
-      params: { profileId: 'child-1' },
-    });
-    expect(mockPush).toHaveBeenNthCalledWith(
-      2,
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -177,7 +177,12 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockPush).toHaveBeenNthCalledWith(1, {
+      pathname: '/(app)/child/[profileId]',
+      params: { profileId: 'child-1' },
+    });
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -91,10 +91,6 @@ export function AccordionTopicList({
             onPress={(event) => {
               event?.stopPropagation?.();
               router.push({
-                pathname: '/(app)/child/[profileId]',
-                params: { profileId: childProfileId },
-              } as never);
-              router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {
                   profileId: childProfileId,

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -91,6 +91,10 @@ export function AccordionTopicList({
             onPress={(event) => {
               event?.stopPropagation?.();
               router.push({
+                pathname: '/(app)/child/[profileId]',
+                params: { profileId: childProfileId },
+              } as never);
+              router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {
                   profileId: childProfileId,


### PR DESCRIPTION
## Summary

Cleanup PR-08: `unstable_settings` on 3 layouts + `AccordionTopicList` cross-tab push fix

**Cluster**: C3 — Mobile navigation safety nets
**Phases**: P1 Nested Layout Initial Routes; P2 AccordionTopicList Cross-Tab Navigation
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: MOBILE-1 1a / MOBILE-2 F5 — add `unstable_settings = { initialRouteName: 'index' }` to 3 nested layouts (`apps/mobile/src/app/(app)/progress/_layout.tsx`, `apps/mobile/src/app/(app)/quiz/_layout.tsx`, `apps/mobile/src/app/(app)/child/[profileId]/_layout.tsx`)
- **P2**: MOBILE-1 F2 — update `AccordionTopicList` cross-tab navigation to push the parent chain (`apps/mobile/src/components/progress/AccordionTopicList.tsx`, `apps/mobile/src/components/progress/AccordionTopicList.test.tsx`)

## Verification

- [x] TypeCheck passes (`pnpm exec nx run-many -t typecheck`)
- [x] Lint passes (`pnpm exec nx run-many -t lint`)
- [x] Related tests pass
- [x] Phase-specific verification commands pass

## Test Plan

- [ ] Verify no regressions in affected test suites
- [ ] Review diff against cleanup-plan.md phase descriptions
- [ ] Check that resolved decisions (D-XXX) are implemented correctly

## References

- Cleanup plan: `docs/audit/cleanup-plan.md` → PR-08
- Resolved decisions: N/A

---
Generated by Archon workflow `execute-cleanup-pr`
