### PR TITLE
refactor: Cleanup PR-08 — unstable_settings on 3 layouts + AccordionTopicList cross-tab push fix

### DIFF
--- a/apps/mobile/src/app/(app)/quiz/_layout.tsx
+++ b/apps/mobile/src/app/(app)/quiz/_layout.tsx
@@ -38,6 +38,10 @@ const INITIAL_STATE: QuizFlowState = {
   completionResult: null,
 };
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 export function useQuizFlow(): QuizFlowContextType {
   const context = useContext(QuizFlowContext);
   if (!context) {
@@ -70,13 +74,13 @@ export function QuizFlowProvider({
     (prefetchedRoundId: string | null) => {
       setState((current) => ({ ...current, prefetchedRoundId }));
     },
-    []
+    [],
   );
   const setCompletionResult = useCallback(
     (completionResult: CompleteRoundResponse | null) => {
       setState((current) => ({ ...current, completionResult }));
     },
-    []
+    [],
   );
   const clear = useCallback(() => {
     setState(INITIAL_STATE);

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -41,13 +41,13 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded={false}
-      />
+      />,
     );
 
     expect(screen.queryByText('No topics yet')).toBeNull();
     expect(mockUseChildSubjectTopics).toHaveBeenCalledWith(
       undefined,
-      undefined
+      undefined,
     );
   });
 
@@ -65,13 +65,13 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     expect(screen.getAllByTestId('accordion-topic-skeleton')).toHaveLength(3);
     expect(mockUseChildSubjectTopics).toHaveBeenCalledWith(
       'child-1',
-      'subject-1'
+      'subject-1',
     );
   });
 
@@ -90,20 +90,20 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     fireEvent.press(screen.getByTestId('accordion-topics-retry'));
 
     expect(
       screen.getByText(
-        'Could not load topics. Tap to retry, or close the subject card to dismiss.'
-      )
+        'Could not load topics. Tap to retry, or close the subject card to dismiss.',
+      ),
     ).toBeTruthy();
     expect(refetch).toHaveBeenCalled();
   });
 
-  it('renders topic labels and navigates to topic details', () => {
+  it('renders topic labels and navigates to topic details through the child parent route', () => {
     mockUseChildSubjectTopics.mockReturnValue({
       data: [
         {
@@ -166,7 +166,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByText('Started');
@@ -177,7 +177,17 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockPush).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        pathname: '/(app)/child/[profileId]',
+        params: {
+          profileId: 'child-1',
+        },
+      }),
+    );
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({
@@ -187,7 +197,7 @@ describe('AccordionTopicList', () => {
           topicId: 'topic-1',
           totalSessions: '3',
         }),
-      })
+      }),
     );
   });
 
@@ -205,7 +215,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByText('No topics yet');
@@ -225,7 +235,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByTestId('accordion-topics-empty');

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -103,7 +103,7 @@ describe('AccordionTopicList', () => {
     expect(refetch).toHaveBeenCalled();
   });
 
-  it('renders topic labels and navigates to topic details through the child parent route', () => {
+  it('renders topic labels and navigates directly to topic details', () => {
     mockUseChildSubjectTopics.mockReturnValue({
       data: [
         {
@@ -177,17 +177,9 @@ describe('AccordionTopicList', () => {
 
     fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
 
+    expect(mockPush).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({
-        pathname: '/(app)/child/[profileId]',
-        params: {
-          profileId: 'child-1',
-        },
-      }),
-    );
-    expect(mockPush).toHaveBeenNthCalledWith(
-      2,
       expect.objectContaining({
         pathname: '/(app)/child/[profileId]/topic/[topicId]',
         params: expect.objectContaining({

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -91,12 +91,6 @@ export function AccordionTopicList({
             onPress={(event) => {
               event?.stopPropagation?.();
               router.push({
-                pathname: '/(app)/child/[profileId]',
-                params: {
-                  profileId: childProfileId,
-                },
-              } as never);
-              router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {
                   profileId: childProfileId,

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -54,7 +54,7 @@ export function AccordionTopicList({
     refetch,
   } = useChildSubjectTopics(
     expanded ? childProfileId : undefined,
-    expanded ? subjectId : undefined
+    expanded ? subjectId : undefined,
   );
 
   if (!expanded) {
@@ -90,6 +90,12 @@ export function AccordionTopicList({
             key={topic.topicId}
             onPress={(event) => {
               event?.stopPropagation?.();
+              router.push({
+                pathname: '/(app)/child/[profileId]',
+                params: {
+                  profileId: childProfileId,
+                },
+              } as never);
               router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {


### PR DESCRIPTION
## Summary

Cleanup PR-08: unstable_settings on 3 layouts + AccordionTopicList cross-tab push fix

**Cluster**: C3 — Mobile navigation safety nets
**Phases**: P1+P2
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: MOBILE-1 1a / MOBILE-2 F5 — Add `unstable_settings = { initialRouteName: 'index' }` to 3 nested layouts (commit `b8377572`)
- **P2**: MOBILE-1 F2 — `AccordionTopicList` cross-tab push must push parent chain (commit `f72b79db`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | `pnpm exec nx run-many -t typecheck` passed for 6 projects. |
| Lint | PASS | `pnpm exec nx run-many -t lint` passed for 6 projects with existing warnings only. |
| Tests | PASS | Related tests passed: 16 suites, 203 tests. Focused phase test passed: 10 suites, 141 tests. |
| Phase verifications | PASS | 2 phase-specific checks passed: mobile `tsc --noEmit` and `AccordionTopicList` related Jest tests. GC1 ratchet check passed. |

## Review Summary

**Verdict**: REQUEST_CHANGES
**Findings**: 0C / 1H / 3M / 0L

---
Generated by Archon workflow `execute-cleanup-pr`
