### PR TITLE
refactor: Cleanup PR-08 — unstable_settings on quiz/_layout.tsx + AccordionTopicList cross-tab push fix. (Workflow-development drafts #179/#184/#185 ran this PR's input; all to be closed unmerged.)

### DIFF
--- a/apps/mobile/src/app/(app)/quiz/_layout.tsx
+++ b/apps/mobile/src/app/(app)/quiz/_layout.tsx
@@ -8,6 +8,10 @@ import type {
 import { useThemeColors } from '../../../lib/theme';
 import { useParentProxy } from '../../../hooks/use-parent-proxy';
 
+export const unstable_settings = {
+  initialRouteName: 'index',
+};
+
 interface QuizFlowState {
   activityType: QuizActivityType | null;
   subjectId: string | null;
@@ -70,13 +74,13 @@ export function QuizFlowProvider({
     (prefetchedRoundId: string | null) => {
       setState((current) => ({ ...current, prefetchedRoundId }));
     },
-    []
+    [],
   );
   const setCompletionResult = useCallback(
     (completionResult: CompleteRoundResponse | null) => {
       setState((current) => ({ ...current, completionResult }));
     },
-    []
+    [],
   );
   const clear = useCallback(() => {
     setState(INITIAL_STATE);

--- a/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.test.tsx
@@ -3,9 +3,11 @@ import { AccordionTopicList } from './AccordionTopicList';
 
 const mockPush = jest.fn();
 const mockUseChildSubjectTopics = jest.fn();
+let mockSegments: string[] = ['(app)', 'child', '[profileId]'];
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: mockPush }),
+  useSegments: () => mockSegments,
 }));
 
 jest.mock('../../hooks/use-dashboard', () => ({
@@ -26,6 +28,7 @@ jest.mock('./RetentionSignal', () => {
 describe('AccordionTopicList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSegments = ['(app)', 'child', '[profileId]'];
     mockUseChildSubjectTopics.mockReturnValue({
       data: [],
       isLoading: false,
@@ -41,13 +44,13 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded={false}
-      />
+      />,
     );
 
     expect(screen.queryByText('No topics yet')).toBeNull();
     expect(mockUseChildSubjectTopics).toHaveBeenCalledWith(
       undefined,
-      undefined
+      undefined,
     );
   });
 
@@ -65,13 +68,13 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     expect(screen.getAllByTestId('accordion-topic-skeleton')).toHaveLength(3);
     expect(mockUseChildSubjectTopics).toHaveBeenCalledWith(
       'child-1',
-      'subject-1'
+      'subject-1',
     );
   });
 
@@ -90,15 +93,15 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     fireEvent.press(screen.getByTestId('accordion-topics-retry'));
 
     expect(
       screen.getByText(
-        'Could not load topics. Tap to retry, or close the subject card to dismiss.'
-      )
+        'Could not load topics. Tap to retry, or close the subject card to dismiss.',
+      ),
     ).toBeTruthy();
     expect(refetch).toHaveBeenCalled();
   });
@@ -166,7 +169,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByText('Started');
@@ -187,7 +190,7 @@ describe('AccordionTopicList', () => {
           topicId: 'topic-1',
           totalSessions: '3',
         }),
-      })
+      }),
     );
   });
 
