### PR TITLE
refactor: Cleanup PR-01 — Move typed errors to @eduagent/schemas/errors.ts + add queued to feedbackResponseSchema

### DIFF
--- a/apps/mobile/src/lib/api-errors.ts
+++ b/apps/mobile/src/lib/api-errors.ts
@@ -11,59 +11,28 @@
  * `instanceof` checks would only succeed within a single package.
  */
 
-import type { QuotaExceeded } from '@eduagent/schemas';
 import {
   BadRequestError,
   ConflictError,
   ForbiddenError,
   NotFoundError,
+  QuotaExceededError,
   RateLimitedError,
+  ResourceGoneError,
 } from '@eduagent/schemas';
+import type { QuotaExceededDetails, UpgradeOption } from '@eduagent/schemas';
 
-export type QuotaExceededDetails = QuotaExceeded['details'];
-export type UpgradeOption = QuotaExceededDetails['upgradeOptions'][number];
-
-export class QuotaExceededError extends Error {
-  readonly code = 'QUOTA_EXCEEDED' as const;
-  readonly errorCode = 'QUOTA_EXCEEDED' as const;
-  readonly details: QuotaExceededDetails;
-
-  constructor(message: string, details: QuotaExceededDetails) {
-    super(message);
-    this.name = 'QuotaExceededError';
-    this.details = details;
-  }
-}
+export type { QuotaExceededDetails, UpgradeOption };
 
 export {
   BadRequestError,
   ConflictError,
   ForbiddenError,
   NotFoundError,
+  QuotaExceededError,
   RateLimitedError,
+  ResourceGoneError,
 };
