### PR TITLE
refactor: Cleanup PR-02 — Delete dead coachingCardCelebrationResponseSchema export from progress.ts (zero consumers; route wraps + rename already shipped upstream).

### DIFF
--- a/packages/schemas/src/progress.ts
+++ b/packages/schemas/src/progress.ts
@@ -346,13 +346,6 @@ export const pendingNoticeSchema = z.object({
 });
 export type PendingNotice = z.infer<typeof pendingNoticeSchema>;
 
-export const coachingCardCelebrationResponseSchema = z.object({
-  pendingCelebrations: z.array(pendingCelebrationSchema),
-});
-export type CoachingCardCelebrationResponse = z.infer<
-  typeof coachingCardCelebrationResponseSchema
->;
-
 // Dashboard data — parent view wrapper
 
 export const dashboardDataSchema = z.object({


### PR DESCRIPTION
## Summary

Cleanup PR-02: Delete dead coachingCardCelebrationResponseSchema export from progress.ts (zero consumers; route wraps + rename already shipped upstream).

**Cluster**: C1 — Schema contract enforcement
**Phases**: P3
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P3**: Delete the dead coachingCardCelebrationResponseSchema export (commit `aa785c7e`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | `pnpm exec nx run-many -t typecheck` passed for 6 projects; `pnpm exec nx run api:typecheck` passed for phase verification. |
| Lint | PASS | `pnpm exec nx run-many -t lint` passed for 6 projects with existing warning-level `gov/no-internal-jest-mock` findings only. |
| Tests | PASS | `doppler run --project mentomate --config dev -- pnpm exec jest --findRelatedTests packages/schemas/src/progress.ts --no-coverage` passed: 274 suites, 4,425 tests. Initial unwrapped run failed because `DATABASE_URL` was unavailable in this local environment. |
| Phase verifications | PASS | 4 checks: API typecheck, related tests, zero hits for `rg 'coachingCardCelebrationResponseSchema' packages apps`, and GC1 ratchet. |

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 0M / 0L

---
Generated by Archon workflow `execute-cleanup-pr`
