### PR TITLE
refactor: Cleanup PR-03 — Rename misnamed request schemas, author response schemas, add streamErrorFrameSchema, execute D-C1-1 dispositions

### DIFF
--- a/apps/api/eval-llm/flows/session-recap.ts
+++ b/apps/api/eval-llm/flows/session-recap.ts
@@ -1,4 +1,4 @@
-import { learnerRecapResponseSchema } from '@eduagent/schemas';
+import { learnerRecapLlmOutputSchema } from '@eduagent/schemas';
 import type { EvalProfile } from '../fixtures/profiles';
 import type { FlowDefinition, PromptMessages } from '../runner/types';
 import {
@@ -59,7 +59,7 @@ export const sessionRecapFlow: FlowDefinition<SessionRecapInput> = {
     safeParse(value: unknown) {
       try {
         const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-        return learnerRecapResponseSchema.safeParse(parsed);
+        return learnerRecapLlmOutputSchema.safeParse(parsed);
       } catch (error) {
         return { success: false, error };
       }
@@ -68,14 +68,14 @@ export const sessionRecapFlow: FlowDefinition<SessionRecapInput> = {
 
   async runLive(
     _input: SessionRecapInput,
-    messages: PromptMessages
+    messages: PromptMessages,
   ): Promise<string> {
     return callLlm(
       [
         { role: 'system', content: messages.system },
         { role: 'user', content: messages.user ?? '' },
       ],
-      { flow: 'session-recap', rung: 2 }
+      { flow: 'session-recap', rung: 2 },
     );
   },
 };

--- a/apps/api/src/routes/assessments.ts
+++ b/apps/api/src/routes/assessments.ts
@@ -2,11 +2,11 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import {
   assessmentAnswerSchema,
-  quickCheckResponseSchema,
+  quickCheckRequestSchema,
   createAssessmentResponseSchema,
   submitAssessmentAnswerResponseSchema,
   getAssessmentResponseSchema,
-  quickCheckFeedbackResponseSchema,
+  quickCheckResponseSchema,
   chatExchangeSchema,
   declineAssessmentRefreshResponseSchema,
 } from '@eduagent/schemas';
@@ -32,7 +32,7 @@ import { createLogger } from '../services/logger';
 const logger = createLogger();
 
 function countLearnerAnswers(
-  history: Array<{ role: 'user' | 'assistant'; content: string }>
+  history: Array<{ role: 'user' | 'assistant'; content: string }>,
 ): number {
   return history.filter((entry) => entry.role === 'user').length;
 }
@@ -49,7 +49,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
       db,
       profileId,
       subjectId,
-      topicId
+      topicId,
     );
 
     return c.json(
@@ -63,7 +63,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
           createdAt: assessment.createdAt,
         },
       }),
-      201
+      201,
     );
   })
 
@@ -83,7 +83,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
       const topicTitle = await loadTopicTitle(
         db,
         assessment.topicId,
-        profileId
+        profileId,
       );
 
       const evaluation = await evaluateAssessmentAnswer(
@@ -93,7 +93,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
           currentDepth: assessment.verificationDepth,
           exchangeHistory: assessment.exchangeHistory,
         },
-        answer
+        answer,
       );
 
       const updatedHistory = [
@@ -112,15 +112,15 @@ export const assessmentRoutes = new Hono<RouteEnv>()
       const newStatus = shouldContinueDepth
         ? 'in_progress'
         : evaluation.passed
-        ? 'passed'
-        : evaluation.masteryScore >= 0.6 &&
-          (capReached ||
-            !evaluation.shouldEscalateDepth ||
-            !evaluation.nextDepth)
-        ? 'borderline'
-        : capReached
-        ? 'failed_exhausted'
-        : 'in_progress';
+          ? 'passed'
+          : evaluation.masteryScore >= 0.6 &&
+              (capReached ||
+                !evaluation.shouldEscalateDepth ||
+                !evaluation.nextDepth)
+            ? 'borderline'
+            : capReached
+              ? 'failed_exhausted'
+              : 'in_progress';
 
       const updatedAssessment = await updateAssessment(
         db,
@@ -133,7 +133,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
           masteryScore: evaluation.masteryScore,
           qualityRating: evaluation.qualityRating,
           exchangeHistory: updatedHistory,
-        }
+        },
       );
 
       // Wire terminal standalone assessments into the retention lifecycle.
@@ -145,7 +145,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
       ) {
         const sm2Quality = mapEvaluateQualityToSm2(
           evaluation.passed,
-          Math.round(evaluation.masteryScore * 5)
+          Math.round(evaluation.masteryScore * 5),
         );
         const sessionTimestamp =
           updatedAssessment?.updatedAt ?? new Date().toISOString();
@@ -158,14 +158,14 @@ export const assessmentRoutes = new Hono<RouteEnv>()
             profileId,
             assessment.topicId,
             sm2Quality,
-            sessionTimestamp
+            sessionTimestamp,
           );
           if (newStatus === 'passed') {
             await insertSessionXpEntry(
               txDb,
               profileId,
               assessment.topicId,
-              assessment.subjectId
+              assessment.subjectId,
             );
           }
         });
@@ -175,9 +175,9 @@ export const assessmentRoutes = new Hono<RouteEnv>()
         submitAssessmentAnswerResponseSchema.parse({
           evaluation,
           status: newStatus,
-        })
+        }),
       );
-    }
+    },
   )
 
   .patch('/assessments/:assessmentId/decline-refresh', async (c) => {
@@ -195,7 +195,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
           code: 'BAD_REQUEST',
           message: 'Assessment is not in a terminal state',
         },
-        400
+        400,
       );
     }
 
@@ -232,7 +232,7 @@ export const assessmentRoutes = new Hono<RouteEnv>()
 
     const sanitizedHistory = Array.isArray(assessment.exchangeHistory)
       ? assessment.exchangeHistory.filter(
-          (entry) => chatExchangeSchema.safeParse(entry).success
+          (entry) => chatExchangeSchema.safeParse(entry).success,
         )
       : [];
     logger.warn(
@@ -241,19 +241,19 @@ export const assessmentRoutes = new Hono<RouteEnv>()
         assessmentId,
         droppedEntries:
           (assessment.exchangeHistory?.length ?? 0) - sanitizedHistory.length,
-      }
+      },
     );
     return c.json(
       getAssessmentResponseSchema.parse({
         assessment: { ...assessment, exchangeHistory: sanitizedHistory },
-      })
+      }),
     );
   })
 
   // Submit quick check response during session
   .post(
     '/sessions/:sessionId/quick-check',
-    zValidator('json', quickCheckResponseSchema),
+    zValidator('json', quickCheckRequestSchema),
     async (c) => {
       const { db, profileId } = withProfile(c);
       const sessionId = c.req.param('sessionId');
@@ -274,14 +274,14 @@ export const assessmentRoutes = new Hono<RouteEnv>()
           currentDepth: 'recall',
           exchangeHistory: [],
         },
-        answer
+        answer,
       );
 
       return c.json(
-        quickCheckFeedbackResponseSchema.parse({
+        quickCheckResponseSchema.parse({
           feedback: evaluation.feedback,
           isCorrect: evaluation.passed,
-        })
+        }),
       );
