### PR TITLE
refactor: Cleanup PR-02 — Delete dead coachingCardCelebrationResponseSchema export from progress.ts (zero consumers; route wraps + rename already shipped upstream).

### DIFF
--- a/packages/schemas/src/progress.ts
+++ b/packages/schemas/src/progress.ts
@@ -355,13 +355,6 @@ export const pendingNoticeSchema = z.object({
 });
 export type PendingNotice = z.infer<typeof pendingNoticeSchema>;
 
-export const coachingCardCelebrationResponseSchema = z.object({
-  pendingCelebrations: z.array(pendingCelebrationSchema),
-});
-export type CoachingCardCelebrationResponse = z.infer<
-  typeof coachingCardCelebrationResponseSchema
->;
-
 // Dashboard data — parent view wrapper
 
 export const dashboardDataSchema = z.object({


### PR DESCRIPTION
## Summary

Cleanup PR-02: Delete dead coachingCardCelebrationResponseSchema export from progress.ts (zero consumers; route wraps + rename already shipped upstream).

**Cluster**: C1 — Schema contract enforcement
**Phases**: P3
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P3**: Delete dead coachingCardCelebrationResponseSchema export (commit `ff9c1a47`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | All 6 projects clean (5 from cache, 1 fresh run) |
| Lint | PASS | 0 errors; 324 warnings are pre-existing grandfathered `gov/no-internal-jest-mock` sites |
| Tests | PASS | `packages/schemas/src/progress.test.ts` — 11/11 passed. Broader `--findRelatedTests` failures (23 suites) are pre-existing and unrelated to the deleted symbol (confirmed: same failures present on base before this commit). DoD grep `rg 'coachingCardCelebrationResponseSchema' packages apps` → zero hits. |
| Phase verifications | PASS | `rg 'coachingCardCelebrationResponseSchema' packages apps` returns zero hits; `api:typecheck` passes |
| GC1 ratchet | PASS | No new internal `jest.mock()` calls introduced |

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 0M / 0L

---
Generated by Archon workflow `execute-cleanup-pr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed exported schema and type definitions for coaching card celebration responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/198)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->