-
-/**
- * Thrown when a 410 Gone response is received — the resource existed but has
- * been permanently removed. Callers should navigate away rather than retry.
- */
-export class ResourceGoneError extends Error {
-  readonly errorCode = 'RESOURCE_GONE' as const;
-  readonly code: string | undefined;
-  readonly details: unknown;
-
-  constructor(
-    message = 'This resource is no longer available.',
-    code?: string,
-    details?: unknown
-  ) {
-    super(message);
-    this.name = 'ResourceGoneError';
-    this.code = code;
-    this.details = details;
-    Object.setPrototypeOf(this, ResourceGoneError.prototype);
-  }
-}
 
 /**
  * Thrown when `fetch` itself rejects (no HTTP response received).
@@ -75,7 +44,7 @@ export class NetworkError extends Error {
 
   constructor(
     message = "Looks like you're offline or our servers can't be reached. Check your internet connection and try again.",
-    cause?: unknown
+    cause?: unknown,
   ) {
     super(message);
     this.name = 'NetworkError';

--- a/packages/schemas/src/errors.test.ts
+++ b/packages/schemas/src/errors.test.ts
@@ -14,7 +14,9 @@ import {
   ConflictError,
   ForbiddenError,
   NotFoundError,
+  QuotaExceededError,
   RateLimitedError,
+  ResourceGoneError,
   SafetyFilterError,
   UpstreamLlmError,
   VocabularyContextError,
@@ -123,6 +125,45 @@ describe('typed error classes [BUG-644]', () => {
         expect(classifyOrphanError(err)).toBe(expected);
       },
     );
+  });
+
+  it('QuotaExceededError carries code, errorCode, and details', () => {
+    const details = {
+      tier: 'free' as const,
+      reason: 'monthly' as const,
+      monthlyLimit: 10,
+      usedThisMonth: 10,
+      dailyLimit: null,
+      usedToday: 3,
+      topUpCreditsRemaining: 0,
+      upgradeOptions: [
+        { tier: 'pro' as const, monthlyQuota: 100, priceMonthly: 9.99 },
+      ],
+    };
+    const err = new QuotaExceededError('Quota exceeded', details);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(QuotaExceededError);
+    expect(err.name).toBe('QuotaExceededError');
+    expect(err.code).toBe('QUOTA_EXCEEDED');
+    expect(err.errorCode).toBe('QUOTA_EXCEEDED');
+    expect(err.details).toBe(details);
+  });
+
+  it('ResourceGoneError exposes errorCode, optional code, and details', () => {
+    const err = new ResourceGoneError('Session archived', 'SESSION_ARCHIVED', {
+      id: '123',
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ResourceGoneError);
+    expect(err.name).toBe('ResourceGoneError');
+    expect(err.errorCode).toBe('RESOURCE_GONE');
+    expect(err.code).toBe('SESSION_ARCHIVED');
+    expect(err.details).toEqual({ id: '123' });
+
+    const defaultErr = new ResourceGoneError();
+    expect(defaultErr.message).toBe('This resource is no longer available.');
+    expect(defaultErr.code).toBeUndefined();
+    expect(defaultErr.details).toBeUndefined();
   });
 
   // The whole point of moving these into schemas: an instance created

--- a/packages/schemas/src/errors.ts
+++ b/packages/schemas/src/errors.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { QuotaExceeded } from './billing';
 
 /**
  * Shared typed error class hierarchy.
@@ -117,6 +118,40 @@ export class TopicNotSkippedError extends Error {
     super('Topic is not skipped');
     this.name = 'TopicNotSkippedError';
     Object.setPrototypeOf(this, TopicNotSkippedError.prototype);
+  }
+}
+
+export type QuotaExceededDetails = QuotaExceeded['details'];
+export type UpgradeOption = QuotaExceededDetails['upgradeOptions'][number];
+
+export class QuotaExceededError extends Error {
+  readonly code = 'QUOTA_EXCEEDED' as const;
+  readonly errorCode = 'QUOTA_EXCEEDED' as const;
+  readonly details: QuotaExceededDetails;
+
+  constructor(message: string, details: QuotaExceededDetails) {
+    super(message);
+    this.name = 'QuotaExceededError';
+    this.details = details;
+    Object.setPrototypeOf(this, QuotaExceededError.prototype);
+  }
+}
+
+export class ResourceGoneError extends Error {
+  readonly errorCode = 'RESOURCE_GONE' as const;
+  readonly code: string | undefined;
+  readonly details: unknown;
+
+  constructor(
+    message = 'This resource is no longer available.',
+    code?: string,
+    details?: unknown,
+  ) {
+    super(message);
+    this.name = 'ResourceGoneError';
+    this.code = code;
+    this.details = details;
+    Object.setPrototypeOf(this, ResourceGoneError.prototype);
   }
 }
 


### PR DESCRIPTION
## Summary

Cleanup PR-01: Move typed errors to @eduagent/schemas/errors.ts + add queued to feedbackResponseSchema

**Cluster**: C1 — Schema contract enforcement
**Phases**: P1+P2
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: Move QuotaExceededError and ResourceGoneError to @eduagent/schemas (commit `6ef1f3f7`)
- **P2**: Add queued to feedbackResponseSchema (commit `(shipped`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | All 6 projects clean (from cache) — api, mobile, schemas, database, retention, test-utils |
| Lint | PASS | 0 errors, 324 warnings (all pre-existing `gov/no-internal-jest-mock` warnings in grandfathered files) |
| Tests (errors.test.ts) | PASS | 20/20 tests pass — new QuotaExceededError / ResourceGoneError schema tests |
| Tests (api-errors + api-client) | PASS | 26/26 tests pass — mobile imports updated correctly |
| Phase P1 verification | PASS | api:typecheck + mobile:typecheck clean; BUG-947 guard tests unchanged |
| Phase P2 verification | PASS | feedbackResponseSchema with `queued: z.boolean()` already shipped in PR #153 |
| GC1 ratchet | PASS | No new internal `jest.mock()` calls introduced |

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 1M / 3L

---
Generated by Archon workflow `execute-cleanup-pr`