@@ -205,7 +208,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByText('No topics yet');
@@ -225,7 +228,7 @@ describe('AccordionTopicList', () => {
         subjectId="subject-1"
         subjectName="Mathematics"
         expanded
-      />
+      />,
     );
 
     screen.getByTestId('accordion-topics-empty');
@@ -234,5 +237,96 @@ describe('AccordionTopicList', () => {
     fireEvent.press(screen.getByTestId('accordion-topics-browse'));
 
     expect(mockPush).toHaveBeenCalledWith('/(app)/library');
+  });
+
+  it('[MOBILE-1 F2] pushes parent chain when rendered outside the child stack', () => {
+    mockSegments = ['(app)', 'progress'];
+    mockUseChildSubjectTopics.mockReturnValue({
+      data: [
+        {
+          topicId: 'topic-1',
+          title: 'Fractions',
+          description: 'Desc',
+          completionStatus: 'in_progress',
+          retentionStatus: null,
+          struggleStatus: 'normal',
+          masteryScore: 0.5,
+          summaryExcerpt: null,
+          xpStatus: 'pending',
+          totalSessions: 2,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <AccordionTopicList
+        childProfileId="child-1"
+        subjectId="subject-1"
+        subjectName="Mathematics"
+        expanded
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
+
+    expect(mockPush).toHaveBeenCalledTimes(2);
+    expect(mockPush).toHaveBeenNthCalledWith(1, {
+      pathname: '/(app)/child/[profileId]',
+      params: { profileId: 'child-1' },
+    });
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        pathname: '/(app)/child/[profileId]/topic/[topicId]',
+        params: expect.objectContaining({
+          profileId: 'child-1',
+          topicId: 'topic-1',
+        }),
+      }),
+    );
+  });
+
+  it('[MOBILE-1 F2] does not double-push when already inside the child stack', () => {
+    mockSegments = ['(app)', 'child', '[profileId]'];
+    mockUseChildSubjectTopics.mockReturnValue({
+      data: [
+        {
+          topicId: 'topic-1',
+          title: 'Fractions',
+          description: 'Desc',
+          completionStatus: 'in_progress',
+          retentionStatus: null,
+          struggleStatus: 'normal',
+          masteryScore: 0.5,
+          summaryExcerpt: null,
+          xpStatus: 'pending',
+          totalSessions: 2,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <AccordionTopicList
+        childProfileId="child-1"
+        subjectId="subject-1"
+        subjectName="Mathematics"
+        expanded
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('accordion-topic-topic-1'));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/(app)/child/[profileId]/topic/[topicId]',
+      }),
+    );
   });
 });

--- a/apps/mobile/src/components/progress/AccordionTopicList.tsx
+++ b/apps/mobile/src/components/progress/AccordionTopicList.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'expo-router';
+import { useRouter, useSegments } from 'expo-router';
 import { Pressable, Text, View } from 'react-native';
 import type { TopicProgress } from '@eduagent/schemas';
 import { useChildSubjectTopics } from '../../hooks/use-dashboard';
@@ -47,6 +47,8 @@ export function AccordionTopicList({
   expanded,
 }: AccordionTopicListProps): React.ReactElement | null {
   const router = useRouter();
+  const segments = useSegments();
+  const isInsideChildStack = segments.includes('child');
   const {
     data: topics,
     isLoading,
@@ -54,7 +56,7 @@ export function AccordionTopicList({
     refetch,
   } = useChildSubjectTopics(
     expanded ? childProfileId : undefined,
-    expanded ? subjectId : undefined
+    expanded ? subjectId : undefined,
   );
 
   if (!expanded) {
@@ -90,6 +92,12 @@ export function AccordionTopicList({
             key={topic.topicId}
             onPress={(event) => {
               event?.stopPropagation?.();
+              if (!isInsideChildStack) {
+                router.push({
+                  pathname: '/(app)/child/[profileId]',
+                  params: { profileId: childProfileId },
+                } as never);
+              }
               router.push({
                 pathname: '/(app)/child/[profileId]/topic/[topicId]',
                 params: {


### PR DESCRIPTION
## Summary

Cleanup PR-08: unstable_settings on quiz/_layout.tsx + AccordionTopicList cross-tab push fix. (Workflow-development drafts #179/#184/#185 ran this PR's input; all to be closed unmerged.)

**Cluster**: C3 — Mobile navigation safety nets
**Phases**: P1+P2
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1**: MOBILE-1 1a / MOBILE-2 F5 — Add unstable_settings to quiz layout (commit `93fb115c`)
- **P2**: MOBILE-1 F2 — AccordionTopicList cross-tab push parent chain (commit `c9480347`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | All 6 projects pass (mobile ran fresh, 5 from cache) |
| Lint | PASS | 0 errors, 324 warnings (all pre-existing grandfathered `gov/no-internal-jest-mock` sites — not touched by this PR) |
| Tests | PASS | 211 tests passed, 14 suites — AccordionTopicList + quiz layout + quiz/play |
| Phase verifications | PASS | Both P1 and P2 typecheck passes confirmed |
| GC1 ratchet | PASS | No new internal `jest.mock()` calls introduced |

## Review Summary

**Verdict**: REQUEST_CHANGES
**Findings**: 0C / 1H / 1M / 0L

---
Generated by Archon workflow `execute-cleanup-pr`