-    }
+    },
   );

--- a/apps/api/src/routes/consent.ts
+++ b/apps/api/src/routes/consent.ts
@@ -2,9 +2,9 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import {
   consentRequestSchema,
-  consentResponseSchema,
+  consentRespondRequestSchema,
   consentRequestResultSchema,
-  consentRespondResultSchema,
+  consentRespondResponseSchema,
   myConsentStatusSchema,
   childConsentStatusSchema,
   consentActionResultSchema,
@@ -131,12 +131,12 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
       const childProfile = await getProfile(
         db,
         input.childProfileId,
-        account.id
+        account.id,
       );
       if (!childProfile) {
         return forbidden(
           c,
-          'Not authorized to request consent for this profile'
+          'Not authorized to request consent for this profile',
         );
       }
 
@@ -148,7 +148,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
           c,
           400,
           ERROR_CODES.VALIDATION_ERROR,
-          'Parent email must be different from your account email'
+          'Parent email must be different from your account email',
         );
       }
 
@@ -170,7 +170,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
             resendApiKey: c.env.RESEND_API_KEY,
             emailFrom: c.env.EMAIL_FROM,
           },
-          account.id
+          account.id,
         );
       } catch (error) {
         if (error instanceof ConsentResendLimitError) {
@@ -200,7 +200,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
         // [A-23] logger.warn alone is invisible in prod — escalate to Sentry so
         // we can query how often the GDPR reminder workflow is permanently skipped.
         logger.warn(
-          '[consent] Failed to dispatch Inngest event — reminder workflow skipped'
+          '[consent] Failed to dispatch Inngest event — reminder workflow skipped',
         );
         captureException(err, {
           extra: {
@@ -216,13 +216,13 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
           consentType: input.consentType,
           emailStatus: result.emailDelivered ? 'sent' : 'failed',
         }),
-        201
+        201,
       );
-    }
+    },
   )
   .post(
     '/consent/respond',
-    zValidator('json', consentResponseSchema),
+    zValidator('json', consentRespondRequestSchema),
     async (c) => {
       const db = c.get('db');
       const input = c.req.valid('json');
@@ -239,23 +239,23 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
         'unknown';
       if (isConsentRespondRateLimited(ipKey)) {
         const retryAfterSecs = Math.ceil(
-          CONSENT_RESPOND_RATE_LIMIT_WINDOW_MS / 1000
+          CONSENT_RESPOND_RATE_LIMIT_WINDOW_MS / 1000,
         );
         c.header('Retry-After', String(retryAfterSecs));
         return apiError(
           c,
           429,
           ERROR_CODES.RATE_LIMITED,
-          'Too many consent attempts. Please try again later.'
+          'Too many consent attempts. Please try again later.',
         );
       }
 
       try {
         await processConsentResponse(db, input.token, input.approved);
         return c.json(
-          consentRespondResultSchema.parse({
+          consentRespondResponseSchema.parse({
             message: input.approved ? 'Consent granted' : 'Consent denied',
-          })
+          }),
         );
       } catch (error) {
         if (error instanceof ConsentTokenNotFoundError) {
@@ -269,7 +269,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
         }
         throw error;
       }
-    }
+    },
   )
   .get('/consent/my-status', async (c) => {
     // This route intentionally works without a profile —
@@ -281,7 +281,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
           consentStatus: null,
           parentEmail: null,
           consentType: null,
-        })
+        }),
       );
     }
     const db = c.get('db');
@@ -296,7 +296,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
         // Mask to "p***@example.com" — preserves verification UX, reduces leak.
         parentEmail: maskEmail(state?.parentEmail ?? null),
         consentType: state?.consentType ?? null,
-      })
+      }),
     );
   })
 
@@ -310,7 +310,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
       const state = await getChildConsentForParent(
         db,
         childProfileId,
-        parentProfileId
+        parentProfileId,
       );
       if (!state) {
         return c.json(
@@ -318,7 +318,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
             consentStatus: null,
             respondedAt: null,
             consentType: null,
-          })
+          }),
         );
       }
       return c.json(
@@ -326,7 +326,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
           consentStatus: state.status,
           respondedAt: state.respondedAt,
           consentType: state.consentType,
-        })
+        }),
       );
     } catch (error) {
       if (error instanceof ConsentNotAuthorizedError) {
@@ -361,7 +361,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
         // [A-23] logger.warn alone is invisible in prod — escalate to Sentry so
         // we can query how often the GDPR 7-day deletion grace period is skipped.
         logger.warn(
-          '[consent] Failed to dispatch Inngest revocation event — grace period job skipped'
+          '[consent] Failed to dispatch Inngest revocation event — grace period job skipped',
         );
         captureException(err, {
           extra: {
@@ -376,7 +376,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
           message:
             'Consent revoked. Data will be deleted after 7-day grace period.',
           consentStatus: state.status,
-        })
+        }),
       );
     } catch (error) {
       if (error instanceof ConsentNotAuthorizedError) {
@@ -401,7 +401,7 @@ export const consentRoutes = new Hono<ConsentRouteEnv>()
         consentActionResultSchema.parse({
           message: 'Consent restored. Deletion cancelled.',
           consentStatus: state.status,
-        })
+        }),
       );
     } catch (error) {
       if (error instanceof ConsentNotAuthorizedError) {

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -18,6 +18,7 @@ import {
   LlmStreamError,
   RateLimitedError,
   SafetyFilterError,
+  streamErrorFrameSchema,
   streamFallbackFrameSchema,
   UpstreamLlmError,
   getSubjectSessionsResponseSchema,
@@ -571,13 +572,14 @@ export const sessionRoutes = new Hono<SessionRouteEnv>()
               if (isSafetyFilterError(streamErr)) return 'safety_filter';
               return 'unknown_error';
             })();
+            const frame = streamErrorFrameSchema.parse({
+              type: 'error',
+              code: errorCode,
+              message:
+                'Something went wrong while generating a reply. Please try again.',
+            });
             await sseStream.writeSSE({
-              data: JSON.stringify({
-                type: 'error',
-                code: errorCode,
-                message:
-                  'Something went wrong while generating a reply. Please try again.',
-              }),
+              data: JSON.stringify(frame),
             });
             return;
           }
@@ -740,11 +742,12 @@ export const sessionRoutes = new Hono<SessionRouteEnv>()
                 );
               }
             }
+            const frame = streamErrorFrameSchema.parse({
+              type: 'error',
+              message: 'Failed to save session progress. Please try again.',
+            });
             await sseStream.writeSSE({
-              data: JSON.stringify({
-                type: 'error',
-                message: 'Failed to save session progress. Please try again.',
-              }),
+              data: JSON.stringify(frame),
             });
           }
         });

--- a/apps/api/src/services/filing.integration.test.ts
+++ b/apps/api/src/services/filing.integration.test.ts
@@ -28,7 +28,7 @@ import {
   fileToLibrary,
   resolveFilingResult,
 } from './filing';
