### PR TITLE
refactor: Cleanup PR-08 — unstable_settings on 3 layouts + AccordionTopicList cross-tab push fix

### DIFF
--- a/apps/mobile/src/app/(app)/quiz/_layout.tsx
+++ b/apps/mobile/src/app/(app)/quiz/_layout.tsx
@@ -70,13 +70,13 @@ export function QuizFlowProvider({
     (prefetchedRoundId: string | null) => {
       setState((current) => ({ ...current, prefetchedRoundId }));
     },
-    []
+    [],
   );
   const setCompletionResult = useCallback(
     (completionResult: CompleteRoundResponse | null) => {
       setState((current) => ({ ...current, completionResult }));
     },
-    []
+    [],
   );
   const clear = useCallback(() => {
     setState(INITIAL_STATE);
@@ -100,6 +100,8 @@ export function QuizFlowProvider({
   );
 }
 
+export const unstable_settings = { initialRouteName: 'index' };
+
 export default function QuizLayout(): React.ReactElement {
   const colors = useThemeColors();
   const { isParentProxy } = useParentProxy();
@@ -109,6 +111,7 @@ export default function QuizLayout(): React.ReactElement {
   return (
     <QuizFlowProvider>
       <Stack
+        initialRouteName="index"
         screenOptions={{
           headerShown: false,
           animation: 'slide_from_right',

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -41,13 +41,13 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded={false}
-      />
+      />,
     );
 
     expect(screen.queryByText('No topics yet')).toBeNull();
     expect(mockUseChildSubjectTopics).toHaveBeenCalledWith(
       undefined,
-      undefined
+      undefined,
     );
   });
 
@@ -65,13 +65,13 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     expect(screen.getAllByTestId('accordion-topic-skeleton')).toHaveLength(3);
     expect(mockUseChildSubjectTopics).toHaveBeenCalledWith(
       'child-1',
-      'subject-1'
+      'subject-1',
     );
   });
 
@@ -90,15 +90,15 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     fireEvent.press(screen.getByTestId('accordion-topics-retry'));
 
     expect(
       screen.getByText(
-        'Could not load topics. Tap to retry, or close the subject card to dismiss.'
-      )
+        'Could not load topics. Tap to retry, or close the subject card to dismiss.',
+      ),
     ).toBeTruthy();
     expect(refetch).toHaveBeenCalled();
   });
@@ -166,7 +166,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByText('Started');
@@ -177,7 +177,16 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockPush).toHaveBeenCalledTimes(2);
+    expect(mockPush).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        pathname: '/(app)/child/[profileId]',
+        params: { profileId: 'child-1' },
+      }),
+    );
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({
@@ -187,7 +196,7 @@ describe('AccordionTopicList', () => {
           topicId: 'topic-1',
           totalSessions: '3',
         }),
-      })
+      }),
     );
   });
 
@@ -205,7 +214,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByText('No topics yet');
@@ -225,7 +234,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByTestId('accordion-topics-empty');

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -54,7 +54,7 @@ export function AccordionTopicList({
     refetch,
   } = useChildSubjectTopics(
     expanded ? childProfileId : undefined,
-    expanded ? subjectId : undefined
+    expanded ? subjectId : undefined,
   );
 
   if (!expanded) {
@@ -90,6 +90,10 @@ export function AccordionTopicList({
             key={topic.topicId}
             onPress={(event) => {
               event?.stopPropagation?.();
+              router.push({
+                pathname: '/(app)/child/[profileId]',
+                params: { profileId: childProfileId },
+              } as never);
               router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {


### PR DESCRIPTION
## Summary

Cleanup PR-08: unstable_settings on 3 layouts + AccordionTopicList cross-tab push fix

**Cluster**: C3 — Mobile navigation safety nets
**Phases**: P1+P2
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: MOBILE-1 1a / MOBILE-2 F5 — Add `unstable_settings` to nested layouts (commit `51005557`)
- **P2**: MOBILE-1 F2 — AccordionTopicList cross-tab push parent chain (commit `304a360f`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | All 6 projects clean (test-utils, schemas, retention, database, api, mobile) |
| Lint | PASS | 0 errors, 406 pre-existing warnings (grandfathered internal jest.mock sites) |
| Tests | PASS | 14 suites, 195 tests (broad); 10 suites, 141 tests (AccordionTopicList scoped) |
| Phase verifications | PASS | P1: `tsc --noEmit` clean; P2: 10 suites/141 tests pass |
| GC1 ratchet | PASS | No new internal jest.mock() calls introduced |

## Review Summary

**Verdict**: REQUEST_CHANGES
**Findings**: 0C / 1H / 1M / 1L

---
Generated by Archon workflow `execute-cleanup-pr`