-import type { FilingResponse, LibraryIndex } from '@eduagent/schemas';
+import type { FilingLlmOutput, LibraryIndex } from '@eduagent/schemas';
 
 // ---------------------------------------------------------------------------
 // DB setup — real connection
@@ -40,7 +40,7 @@ function requireDatabaseUrl(): string {
   const url = process.env.DATABASE_URL;
   if (!url) {
     throw new Error(
-      'DATABASE_URL is not set. Create .env.test.local or .env.development.local.'
+      'DATABASE_URL is not set. Create .env.test.local or .env.development.local.',
     );
   }
   return url;
@@ -118,7 +118,7 @@ describe('resolveFilingResult (integration)', () => {
     const { profile } = await seedAccountAndProfile();
     const db = createIntegrationDb();
 
-    const filingResponse: FilingResponse = {
+    const filingResponse: FilingLlmOutput = {
       shelf: { name: 'Geography' },
       book: { name: 'Europe', emoji: '🌍', description: 'European geography' },
       chapter: { name: 'Rivers' },
@@ -188,7 +188,7 @@ describe('resolveFilingResult (integration)', () => {
       })
       .returning();
 
-    const filingResponse: FilingResponse = {
+    const filingResponse: FilingLlmOutput = {
       shelf: { id: existingSubject!.id },
       book: {
         name: 'Chemistry',
@@ -227,7 +227,7 @@ describe('resolveFilingResult (integration)', () => {
       .returning();
 
     // File with "science" (lowercase) — should reuse, not create new
-    const filingResponse: FilingResponse = {
+    const filingResponse: FilingLlmOutput = {
       shelf: { name: 'science' },
       book: { name: 'Biology', emoji: '🧬', description: 'Living things' },
       chapter: { name: 'Cells' },
@@ -278,7 +278,7 @@ describe('resolveFilingResult (integration)', () => {
       .returning();
 
     // File with "physics" (lowercase) — should reuse existing book
-    const filingResponse: FilingResponse = {
+    const filingResponse: FilingLlmOutput = {
       shelf: { id: subject!.id },
       book: { name: 'physics', emoji: '⚛️', description: 'Physical science' },
       chapter: { name: 'Mechanics' },
@@ -328,7 +328,7 @@ describe('resolveFilingResult (integration)', () => {
       })
       .returning();
 
-    const filingResponse: FilingResponse = {
+    const filingResponse: FilingLlmOutput = {
       shelf: { id: subject!.id },
       book: { id: existingBook!.id },
       chapter: { name: 'WW2' },
@@ -373,7 +373,7 @@ describe('resolveFilingResult (integration)', () => {
       })
       .returning();
 
-    const filingResponse: FilingResponse = {
+    const filingResponse: FilingLlmOutput = {
       shelf: { name: 'Art' },
       book: {
         name: 'Painting',
@@ -424,7 +424,7 @@ describe('resolveFilingResult (integration)', () => {
           title: `Concurrent Topic ${topicSuffix}`,
           description: 'Race test topic',
         },
-      } satisfies FilingResponse,
+      } satisfies FilingLlmOutput,
       filedFrom: 'session_filing' as const,
     });
 
@@ -444,8 +444,8 @@ describe('resolveFilingResult (integration)', () => {
       .where(
         and(
           eq(subjects.profileId, profile.id),
-          sql`lower(${subjects.name}) = lower(${'ConcurrentShelf'})`
-        )
+          sql`lower(${subjects.name}) = lower(${'ConcurrentShelf'})`,
+        ),
       );
     expect(rows).toHaveLength(1);
   });
@@ -488,7 +488,7 @@ describe('resolveFilingResult (integration)', () => {
           title: `Concurrent Topic ${topicSuffix}`,
           description: 'Race test topic',
         },
-      } satisfies FilingResponse,
+      } satisfies FilingLlmOutput,
       filedFrom: 'session_filing' as const,
     });
 
@@ -508,8 +508,8 @@ describe('resolveFilingResult (integration)', () => {
       .where(
         and(
           eq(curriculumBooks.subjectId, subject!.id),
-          sql`lower(${curriculumBooks.title}) = lower(${'ConcurrentBook'})`
-        )
+          sql`lower(${curriculumBooks.title}) = lower(${'ConcurrentBook'})`,
+        ),
       );
     expect(rows).toHaveLength(1);
   });
@@ -554,7 +554,7 @@ describe('resolveFilingResult (integration)', () => {
       where: eq(curriculumTopics.bookId, first.bookId),
     });
     const matchingTopics = allTopics.filter(
-      (t) => t.title.toLowerCase() === 'light reactions'
+      (t) => t.title.toLowerCase() === 'light reactions',
     );
     expect(matchingTopics).toHaveLength(1);
   });
@@ -628,7 +628,7 @@ describe('resolveFilingResult (integration)', () => {
           topic: { title: 'Fail', description: 'This should not work' },
         },
         filedFrom: 'session_filing',
-      })
+      }),
     ).rejects.toThrow('Shelf not found');
   });
 });
@@ -665,7 +665,7 @@ describe('buildLibraryIndex after filing (integration)', () => {
     expect(index.shelves[0]!.books[0]!.chapters[0]!.name).toBe('Basics');
     expect(index.shelves[0]!.books[0]!.chapters[0]!.topics).toHaveLength(1);
     expect(index.shelves[0]!.books[0]!.chapters[0]!.topics[0]!.title).toBe(
-      'Variables'
+      'Variables',
     );
   });
 });
@@ -693,7 +693,7 @@ describe('fileToLibrary (LLM mock, schema validation)', () => {
     const result = await fileToLibrary(
       { rawInput: 'hydrogen' },
       emptyIndex,
-      mockRouteAndCall
+      mockRouteAndCall,
     );
 
     expect(result.shelf).toEqual({ name: 'Science' });
@@ -733,7 +733,7 @@ describe('fileToLibrary (LLM mock, schema validation)', () => {
         sessionMode: 'freeform',
       },
       emptyIndex,
-      mockRouteAndCall
+      mockRouteAndCall,
     );
 
     expect(result.extracted).toBe('Photosynthesis in plants');
@@ -796,7 +796,7 @@ describe('fileToLibrary (LLM mock, schema validation)', () => {
     const result = await fileToLibrary(
       { rawInput: 'hydrogen' },
       existingIndex,
-      mockRouteAndCall
+      mockRouteAndCall,
     );
 
     expect(result.shelf).toEqual({
@@ -824,7 +824,7 @@ describe('fileToLibrary (LLM mock, schema validation)', () => {
     const result = await fileToLibrary(
       { rawInput: 'variables' },
       emptyIndex,
-      mockRouteAndCall
+      mockRouteAndCall,
     );
 
     expect(result.topic.title).toBe('Variables');
@@ -841,7 +841,7 @@ describe('fileToLibrary (LLM mock, schema validation)', () => {
     });
 
     await expect(
-      fileToLibrary({ rawInput: 'hydrogen' }, emptyIndex, mockRouteAndCall)
+      fileToLibrary({ rawInput: 'hydrogen' }, emptyIndex, mockRouteAndCall),
     ).rejects.toThrow();
   });
 
@@ -850,7 +850,7 @@ describe('fileToLibrary (LLM mock, schema validation)', () => {
     const mockRouteAndCall = jest.fn();
 
     await expect(
-      fileToLibrary({}, emptyIndex, mockRouteAndCall)
+      fileToLibrary({}, emptyIndex, mockRouteAndCall),
     ).rejects.toThrow('Filing requires either rawInput or sessionTranscript');
   });
 });

--- a/apps/api/src/services/filing.test.ts
+++ b/apps/api/src/services/filing.test.ts
@@ -84,7 +84,7 @@ describe('buildLibraryIndex', () => {
 describe('formatLibraryIndexForPrompt', () => {
   it('returns "(empty library)" for empty index', () => {
     expect(formatLibraryIndexForPrompt({ shelves: [] })).toBe(
-      '(empty library)'
+      '(empty library)',
     );
   });
 
@@ -143,7 +143,7 @@ describe('fileToLibrary', () => {
         selectedSuggestion: 'European Rivers',
       },
       index,
-      mockRouteAndCall
+      mockRouteAndCall,
     );
 
     expect(result.topic.title).toBe('Danube');
@@ -190,7 +190,7 @@ describe('fileToLibrary — post-session variant', () => {
         sessionMode: 'freeform',
       },
       index,
-      mockRouteAndCall
+      mockRouteAndCall,
     );
 
     expect(result.extracted).toBe('European rivers and the Danube');
@@ -203,9 +203,9 @@ describe('fileToLibrary — post-session variant', () => {
   });
 
   // [BUG-849] Break test — LLM returns valid JSON but missing required schema
-  // fields. The cast `JSON.parse(jsonStr) as FilingResponse` would silently
+  // fields. The cast `JSON.parse(jsonStr) as FilingLlmOutput` would silently
   // produce a malformed object that crashes downstream destructuring.
-  // filingResponseSchema.parse() must throw a ZodError instead.
+  // filingLlmOutputSchema.parse() must throw a ZodError instead.
   it('[BUG-849] throws ZodError when LLM response is missing required fields', async () => {
     const mockRouteAndCall = jest.fn().mockResolvedValue({
       response: JSON.stringify({
@@ -226,7 +226,7 @@ describe('fileToLibrary — post-session variant', () => {
     const index: LibraryIndex = { shelves: [] };
 
     await expect(
-      fileToLibrary({ rawInput: 'Danube' }, index, mockRouteAndCall)
+      fileToLibrary({ rawInput: 'Danube' }, index, mockRouteAndCall),
     ).rejects.toThrow();
   });
 });
@@ -295,7 +295,7 @@ describe('buildFallbackFilingResponse [BUG-871]', () => {
     const result = buildFallbackFilingResponse(
       SUBJECT_ID,
       'Geometry Foundations',
-      'Geometry Foundations'
+      'Geometry Foundations',
     );
     if ('id' in result.book) {
       throw new Error('expected book to be a name-form ref');
@@ -328,7 +328,7 @@ describe('buildFallbackFilingResponse [BUG-871]', () => {
     const result = buildFallbackFilingResponse(
       SUBJECT_ID,
       'raw fallback name',
-      'Picked Suggestion'
+      'Picked Suggestion',
     );
     if ('id' in result.book) {
       throw new Error('expected book to be a name-form ref');
@@ -340,7 +340,7 @@ describe('buildFallbackFilingResponse [BUG-871]', () => {
     const result = buildFallbackFilingResponse(
       SUBJECT_ID,
       'rawInput',
-      '   Geometry   '
+      '   Geometry   ',
     );
     if ('id' in result.book) {
       throw new Error('expected book to be a name-form ref');

--- a/apps/api/src/services/filing.ts
+++ b/apps/api/src/services/filing.ts
@@ -21,10 +21,10 @@ import {
   createScopedRepository,
 } from '@eduagent/database';
 import {
-  filingResponseSchema,
+  filingLlmOutputSchema,
   type FiledFrom,
   type FilingRequest,
-  type FilingResponse,
+  type FilingLlmOutput,
   type FilingResult,
   type LibraryIndex,
 } from '@eduagent/schemas';
@@ -41,11 +41,11 @@ const MAX_TOPIC_SUMMARIES = 50;
 
 export async function buildLibraryIndex(
   db: Database,
-  profileId: string
+  profileId: string,
 ): Promise<LibraryIndex> {
   const repo = createScopedRepository(db, profileId);
   const activeSubjects = await repo.subjects.findMany(
-    eq(subjects.status, 'active')
+    eq(subjects.status, 'active'),
   );
 
   if (activeSubjects.length === 0) {
@@ -107,7 +107,7 @@ export async function buildLibraryIndex(
         const chapterTopics = chapterMap.get(chapterName);
         if (!chapterTopics)
           throw new Error(
-            `Chapter map entry missing for chapter: ${chapterName}`
+            `Chapter map entry missing for chapter: ${chapterName}`,
           );
         chapterTopics.push({
           title: topic.title,
@@ -139,11 +139,11 @@ export async function buildLibraryIndex(
       const shelfTopicCount = shelf.books.reduce(
         (sum, b) =>
           sum + b.chapters.reduce((cSum, c) => cSum + c.topics.length, 0),
-        0
+        0,
       );
       const shelfBudget = Math.max(
         1,
-        Math.round(MAX_TOPIC_SUMMARIES * (shelfTopicCount / totalTopics))
+        Math.round(MAX_TOPIC_SUMMARIES * (shelfTopicCount / totalTopics)),
       );
 
       let shelfKept = 0;
@@ -169,9 +169,9 @@ function countTopics(shelves: LibraryIndex['shelves']): number {
       s.books.reduce(
         (bSum, b) =>
           bSum + b.chapters.reduce((cSum, c) => cSum + c.topics.length, 0),
-        0
+        0,
       ),
-    0
+    0,
   );
 }
 
@@ -202,7 +202,7 @@ export function formatLibraryIndexForPrompt(index: LibraryIndex): string {
 
 export type LLMCaller = (
   messages: ChatMessage[],
-  rung?: number
+  rung?: number,
 ) => Promise<RouteResult>;
 
 const SEED_TAXONOMY = `When the learner's library is empty or sparse, prefer these standard
@@ -216,7 +216,7 @@ export function buildPreSessionPrompt(
   rawInput: string,
   selectedSuggestion: string | null | undefined,
   libraryText: string,
-  isSparse: boolean
+  isSparse: boolean,
 ): string {
   const seedBlock = isSparse ? `\n\n${SEED_TAXONOMY}` : '';
 
@@ -252,7 +252,7 @@ Return ONLY valid JSON:
 export function buildPostSessionPrompt(
   sessionTranscript: string,
   libraryText: string,
-  isSparse: boolean
+  isSparse: boolean,
 ): string {
   const seedBlock = isSparse ? `\n\n${SEED_TAXONOMY}` : '';
 
@@ -284,8 +284,8 @@ export async function fileToLibrary(
     'rawInput' | 'selectedSuggestion' | 'sessionTranscript' | 'sessionMode'
   >,
   libraryIndex: LibraryIndex,
-  routeAndCall: LLMCaller
-): Promise<FilingResponse> {
+  routeAndCall: LLMCaller,
+): Promise<FilingLlmOutput> {
   const libraryText = formatLibraryIndexForPrompt(libraryIndex);
   const totalTopics = countTopics(libraryIndex.shelves);
   const isSparse = totalTopics < 5;
@@ -307,7 +307,7 @@ export async function fileToLibrary(
       request.rawInput,
       request.selectedSuggestion,
       libraryText,
-      isSparse
+      isSparse,
     );
   } else {
     throw new Error('Filing requires either rawInput or sessionTranscript');
@@ -349,7 +349,7 @@ export async function fileToLibrary(
     throw err;
   }
 
-  const result = filingResponseSchema.safeParse(parsed);
+  const result = filingLlmOutputSchema.safeParse(parsed);
   if (!result.success) {
     captureException(result.error, {
       extra: {
@@ -383,7 +383,7 @@ const MAX_BOOK_NAME_LENGTH = 200;
 
 function pickFallbackBookName(
   selectedSuggestion: string | null | undefined,
-  rawInput: string
+  rawInput: string,
 ): { name: string; isSpecific: boolean } {
   const candidates = [selectedSuggestion, rawInput];
   for (const candidate of candidates) {
@@ -401,11 +401,11 @@ function pickFallbackBookName(
 export function buildFallbackFilingResponse(
   subjectId: string,
   rawInput: string,
-  selectedSuggestion?: string | null
-): FilingResponse {
+  selectedSuggestion?: string | null,
+): FilingLlmOutput {
   const { name: bookName, isSpecific } = pickFallbackBookName(
     selectedSuggestion,
-    rawInput
+    rawInput,
   );
   return {
     shelf: { id: subjectId },
@@ -430,14 +430,14 @@ export function buildFallbackFilingResponse(
 
 interface ResolveFilingInput {
   profileId: string;
-  filingResponse: FilingResponse;
+  filingResponse: FilingLlmOutput;
   filedFrom: FiledFrom;
   sessionId?: string;
 }
 
 export async function resolveFilingResult(
   db: Database,
-  input: ResolveFilingInput
+  input: ResolveFilingInput,
 ): Promise<FilingResult> {
   const { profileId, filingResponse, filedFrom, sessionId } = input;
 
@@ -455,7 +455,7 @@ export async function resolveFilingResult(
       const existing = await txDb.query.subjects.findFirst({
         where: and(
           eq(subjects.id, filingResponse.shelf.id),
-          eq(subjects.profileId, profileId)
+          eq(subjects.profileId, profileId),
         ),
       });
       if (!existing)
@@ -478,8 +478,8 @@ export async function resolveFilingResult(
           and(
             eq(subjects.profileId, profileId),
             sql`lower(${subjects.name}) = lower(${filingResponse.shelf.name})`,
-            eq(subjects.status, 'active')
-          )
+            eq(subjects.status, 'active'),
+          ),
         )
         .limit(1);
       if (existing) {
@@ -514,7 +514,7 @@ export async function resolveFilingResult(
             where: and(
               eq(subjects.profileId, profileId),
               sql`lower(${subjects.name}) = lower(${filingResponse.shelf.name})`,
-              eq(subjects.status, 'active')
+              eq(subjects.status, 'active'),
             ),
             columns: { id: true, name: true },
           });
@@ -523,7 +523,7 @@ export async function resolveFilingResult(
             // so a row with that key MUST exist. Surface as an error rather
             // than silently continuing.
             throw new Error(
-              `[CR-FIL-DEDUP-INDEX-12-FOLLOWUP] Shelf insert hit unique-index conflict but no matching row found on re-find. profileId=${profileId} name=${filingResponse.shelf.name}`
+              `[CR-FIL-DEDUP-INDEX-12-FOLLOWUP] Shelf insert hit unique-index conflict but no matching row found on re-find. profileId=${profileId} name=${filingResponse.shelf.name}`,
             );
           }
           shelfId = racedExisting.id;
@@ -557,7 +557,7 @@ export async function resolveFilingResult(
       const existing = await txDb.query.curriculumBooks.findFirst({
         where: and(
           eq(curriculumBooks.id, filingResponse.book.id),
-          eq(curriculumBooks.subjectId, shelfId)
+          eq(curriculumBooks.subjectId, shelfId),
         ),
       });
       if (!existing)
@@ -580,8 +580,8 @@ export async function resolveFilingResult(
         .where(
           and(
             eq(curriculumBooks.subjectId, shelfId),
-            sql`lower(${curriculumBooks.title}) = lower(${filingResponse.book.name})`
-          )
+            sql`lower(${curriculumBooks.title}) = lower(${filingResponse.book.name})`,
+          ),
         )
         .limit(1);
       if (existing) {
@@ -593,7 +593,7 @@ export async function resolveFilingResult(
         });
         const maxOrder = allBooks.reduce(
           (max, b) => Math.max(max, b.sortOrder),
-          -1
+          -1,
         );
 
         const newId = generateUUIDv7();
@@ -628,7 +628,7 @@ export async function resolveFilingResult(
           const racedExisting = await txDb.query.curriculumBooks.findFirst({
             where: and(
               eq(curriculumBooks.subjectId, shelfId),
-              sql`lower(${curriculumBooks.title}) = lower(${filingResponse.book.name})`
+              sql`lower(${curriculumBooks.title}) = lower(${filingResponse.book.name})`,
             ),
             columns: { id: true, title: true },
           });
@@ -637,7 +637,7 @@ export async function resolveFilingResult(
             // so a row with that key MUST exist. Surface as an error rather
             // than silently continuing.
             throw new Error(
-              `[CR-FIL-DEDUP-INDEX-12-FOLLOWUP] Book insert hit unique-index conflict but no matching row found on re-find. subjectId=${shelfId} title=${filingResponse.book.name}`
+              `[CR-FIL-DEDUP-INDEX-12-FOLLOWUP] Book insert hit unique-index conflict but no matching row found on re-find. subjectId=${shelfId} title=${filingResponse.book.name}`,
             );
           }
           bookId = racedExisting.id;
@@ -657,7 +657,7 @@ export async function resolveFilingResult(
       const existingTopic = await txDb.query.curriculumTopics.findFirst({
         where: and(
           eq(curriculumTopics.bookId, bookId),
-          sql`lower(${curriculumTopics.chapter}) = lower(${filingResponse.chapter.name})`
+          sql`lower(${curriculumTopics.chapter}) = lower(${filingResponse.chapter.name})`,
         ),
       });
       chapterName = filingResponse.chapter.name;
@@ -679,7 +679,7 @@ export async function resolveFilingResult(
       where: eq(curriculumTopics.bookId, bookId),
     });
     const existingDuplicate = existingTopics.find(
-      (t) => t.title.toLowerCase() === filingResponse.topic.title.toLowerCase()
+      (t) => t.title.toLowerCase() === filingResponse.topic.title.toLowerCase(),
     );
     let topicId: string;
     if (existingDuplicate) {
@@ -688,7 +688,7 @@ export async function resolveFilingResult(
       const newTopicId = generateUUIDv7();
       const maxTopicOrder = existingTopics.reduce(
         (max, t) => Math.max(max, t.sortOrder),
-        -1
+        -1,
       );
       // [CR-FIL-DEDUP-INDEX-12] onConflictDoNothing + .returning() lets us
       // detect when the unique index suppressed our insert (race lost) so
@@ -723,7 +723,7 @@ export async function resolveFilingResult(
         const racedExisting = await txDb.query.curriculumTopics.findFirst({
           where: and(
             eq(curriculumTopics.bookId, bookId),
-            sql`lower(${curriculumTopics.title}) = lower(${filingResponse.topic.title})`
+            sql`lower(${curriculumTopics.title}) = lower(${filingResponse.topic.title})`,
           ),
           columns: { id: true },
         });
@@ -733,7 +733,7 @@ export async function resolveFilingResult(
           // else is wrong (unrelated constraint, transaction visibility
           // anomaly) — surface as an error rather than silently continue.
           throw new Error(
-            `[CR-FIL-DEDUP-INDEX-12] Topic insert hit unique-index conflict but no matching row found on re-find. bookId=${bookId} title=${filingResponse.topic.title}`
+            `[CR-FIL-DEDUP-INDEX-12] Topic insert hit unique-index conflict but no matching row found on re-find. bookId=${bookId} title=${filingResponse.topic.title}`,
           );
         }
         topicId = racedExisting.id;
@@ -751,8 +751,8 @@ export async function resolveFilingResult(
         .where(
           and(
             eq(learningSessions.id, sessionId),
-            eq(learningSessions.profileId, profileId)
-          )
+            eq(learningSessions.profileId, profileId),
+          ),
         );
     }
 

--- a/apps/api/src/services/session-recap.ts
+++ b/apps/api/src/services/session-recap.ts
@@ -5,7 +5,7 @@ import {
   type Database,
   type ScopedRepository,
 } from '@eduagent/database';
-import { learnerRecapResponseSchema } from '@eduagent/schemas';
+import { learnerRecapLlmOutputSchema } from '@eduagent/schemas';
 import { extractFirstJsonObject, routeAndCall } from './llm';
 import { escapeXml, sanitizeXmlValue } from './llm/sanitize';
 import { projectAiResponseContent } from './llm/project-response';
@@ -59,7 +59,7 @@ export function getAgeVoiceTierLabel(birthYear: number | null): string {
  * smuggle a directive out of the data section. [PROMPT-INJECT-3]
  */
 export function buildRecapTranscriptText(
-  events: ReadonlyArray<{ eventType: string; content: string }>
+  events: ReadonlyArray<{ eventType: string; content: string }>,
 ): string {
   return events
     .map((event) => {
@@ -76,7 +76,7 @@ export function buildRecapTranscriptText(
 
 export function buildRecapPrompt(
   ageVoiceTier: string,
-  nextTopicTitle: string | null
+  nextTopicTitle: string | null,
 ): string {
   const basePrompt = [
     'You are reviewing a completed tutoring session transcript for a learner.',
@@ -107,7 +107,7 @@ export function buildRecapPrompt(
   if (!nextTopicTitle) {
     basePrompt.push(
       '',
-      'Set nextTopicReason to null because no next topic is provided.'
+      'Set nextTopicReason to null because no next topic is provided.',
     );
     return basePrompt.join('\n');
   }
@@ -122,7 +122,7 @@ export function buildRecapPrompt(
     `A likely next topic is <next_topic>${safeTitle}</next_topic>.`,
     'If the connection is genuinely clear, set nextTopicReason to one sentence explaining why it follows from this session.',
     'If the connection is weak or unclear, set nextTopicReason to null.',
-    'Max 120 characters for nextTopicReason.'
+    'Max 120 characters for nextTopicReason.',
   );
 
   return basePrompt.join('\n');
@@ -130,7 +130,7 @@ export function buildRecapPrompt(
 
 export async function resolveNextTopic(
   repo: ScopedRepository,
-  topicId: string
+  topicId: string,
 ): Promise<TopicSuggestion | null> {
   const currentTopic = await repo.curriculumTopics.findById(topicId);
   if (!currentTopic) {
@@ -157,10 +157,10 @@ export async function resolveNextTopic(
   const sameBookCandidates = await repo.curriculumTopics.findLaterInBook(
     currentTopic.bookId,
     currentTopic.sortOrder,
-    MAX_NEXT_TOPIC_CANDIDATES
+    MAX_NEXT_TOPIC_CANDIDATES,
   );
   const sameBookHit = sameBookCandidates.find(
-    (candidate) => !completedTopicIds.has(candidate.id)
+    (candidate) => !completedTopicIds.has(candidate.id),
   );
   if (sameBookHit) return sameBookHit;
 
@@ -172,11 +172,11 @@ export async function resolveNextTopic(
     await repo.curriculumTopics.findEarliestInLaterBooks(
       currentTopic.subjectId,
       currentTopic.bookSortOrder,
-      MAX_NEXT_TOPIC_CANDIDATES
+      MAX_NEXT_TOPIC_CANDIDATES,
     );
   return (
     nextBookCandidates.find(
-      (candidate) => !completedTopicIds.has(candidate.id)
+      (candidate) => !completedTopicIds.has(candidate.id),
     ) ?? null
   );
 }
@@ -194,7 +194,7 @@ export async function resolveNextTopic(
 export async function matchFreeformTopic(
   repo: ScopedRepository,
   subjectId: string,
-  takeaways: string[]
+  takeaways: string[],
 ): Promise<TopicSuggestion | null> {
   // Filler/function words that survive the length>=4 filter but carry no
   // topic signal for curriculum matching. Tokens under 4 chars (the, and,
@@ -280,7 +280,7 @@ export async function matchFreeformTopic(
       takeaways
         .flatMap((takeaway) => takeaway.split(/\s+/))
         .map((word) => word.toLowerCase().replace(/[^a-z0-9]/g, ''))
-        .filter((word) => word.length >= 4 && !stopWords.has(word))
+        .filter((word) => word.length >= 4 && !stopWords.has(word)),
     ),
   ].slice(0, 5);
 
@@ -289,7 +289,7 @@ export async function matchFreeformTopic(
   const matches = await repo.curriculumTopics.findMatchingInSubject(
     subjectId,
     keywords,
-    MAX_FREEFORM_MATCHES
+    MAX_FREEFORM_MATCHES,
   );
 
   // Only return a match when the keyword set resolves unambiguously to one
@@ -302,7 +302,7 @@ export async function matchFreeformTopic(
 
 export async function generateLearnerRecap(
   db: Database,
-  input: RecapInput
+  input: RecapInput,
 ): Promise<LearnerRecapResult | null> {
   if (input.exchangeCount < 3) {
     return null;
@@ -311,7 +311,7 @@ export async function generateLearnerRecap(
   const transcriptEvents = await db.query.sessionEvents.findMany({
     where: and(
       eq(sessionEvents.sessionId, input.sessionId),
-      eq(sessionEvents.profileId, input.profileId)
+      eq(sessionEvents.profileId, input.profileId),
     ),
     // [BUG-913 sweep] Tie-break by id when created_at collides — see
     // session-crud.ts getSessionTranscript for the full rationale.
@@ -324,7 +324,7 @@ export async function generateLearnerRecap(
 
   const transcriptTurns = transcriptEvents.filter(
     (event) =>
-      event.eventType === 'user_message' || event.eventType === 'ai_response'
+      event.eventType === 'user_message' || event.eventType === 'ai_response',
   );
 
   if (transcriptTurns.length < 4) {
@@ -341,14 +341,14 @@ export async function generateLearnerRecap(
   // Pure content-generation flow: the LLM returns only recap text + next-topic
   // reason for UI rendering. No envelope signals (close, escalate, widgets) drive
   // any state machine here — session termination already happened. We therefore
-  // validate against learnerRecapResponseSchema directly instead of parseEnvelope.
+  // validate against learnerRecapLlmOutputSchema directly instead of parseEnvelope.
   const result = await routeAndCall(
     [
       {
         role: 'system',
         content: buildRecapPrompt(
           getAgeVoiceTierLabel(input.birthYear),
-          nextTopic?.title ?? null
+          nextTopic?.title ?? null,
         ),
       },
       {
@@ -359,7 +359,7 @@ export async function generateLearnerRecap(
         content: `<transcript>\n${transcriptText}\n</transcript>`,
       },
     ],
-    1
+    1,
   );
 
   const jsonObject = extractFirstJsonObject(result.response);
@@ -383,7 +383,7 @@ export async function generateLearnerRecap(
     return null;
   }
 
-  const validated = learnerRecapResponseSchema.safeParse(parsed);
+  const validated = learnerRecapLlmOutputSchema.safeParse(parsed);
   if (!validated.success) {
     logger.warn('Learner recap schema validation failed', {
       sessionId: input.sessionId,
@@ -402,6 +402,6 @@ export async function generateLearnerRecap(
     closingLine,
     learnerRecap: takeaways.map((takeaway) => `- ${takeaway}`).join('\n'),
     nextTopicId: nextTopic?.id ?? null,
-    nextTopicReason: input.topicId ? nextTopicReason ?? null : null,
+    nextTopicReason: input.topicId ? (nextTopicReason ?? null) : null,
   };
 }

--- a/packages/schemas/src/assessments.ts
+++ b/packages/schemas/src/assessments.ts
@@ -98,12 +98,12 @@ export const assessmentAnswerSchema = z.object({
 });
 export type AssessmentAnswerInput = z.infer<typeof assessmentAnswerSchema>;
 
-// Quick check response
+// Quick check request
 
-export const quickCheckResponseSchema = z.object({
+export const quickCheckRequestSchema = z.object({
   answer: z.string().min(1).max(5000),
 });
-export type QuickCheckResponseInput = z.infer<typeof quickCheckResponseSchema>;
+export type QuickCheckRequestInput = z.infer<typeof quickCheckRequestSchema>;
 
 // Verification type — standard, evaluate (Devil's Advocate), teach_back (Feynman)
 
@@ -289,13 +289,14 @@ export const getAssessmentResponseSchema = z.object({
 });
 export type GetAssessmentResponse = z.infer<typeof getAssessmentResponseSchema>;
 
-export const quickCheckFeedbackResponseSchema = z.object({
+export const quickCheckResponseSchema = z.object({
   feedback: z.string(),
   isCorrect: z.boolean(),
 });
-export type QuickCheckFeedbackResponse = z.infer<
-  typeof quickCheckFeedbackResponseSchema
->;
+export type QuickCheckResponse = z.infer<typeof quickCheckResponseSchema>;
+
+export const quickCheckFeedbackResponseSchema = quickCheckResponseSchema;
+export type QuickCheckFeedbackResponse = QuickCheckResponse;
 
 export const declineAssessmentRefreshResponseSchema = z.object({
   ok: z.literal(true),

--- a/packages/schemas/src/consent.ts
+++ b/packages/schemas/src/consent.ts
@@ -19,12 +19,12 @@ export const consentRequestSchema = z.object({
 
 export type ConsentRequest = z.infer<typeof consentRequestSchema>;
 
-export const consentResponseSchema = z.object({
+export const consentRespondRequestSchema = z.object({
   token: z.string(),
   approved: z.boolean(),
 });
 
-export type ConsentResponse = z.infer<typeof consentResponseSchema>;
+export type ConsentRespondRequest = z.infer<typeof consentRespondRequestSchema>;
 
 // Consent request result — response after submitting a consent request
 
@@ -36,10 +36,15 @@ export const consentRequestResultSchema = z.object({
 export type ConsentRequestResult = z.infer<typeof consentRequestResultSchema>;
 
 // Response after a parent processes a consent token (approve/deny)
-export const consentRespondResultSchema = z.object({
+export const consentRespondResponseSchema = z.object({
   message: z.string(),
 });
-export type ConsentRespondResult = z.infer<typeof consentRespondResultSchema>;
+export type ConsentRespondResponse = z.infer<
+  typeof consentRespondResponseSchema
+>;
+
+export const consentRespondResultSchema = consentRespondResponseSchema;
+export type ConsentRespondResult = ConsentRespondResponse;
 
 // Response for GET /consent/my-status (child profile view)
 export const myConsentStatusSchema = z.object({

--- a/packages/schemas/src/filing.test.ts
+++ b/packages/schemas/src/filing.test.ts
@@ -1,6 +1,6 @@
 import {
   filingRequestSchema,
-  filingResponseSchema,
+  filingLlmOutputSchema,
   filedFromSchema,
 } from './filing.js';
 
@@ -27,9 +27,9 @@ describe('filingRequestSchema', () => {
   });
 });
 
-describe('filingResponseSchema', () => {
+describe('filingLlmOutputSchema', () => {
   it('accepts new entities', () => {
-    const result = filingResponseSchema.safeParse({
+    const result = filingLlmOutputSchema.safeParse({
       shelf: { name: 'Geography' },
       book: { name: 'Europe', emoji: '🌍', description: 'European geography' },
       chapter: { name: 'Rivers' },
@@ -39,7 +39,7 @@ describe('filingResponseSchema', () => {
   });
 
   it('accepts existing entity references', () => {
-    const result = filingResponseSchema.safeParse({
+    const result = filingLlmOutputSchema.safeParse({
       shelf: { id: '019012ab-cdef-7000-8000-000000000001' },
       book: { id: '019012ab-cdef-7000-8000-000000000002' },
       chapter: { existing: 'Rivers' },
@@ -49,7 +49,7 @@ describe('filingResponseSchema', () => {
   });
 
   it('accepts post-session variant with extracted field', () => {
-    const result = filingResponseSchema.safeParse({
+    const result = filingLlmOutputSchema.safeParse({
       extracted: 'European rivers and the Danube',
       shelf: { name: 'Geography' },
       book: { name: 'Europe', emoji: '🌍', description: 'European geography' },

--- a/packages/schemas/src/filing.ts
+++ b/packages/schemas/src/filing.ts
@@ -36,7 +36,7 @@ export const filingRequestSchema = z
   });
 export type FilingRequest = z.infer<typeof filingRequestSchema>;
 
-// --- Filing LLM response (parsed from LLM JSON output) ---
+// --- Filing LLM output (parsed from LLM JSON output) ---
 
 const shelfRefSchema = z.union([
   z.object({ id: z.string().uuid() }),
@@ -62,14 +62,14 @@ const topicRefSchema = z.object({
   description: z.string().min(1).max(500),
 });
 
-export const filingResponseSchema = z.object({
+export const filingLlmOutputSchema = z.object({
   extracted: z.string().max(500).optional(),
   shelf: shelfRefSchema,
   book: bookRefSchema,
   chapter: chapterRefSchema,
   topic: topicRefSchema,
 });
-export type FilingResponse = z.infer<typeof filingResponseSchema>;
+export type FilingLlmOutput = z.infer<typeof filingLlmOutputSchema>;
 
 // --- Library index (condensed structure for LLM prompt) ---
 

--- a/packages/schemas/src/progress.ts
+++ b/packages/schemas/src/progress.ts
@@ -532,12 +532,6 @@ export const homeCardSchema = z.object({
 });
 export type HomeCard = z.infer<typeof homeCardSchema>;
 
-export const homeCardsResponseSchema = z.object({
-  cards: z.array(homeCardSchema),
-  coldStart: z.boolean(),
-});
-export type HomeCardsResponse = z.infer<typeof homeCardsResponseSchema>;
-
 export const homeCardInteractionTypeSchema = z.enum(['tap', 'dismiss']);
 export type HomeCardInteractionType = z.infer<
   typeof homeCardInteractionTypeSchema

--- a/packages/schemas/src/quiz.ts
+++ b/packages/schemas/src/quiz.ts
@@ -132,7 +132,7 @@ export const generateRoundInputSchema = z
       .max(100)
       .regex(
         /^[\p{L}\p{N} ,.'!?_-]+$/u,
-        'Theme must contain only letters, numbers, spaces, and basic punctuation'
+        'Theme must contain only letters, numbers, spaces, and basic punctuation',
       )
       .optional(),
     subjectId: z.string().uuid().optional(),
@@ -176,18 +176,6 @@ export const quizRoundResponseSchema = z.object({
   difficultyBump: z.boolean().optional(),
 });
 export type QuizRoundResponse = z.infer<typeof quizRoundResponseSchema>;
-
-// Server-internal round response — full question data for DB/service use
-export const internalQuizRoundResponseSchema = z.object({
-  id: z.string().uuid(),
-  activityType: quizActivityTypeSchema,
-  theme: z.string(),
-  questions: z.array(quizQuestionSchema),
-  total: z.number().int().positive(),
-});
-export type InternalQuizRoundResponse = z.infer<
-  typeof internalQuizRoundResponseSchema
->;
 
 export const validatedQuestionResultSchema = z.object({
   questionIndex: z.number().int().min(0),
@@ -336,7 +324,7 @@ export const completedRoundQuestionSchema = z.intersection(
   z.object({
     correctAnswer: z.string(),
     acceptedAliases: z.array(z.string()).optional(),
-  })
+  }),
 );
 export type CompletedRoundQuestion = z.infer<
   typeof completedRoundQuestionSchema

--- a/packages/schemas/src/sessions.ts
+++ b/packages/schemas/src/sessions.ts
@@ -392,12 +392,12 @@ export const skipSummaryResponseSchema = z.object({
 });
 export type SkipSummaryResponse = z.infer<typeof skipSummaryResponseSchema>;
 
-export const learnerRecapResponseSchema = z.object({
+export const learnerRecapLlmOutputSchema = z.object({
   closingLine: z.string().min(1).max(150),
   takeaways: z.array(z.string().min(1).max(200)).min(1).max(4),
   nextTopicReason: z.string().min(1).max(120).nullable(),
 });
-export type LearnerRecapResponse = z.infer<typeof learnerRecapResponseSchema>;
+export type LearnerRecapLlmOutput = z.infer<typeof learnerRecapLlmOutputSchema>;
 
 // Parking lot schemas
 

--- a/packages/schemas/src/stream-fallback.test.ts
+++ b/packages/schemas/src/stream-fallback.test.ts
@@ -1,0 +1,31 @@
+import { streamErrorFrameSchema } from './stream-fallback.js';
+
+describe('streamErrorFrameSchema', () => {
+  it('accepts an error frame with a stable code', () => {
+    const parsed = streamErrorFrameSchema.parse({
+      type: 'error',
+      code: 'quota_exhausted',
+      message:
+        'Something went wrong while generating a reply. Please try again.',
+    });
+
+    expect(parsed).toEqual({
+      type: 'error',
+      code: 'quota_exhausted',
+      message:
+        'Something went wrong while generating a reply. Please try again.',
+    });
+  });
+
+  it('accepts an error frame without a code', () => {
+    const parsed = streamErrorFrameSchema.parse({
+      type: 'error',
+      message: 'Failed to save session progress. Please try again.',
+    });
+
+    expect(parsed).toEqual({
+      type: 'error',
+      message: 'Failed to save session progress. Please try again.',
+    });
+  });
+});

--- a/packages/schemas/src/stream-fallback.ts
+++ b/packages/schemas/src/stream-fallback.ts
@@ -29,6 +29,13 @@ export const streamFallbackFrameSchema = z.object({
 });
 export type StreamFallbackFrame = z.infer<typeof streamFallbackFrameSchema>;
 
+export const streamErrorFrameSchema = z.object({
+  type: z.literal('error'),
+  message: z.string(),
+  code: z.string().optional(),
+});
+export type StreamErrorFrame = z.infer<typeof streamErrorFrameSchema>;
+
 export const exchangeFallbackSchema = z.object({
   reason: exchangeFallbackReasonSchema,
   fallbackText: z.string().min(1),


### PR DESCRIPTION
## Summary

Cleanup PR-03: Rename misnamed request schemas, author response schemas, add streamErrorFrameSchema, execute D-C1-1 dispositions

**Cluster**: C1 — Schema contract enforcement
**Phases**: P4+P5+P6
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P4**: AUDIT-TYPES-2.3 — Rename request-shaped quick-check and consent schemas (commit `cd369298`)
- **P5**: Per D-C1-3 — stream error frame schema (commit `f8f4d646`)
- **P6**: AUDIT-TYPES-2.5 — Resolve no-matching-route schemas per D-C1-1 (commit `89bc1ae6`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | `pnpm exec nx run-many -t typecheck` passed for 6 projects; `pnpm exec nx run api:typecheck` also passed. |
| Lint | PASS | `pnpm exec nx run-many -t lint` exited successfully with 0 errors; existing internal-mock warnings remain. |
| Tests | PASS | Related tests passed under Doppler `mentomate/dev`: 279 suites, 4510 tests. |
| Phase verifications | PASS | P4 related tests passed: 276 suites, 4468 tests. P5 API/schema related tests passed: 167 suites, 2890 tests. P6 workspace typecheck passed. GC1 ratchet passed. |

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 3M / 2L

---
Generated by Archon workflow `execute-cleanup-pr`
