### PR TITLE
refactor: Cleanup PR-07 — Drain 5 Inngest mock allowlist offenders + shared tests/integration/mocks.ts setup. ~~Blocked on PR-05.~~ **Unblocked** — GC1 ratchet (#171) prevents regression during/after drain.

### DIFF
--- a/tests/integration/account-deletion.integration.test.ts
+++ b/tests/integration/account-deletion.integration.test.ts
@@ -6,7 +6,7 @@
  *
  * Mocked boundaries:
  * - JWT verification (Clerk JWKS) — intercepted via global fetch mock in setup.ts
- * - Inngest transport (external event dispatch — asserted but not delivered)
+ * - Inngest event HTTP API — intercepted via global fetch mock
  *
  * Validates:
  * 1. POST /account/delete returns 200 with gracePeriodEnds
@@ -34,25 +34,9 @@ import {
   createIntegrationDb,
 } from './helpers';
 import { buildAuthHeaders } from './test-keys';
+import { getCapturedInngestEvents, mockInngestEvents } from './mocks';
+import { clearFetchCalls } from './fetch-interceptor';
 import { executeDeletion } from '../../apps/api/src/services/deletion';
-
-// --- Inngest transport mock (external boundary) ---
-const mockInngestSend = jest.fn().mockResolvedValue({ ids: [] });
-const mockInngestCreateFunction = jest.fn().mockImplementation((config) => {
-  const id = config?.id ?? 'mock-inngest-function';
-  const fn = jest.fn();
-  (fn as { getConfig: () => unknown[] }).getConfig = () => [
-    { id, name: id, triggers: [], steps: {} },
-  ];
-  return fn;
-});
-
-jest.mock('../../apps/api/src/inngest/client', () => ({
-  inngest: {
-    send: mockInngestSend,
-    createFunction: mockInngestCreateFunction,
-  },
-}));
 
 import { app } from '../../apps/api/src/index';
 
@@ -60,6 +44,10 @@ const TEST_ENV = buildIntegrationEnv();
 
 const AUTH_USER_ID = 'integration-deletion-user';
 const AUTH_EMAIL = 'integration-deletion@integration.test';
+
+beforeAll(() => {
+  mockInngestEvents();
+});
 
 async function createOwnerProfile(): Promise<string> {
   const profile = await createOwnerProfileRecord();
@@ -80,7 +68,7 @@ async function createOwnerProfileRecord(): Promise<{
         birthYear: 2000,
       }),
     },
-    TEST_ENV
+    TEST_ENV,
   );
 
   expect(res.status).toBe(201);
@@ -101,6 +89,7 @@ async function createOwnerProfileRecord(): Promise<{
 
 beforeEach(async () => {
   jest.clearAllMocks();
+  clearFetchCalls();
   await cleanupAccounts({
     emails: [AUTH_EMAIL],
     clerkUserIds: [AUTH_USER_ID],
@@ -128,7 +117,7 @@ describe('Integration: POST /v1/account/delete (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -162,7 +151,7 @@ describe('Integration: POST /v1/account/delete (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     // After deletion: scheduledAt is set
@@ -181,29 +170,29 @@ describe('Integration: POST /v1/account/delete (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
-    expect(mockInngestSend).toHaveBeenCalledWith(
+    expect(getCapturedInngestEvents()).toEqual([
       expect.objectContaining({
         name: 'app/account.deletion-scheduled',
         data: expect.objectContaining({
           profileIds: expect.arrayContaining([profileId]),
           timestamp: expect.any(String),
         }),
-      })
-    );
+      }),
+    ]);
   });
 
   it('returns 401 without authentication', async () => {
     const res = await app.request(
       '/v1/account/delete',
       { method: 'POST' },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(401);
-    expect(mockInngestSend).not.toHaveBeenCalled();
+    expect(getCapturedInngestEvents()).toHaveLength(0);
   });
 });
 
@@ -222,7 +211,7 @@ describe('Integration: POST /v1/account/cancel-deletion (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     const res = await app.request(
@@ -231,7 +220,7 @@ describe('Integration: POST /v1/account/cancel-deletion (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -249,7 +238,7 @@ describe('Integration: POST /v1/account/cancel-deletion (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
     await app.request(
       '/v1/account/cancel-deletion',
@@ -257,7 +246,7 @@ describe('Integration: POST /v1/account/cancel-deletion (P0-004)', () => {
         method: 'POST',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     const db = createIntegrationDb();
@@ -268,7 +257,7 @@ describe('Integration: POST /v1/account/cancel-deletion (P0-004)', () => {
     expect(row!.deletionCancelledAt).not.toBeNull();
     // Cancelled timestamp should be after scheduled timestamp
     expect(row!.deletionCancelledAt!.getTime()).toBeGreaterThan(
-      row!.deletionScheduledAt!.getTime()
+      row!.deletionScheduledAt!.getTime(),
     );
   });
 
@@ -276,7 +265,7 @@ describe('Integration: POST /v1/account/cancel-deletion (P0-004)', () => {
     const res = await app.request(
       '/v1/account/cancel-deletion',
       { method: 'POST' },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(401);
@@ -297,7 +286,7 @@ describe('Integration: GET /v1/account/export', () => {
         method: 'GET',
         headers: buildAuthHeaders({ sub: AUTH_USER_ID, email: AUTH_EMAIL }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -306,7 +295,7 @@ describe('Integration: GET /v1/account/export', () => {
     expect(Array.isArray(body.profiles)).toBe(true);
     expect(body.profiles.length).toBeGreaterThanOrEqual(1);
     expect(body.profiles.some((p: { id: string }) => p.id === profileId)).toBe(
-      true
+      true,
     );
   });
 });
@@ -376,17 +365,17 @@ describe('Integration: account deletion cascade', () => {
     await executeDeletion(db, accountId);
 
     const summaries = await db.execute(
-      sql`SELECT count(*)::int AS c FROM session_summaries WHERE profile_id = ${profileId}`
+      sql`SELECT count(*)::int AS c FROM session_summaries WHERE profile_id = ${profileId}`,
     );
     expect((summaries.rows as Array<{ c: number }>)[0].c).toBe(0);
 
     const embeddings = await db.execute(
-      sql`SELECT count(*)::int AS c FROM session_embeddings WHERE profile_id = ${profileId}`
+      sql`SELECT count(*)::int AS c FROM session_embeddings WHERE profile_id = ${profileId}`,
     );
     expect((embeddings.rows as Array<{ c: number }>)[0].c).toBe(0);
 
     const events = await db.execute(
-      sql`SELECT count(*)::int AS c FROM session_events WHERE profile_id = ${profileId}`
+      sql`SELECT count(*)::int AS c FROM session_events WHERE profile_id = ${profileId}`,
     );
     expect((events.rows as Array<{ c: number }>)[0].c).toBe(0);
   });

--- a/tests/integration/consent-email.integration.test.ts
+++ b/tests/integration/consent-email.integration.test.ts
@@ -10,13 +10,12 @@
  * The consent request returned emailStatus: 'failed' and users could
  * not complete the parental consent flow.
  *
- * Mocked: Inngest, Resend HTTP (intercepted via global fetch interceptor)
+ * Mocked: Inngest event HTTP API, Resend HTTP (intercepted via global fetch interceptor)
  * Real:   JWT verification, Database, consent service, notification service plumbing
  */
 
 import { consentStates } from '@eduagent/database';
 import { eq } from 'drizzle-orm';
-import { inngestClientMock } from './mocks';
 import {
   buildIntegrationEnv,
   cleanupAccounts,
@@ -24,10 +23,8 @@ import {
 } from './helpers';
 import { buildAuthHeaders } from './test-keys';
 import { mockResendEmail } from './external-mocks';
+import { mockInngestEvents } from './mocks';
 import { getFetchCalls, clearFetchCalls } from './fetch-interceptor';
-
-// --- Mock boundaries ---
-jest.mock('../../apps/api/src/inngest/client', () => inngestClientMock());
 
 import { app } from '../../apps/api/src/index';
 
@@ -49,7 +46,7 @@ async function createChildProfile(): Promise<string> {
         birthYear: CHILD_BIRTH_YEAR,
       }),
     },
-    buildIntegrationEnv()
+    buildIntegrationEnv(),
   );
 
   expect(res.status).toBe(201);
@@ -62,6 +59,7 @@ describe('Integration: Consent email delivery', () => {
   let childProfileId: string;
 
   beforeAll(async () => {
+    mockInngestEvents();
     mockResendEmail();
     await cleanupAccounts({
       emails: [CONSENT_EMAIL],
@@ -94,7 +92,7 @@ describe('Integration: Consent email delivery', () => {
         method: 'POST',
         headers: buildAuthHeaders(
           { sub: CONSENT_USER_ID, email: CONSENT_EMAIL },
-          childProfileId
+          childProfileId,
         ),
         body: JSON.stringify({
           childProfileId,
@@ -102,7 +100,7 @@ describe('Integration: Consent email delivery', () => {
           consentType: 'GDPR',
         }),
       },
-      env
+      env,
     );
 
     expect(res.status).toBe(201);
@@ -138,7 +136,7 @@ describe('Integration: Consent email delivery', () => {
         method: 'POST',
         headers: buildAuthHeaders(
           { sub: CONSENT_USER_ID, email: CONSENT_EMAIL },
-          childProfileId
+          childProfileId,
         ),
         body: JSON.stringify({
           childProfileId,
@@ -146,7 +144,7 @@ describe('Integration: Consent email delivery', () => {
           consentType: 'GDPR',
         }),
       },
-      env
+      env,
     );
 
     expect(res.status).toBe(201);

--- a/tests/integration/consent-email.integration.test.ts
+++ b/tests/integration/consent-email.integration.test.ts
@@ -23,7 +23,7 @@ import {
 } from './helpers';
 import { buildAuthHeaders } from './test-keys';
 import { mockResendEmail } from './external-mocks';
-import { mockInngestEvents } from './mocks';
+import { getCapturedInngestEvents, mockInngestEvents } from './mocks';
 import { getFetchCalls, clearFetchCalls } from './fetch-interceptor';
 
 import { app } from '../../apps/api/src/index';
@@ -118,6 +118,19 @@ describe('Integration: Consent email delivery', () => {
     expect(emailBody.to).toContain(PARENT_EMAIL);
     expect(emailBody.from).toBe('test@mentomate.test');
     expect(emailBody.subject).toContain('consent');
+
+    const inngestEvents = getCapturedInngestEvents();
+    expect(inngestEvents).toEqual([
+      expect.objectContaining({
+        name: 'app/consent.requested',
+        data: expect.objectContaining({
+          profileId: childProfileId,
+          consentType: 'GDPR',
+          timestamp: expect.any(String),
+        }),
+      }),
+    ]);
+    expect(inngestEvents[0].data).not.toHaveProperty('parentEmail');
   });
 
   it('returns emailStatus "failed" when RESEND_API_KEY is missing from env', async () => {

--- a/tests/integration/learning-session.integration.test.ts
+++ b/tests/integration/learning-session.integration.test.ts
@@ -6,7 +6,7 @@
  *
  * Mocked boundaries:
  * - JWT verification (Clerk JWKS — via fetch interceptor in setup.ts)
- * - Inngest transport bootstrapping / send
+ * - Inngest event HTTP API — via fetch interceptor
  * - LLM provider — via registerProvider (real routeAndCall dispatch, mock chat fn)
  */
 
@@ -32,6 +32,8 @@ import {
   createIntegrationDb,
 } from './helpers';
 import { buildAuthHeaders } from './test-keys';
+import { getCapturedInngestEvents, mockInngestEvents } from './mocks';
+import { clearFetchCalls } from './fetch-interceptor';
 import { registerProvider } from '../../apps/api/src/services/llm';
 
 // Controllable mock provider — overrides the default mock registered in setup.ts.
@@ -45,29 +47,13 @@ const mockChat = jest
       hasUnderstandingGaps: false,
       gapAreas: [],
       isAccepted: true,
-    })
+    }),
   );
-
-const mockInngestSend = jest.fn();
-const mockInngestCreateFunction = jest.fn().mockImplementation((config) => {
-  const id = config?.id ?? 'mock-inngest-function';
-  const fn = jest.fn();
-  (fn as { getConfig: () => unknown[] }).getConfig = () => [
-    { id, name: id, triggers: [], steps: {} },
-  ];
-  return fn;
-});
-
-jest.mock('../../apps/api/src/inngest/client', () => ({
-  inngest: {
-    send: mockInngestSend,
-    createFunction: mockInngestCreateFunction,
-  },
-}));
 
 // Register once — overrides setup.ts default so tests control the LLM response
 // without bypassing the real routeAndCall dispatch path.
 beforeAll(() => {
+  mockInngestEvents();
   registerProvider({
     id: 'gemini',
     chat: mockChat,
@@ -103,7 +89,7 @@ async function createOwnerProfile(): Promise<string> {
         birthYear: 2000,
       }),
     },
-    TEST_ENV
+    TEST_ENV,
   );
 
   expect(res.status).toBe(201);
@@ -123,7 +109,7 @@ async function seedSubject(
   overrides: Partial<{
     name: string;
     status: 'active' | 'paused' | 'archived';
-  }> = {}
+  }> = {},
 ) {
   const db = createIntegrationDb();
   const [subject] = await db
@@ -141,7 +127,7 @@ async function seedSubject(
 
 async function seedCurriculum(
   subjectId: string,
-  topicTitles: string[] = ['Photosynthesis']
+  topicTitles: string[] = ['Photosynthesis'],
 ) {
   const db = createIntegrationDb();
   const [curriculum] = await db
@@ -167,7 +153,7 @@ async function seedCurriculum(
         description: `${title} description`,
         sortOrder: index + 1,
         estimatedMinutes: 15,
-      }))
+      })),
     )
     .returning();
 
@@ -187,14 +173,14 @@ async function seedRetentionCards(profileId: string, topicIds: string[]) {
       intervalDays: 3,
       nextReviewAt: new Date(Date.now() - (index + 1) * 60 * 60 * 1000),
       consecutiveSuccesses: index + 1,
-    }))
+    })),
   );
 }
 
 async function startSession(
   profileId: string,
   subjectId: string,
-  input?: Record<string, unknown>
+  input?: Record<string, unknown>,
 ) {
   const res = await app.request(
     `/v1/subjects/${subjectId}/sessions`,
@@ -202,14 +188,14 @@ async function startSession(
       method: 'POST',
       headers: buildAuthHeaders(
         { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-        profileId
+        profileId,
       ),
       body: JSON.stringify({
         subjectId,
         ...(input ?? {}),
       }),
     },
-    TEST_ENV
+    TEST_ENV,
   );
 
   expect(res.status).toBe(201);
@@ -267,8 +253,7 @@ async function loadSubscriptionAndQuota() {
 }
 
 beforeEach(async () => {
-  mockInngestSend.mockReset();
-  mockInngestSend.mockResolvedValue({ ids: [] });
+  clearFetchCalls();
   await cleanupAccounts({
     emails: [AUTH_EMAIL],
     clerkUserIds: [AUTH_USER_ID],
@@ -294,11 +279,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({ subjectId: subject.id }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(201);
@@ -325,11 +310,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({ subjectId: subject.id }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(403);
@@ -345,7 +330,7 @@ describe('Integration: Learning Session Lifecycle', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ subjectId: UNKNOWN_ID }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(401);
@@ -364,10 +349,10 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'GET',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -386,10 +371,10 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'GET',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(404);
@@ -410,11 +395,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({ message: 'What is photosynthesis?' }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -431,12 +416,16 @@ describe('Integration: Learning Session Lifecycle', () => {
       const quota = await loadSubscriptionAndQuota();
       expect(quota.subscription.id).toBe(before.subscription.id);
       expect(quota.quotaPool.usedThisMonth).toBe(
-        before.quotaPool.usedThisMonth + 1
+        before.quotaPool.usedThisMonth + 1,
       );
 
       const events = await loadSessionEvents(session.id);
       expect(events.map((event) => event.eventType)).toEqual(
-        expect.arrayContaining(['session_start', 'user_message', 'ai_response'])
+        expect.arrayContaining([
+          'session_start',
+          'user_message',
+          'ai_response',
+        ]),
       );
     });
 
@@ -451,11 +440,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({}),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(400);
@@ -474,11 +463,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({ message: 'Explain gravity' }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -496,7 +485,11 @@ describe('Integration: Learning Session Lifecycle', () => {
 
       const events = await loadSessionEvents(session.id);
       expect(events.map((event) => event.eventType)).toEqual(
-        expect.arrayContaining(['session_start', 'user_message', 'ai_response'])
+        expect.arrayContaining([
+          'session_start',
+          'user_message',
+          'ai_response',
+        ]),
       );
     });
   });
@@ -513,11 +506,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({}),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -525,7 +518,7 @@ describe('Integration: Learning Session Lifecycle', () => {
       expect(body.sessionId).toBe(session.id);
       expect(body.summaryStatus).toBe('pending');
       expect(body.wallClockSeconds).toBeDefined();
-      expect(mockInngestSend).not.toHaveBeenCalled();
+      expect(getCapturedInngestEvents()).toHaveLength(0);
 
       const persistedSession = await loadSession(session.id);
       expect(persistedSession!.status).toBe('completed');
@@ -540,10 +533,10 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'GET',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(summaryRes.status).toBe(200);
@@ -564,11 +557,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({}),
         },
-        TEST_ENV
+        TEST_ENV,
       );
       expect(closeRes.status).toBe(200);
 
@@ -578,14 +571,14 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({
             content:
               'I learned that plants use sunlight to turn water and carbon dioxide into food.',
           }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -599,7 +592,7 @@ describe('Integration: Learning Session Lifecycle', () => {
       expect(summary!.status).toBe('accepted');
       expect(summary!.content).toContain('sunlight');
 
-      expect(mockInngestSend).toHaveBeenCalledWith(
+      expect(getCapturedInngestEvents()).toEqual([
         expect.objectContaining({
           name: 'app/session.completed',
           data: expect.objectContaining({
@@ -610,8 +603,8 @@ describe('Integration: Learning Session Lifecycle', () => {
             qualityRating: 4,
             summaryTrackingHandled: true,
           }),
-        })
-      );
+        }),
+      ]);
     });
   });
 
@@ -627,14 +620,14 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({
             eventId: FLAG_EVENT_ID,
             reason: 'Incorrect information',
           }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -661,7 +654,7 @@ describe('Integration: Learning Session Lifecycle', () => {
       ]);
       await seedRetentionCards(
         profileId,
-        topics.map((topic) => topic.id)
+        topics.map((topic) => topic.id),
       );
 
       const res = await app.request(
@@ -670,11 +663,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({ subjectId: subject.id, topicCount: 2 }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(201);
@@ -682,7 +675,7 @@ describe('Integration: Learning Session Lifecycle', () => {
       expect(body.sessionId).toEqual(expect.any(String));
       expect(body.topics).toHaveLength(2);
       expect(
-        body.topics.map((topic: { topicId: string }) => topic.topicId)
+        body.topics.map((topic: { topicId: string }) => topic.topicId),
       ).toEqual(expect.arrayContaining(topics.map((topic) => topic.id)));
 
       const session = await loadSession(body.sessionId);
@@ -694,8 +687,8 @@ describe('Integration: Learning Session Lifecycle', () => {
             expect.objectContaining({
               topicId: topic.id,
               subjectId: subject.id,
-            })
-          )
+            }),
+          ),
         ),
       });
     });
@@ -711,11 +704,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({ subjectId: subject.id }),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(400);
@@ -740,11 +733,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({}),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(200);
@@ -765,11 +758,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({}),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(400);
@@ -786,11 +779,11 @@ describe('Integration: Learning Session Lifecycle', () => {
           method: 'POST',
           headers: buildAuthHeaders(
             { sub: AUTH_USER_ID, email: AUTH_EMAIL },
-            profileId
+            profileId,
           ),
           body: JSON.stringify({}),
         },
-        TEST_ENV
+        TEST_ENV,
       );
 
       expect(res.status).toBe(404);

--- a/tests/integration/mocks.ts
+++ b/tests/integration/mocks.ts
@@ -1,45 +1,86 @@
 /**
- * Inngest client mock for integration tests.
+ * Shared integration-test HTTP boundary stubs.
  *
- * INTENTIONALLY mocks an internal module. Unlike other internal mocks
- * (which have been migrated to fetch interceptors), this prevents real
- * Inngest event dispatch during tests. The alternative — letting events
- * dispatch to a real/dev Inngest server — would make tests flaky and
- * environment-dependent.
- *
- * The Inngest functions themselves are tested directly (session-completed,
- * trial-expiry, etc.) by calling the handler with a mock step runner.
- *
- * Usage:
- *   import { inngestClientMock } from './mocks';
- *   jest.mock('../../apps/api/src/inngest/client', () => inngestClientMock());
+ * Keep app modules real here. These helpers register fetch-interceptor
+ * handlers for external transports that the app reaches through HTTP.
  */
 
-/**
- * Mock `../../apps/api/src/inngest/client`.
- *
- * The `inngest.createFunction()` call happens at import time for every Inngest
- * function module. The `serve()` handler calls `fn.getConfig()` during setup.
- * This factory satisfies both requirements.
- *
- * @param sendMock - Optional pre-created jest.fn() for `inngest.send` (useful
- *   when tests need to assert on sent events).
- */
-export function inngestClientMock(sendMock?: jest.Mock): {
-  inngest: Record<string, jest.Mock>;
-} {
-  let fnCounter = 0;
+import {
+  addFetchHandler,
+  getFetchCalls,
+  jsonResponse,
+  type FetchHandler,
+} from './fetch-interceptor';
+
+export interface MockHandle {
+  /**
+   * Override the response for the next matching fetch call only.
+   * After one use, reverts to the default response.
+   */
+  nextResponse: (responseFn: () => Response) => void;
+  /**
+   * Replace the default response factory permanently (until changed again).
+   *
+   * Accepts a factory function because Response bodies are single-use.
+   */
+  setDefault: (responseFn: () => Response) => void;
+}
+
+export interface CapturedInngestEvent {
+  name: string;
+  data?: Record<string, unknown>;
+  id?: string;
+  ts?: number;
+}
+
+function createMockHandle(
+  pattern: string | RegExp,
+  defaultResponseFn: () => Response,
+): MockHandle {
+  let oneShot: (() => Response) | null = null;
+  let customDefault: (() => Response) | null = null;
+
+  const handler: FetchHandler = () => {
+    if (oneShot) {
+      const factory = oneShot;
+      oneShot = null;
+      return factory();
+    }
+    return customDefault ? customDefault() : defaultResponseFn();
+  };
+
+  addFetchHandler(pattern, handler);
+
   return {
-    inngest: {
-      send: sendMock ?? jest.fn().mockResolvedValue({ ids: [] }),
-      createFunction: jest.fn().mockImplementation((config) => {
-        const id = config?.id ?? `mock-fn-${fnCounter++}`;
-        const fn = jest.fn();
-        (fn as any).getConfig = () => [
-          { id, name: id, triggers: [], steps: {} },
-        ];
-        return fn;
-      }),
+    nextResponse: (responseFn: () => Response) => {
+      oneShot = responseFn;
+    },
+    setDefault: (responseFn: () => Response) => {
+      customDefault = responseFn;
     },
   };
+}
+
+/**
+ * Intercepts the real Inngest client's event transport.
+ *
+ * The application imports and uses the real `inngest` client. This handler
+ * stubs only the outbound Inngest HTTP event API so integration tests can
+ * assert on dispatched payloads without mocking the internal client module.
+ */
+export function mockInngestEvents(): MockHandle {
+  return createMockHandle('inn.gs/e/', () =>
+    jsonResponse({ ids: ['mock-inngest-event-id'], status: 200 }),
+  );
+}
+
+export function getCapturedInngestEvents(): CapturedInngestEvent[] {
+  return getFetchCalls('inn.gs/e/').flatMap((call) => {
+    if (!call.body) {
+      return [];
+    }
+
+    const body = JSON.parse(call.body) as CapturedInngestEvent[];
+    return Array.isArray(body) ? body : [body];
+  });
 }

--- a/tests/integration/sessions-routes.integration.test.ts
+++ b/tests/integration/sessions-routes.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration: Sessions routes — security break tests
  *
  * Exercises the real session routes through the full app + real database.
- * JWT verification and Inngest are the only mocked boundaries.
+ * JWT verification uses the global fetch mock; Inngest uses a HTTP-boundary stub.
  *
  * C5 break test: PATCH /v1/sessions/:sessionId/clear-continuation-depth
  * must return 404 when the sessionId belongs to a different profile.
@@ -14,6 +14,7 @@ import { eq } from 'drizzle-orm';
 import { learningSessions } from '@eduagent/database';
 
 import { buildIntegrationEnv, cleanupAccounts } from './helpers';
+import { mockInngestEvents } from './mocks';
 import {
   buildAuthHeaders,
   createProfileViaRoute,
@@ -34,22 +35,9 @@ const USER_B = {
   email: 'integration-sessions-b@integration.test',
 };
 
-// jest.mock is hoisted; capture the send spy via module.__esModule access
-// rather than a closure to avoid TDZ. Tests that need to assert on send
-// can import the mocked module directly.
-jest.mock('../../apps/api/src/inngest/client', () => ({ // gc1-allow: Inngest is an external async boundary for this route integration break test; DB and route code remain real.
-  inngest: {
-    send: jest.fn(),
-    createFunction: jest.fn().mockImplementation((config: { id?: string }) => {
-      const id = config?.id ?? 'mock-inngest-function';
-      const fn = jest.fn();
-      (fn as unknown as { getConfig: () => unknown[] }).getConfig = () => [
-        { id, name: id, triggers: [], steps: {} },
-      ];
-      return fn;
-    }),
-  },
-}));
+beforeAll(() => {
+  mockInngestEvents();
+});
 
 beforeEach(async () => {
   jest.clearAllMocks();
@@ -105,10 +93,10 @@ describe('PATCH /v1/sessions/:sessionId/clear-continuation-depth', () => {
         method: 'PATCH',
         headers: buildAuthHeaders(
           { sub: USER_A.userId, email: USER_A.email },
-          profileA.id
+          profileA.id,
         ),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(404);

--- a/tests/integration/stripe-webhook.integration.test.ts
+++ b/tests/integration/stripe-webhook.integration.test.ts
@@ -6,7 +6,7 @@
  *
  * Mocked boundaries:
  * - Stripe signature verification
- * - Inngest transport bootstrapping / send
+ * - Inngest event HTTP API — via fetch interceptor
  */
 
 import { eq } from 'drizzle-orm';
@@ -17,27 +17,13 @@ import {
   cleanupAccounts,
   createIntegrationDb,
 } from './helpers';
+import { getCapturedInngestEvents, mockInngestEvents } from './mocks';
+import { clearFetchCalls } from './fetch-interceptor';
 
 const mockVerifyWebhookSignature = jest.fn();
-const mockInngestSend = jest.fn();
-const mockInngestCreateFunction = jest.fn().mockImplementation((config) => {
-  const id = config?.id ?? 'mock-inngest-function';
-  const fn = jest.fn();
-  (fn as { getConfig: () => unknown[] }).getConfig = () => [
-    { id, name: id, triggers: [], steps: {} },
-  ];
-  return fn;
-});
 
 jest.mock('../../apps/api/src/services/stripe', () => ({
   verifyWebhookSignature: mockVerifyWebhookSignature,
-}));
-
-jest.mock('../../apps/api/src/inngest/client', () => ({
-  inngest: {
-    send: mockInngestSend,
-    createFunction: mockInngestCreateFunction,
-  },
 }));
 
 import { app } from '../../apps/api/src/index';
@@ -59,6 +45,10 @@ const TEST_ENV = {
 const seededEmails = new Set<string>();
 const seededClerkUserIds = new Set<string>();
 let seedCounter = 0;
+
+beforeAll(() => {
+  mockInngestEvents();
+});
 
 function nextSeed(prefix: string) {
   seedCounter += 1;
@@ -139,8 +129,8 @@ async function seedSubscriptionState(input: {
         input.lastStripeEventTimestamp === undefined
           ? null
           : input.lastStripeEventTimestamp
-          ? new Date(input.lastStripeEventTimestamp)
-          : null,
+            ? new Date(input.lastStripeEventTimestamp)
+            : null,
     })
     .returning();
 
@@ -167,7 +157,7 @@ async function seedSubscriptionState(input: {
 function buildStripeEvent(
   type: string,
   dataObject: Record<string, unknown>,
-  overrides?: { created?: number }
+  overrides?: { created?: number },
 ) {
   return {
     id: `evt_${type.replace(/\W+/g, '_')}_${Date.now()}`,
@@ -223,8 +213,7 @@ function readKvPayload() {
 
 beforeEach(async () => {
   mockVerifyWebhookSignature.mockReset();
-  mockInngestSend.mockReset();
-  mockInngestSend.mockResolvedValue({ ids: [] });
+  clearFetchCalls();
   mockKvPut.mockClear();
   mockKvGet.mockClear();
   await cleanupSeededAccounts();
@@ -243,7 +232,7 @@ describe('Integration: Stripe Webhook guards', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(400);
@@ -256,7 +245,7 @@ describe('Integration: Stripe Webhook guards', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest({}),
-      buildIntegrationEnv()
+      buildIntegrationEnv(),
     );
 
     expect(res.status).toBe(500);
@@ -266,13 +255,13 @@ describe('Integration: Stripe Webhook guards', () => {
 
   it('returns 400 when webhook signature verification fails', async () => {
     mockVerifyWebhookSignature.mockRejectedValueOnce(
-      new Error('Invalid signature')
+      new Error('Invalid signature'),
     );
 
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest({ invalid: true }),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(400);
@@ -291,7 +280,7 @@ describe('Integration: Stripe Webhook guards', () => {
           data: [{ current_period_start: 1700000000, current_period_end: 1 }],
         },
       },
-      { created: Math.floor(Date.now() / 1000) - 49 * 60 * 60 }
+      { created: Math.floor(Date.now() / 1000) - 49 * 60 * 60 },
     );
 
     mockVerifyWebhookSignature.mockResolvedValueOnce(staleEvent);
@@ -299,7 +288,7 @@ describe('Integration: Stripe Webhook guards', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest(staleEvent),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(400);
@@ -311,9 +300,8 @@ describe('Integration: Stripe Webhook guards', () => {
 
 describe('Integration: Stripe Webhook event handling', () => {
   it('checkout.session.completed creates and activates a paid subscription', async () => {
-    const { account, stripeSubscriptionId } = await seedAccount(
-      'stripe-checkout'
-    );
+    const { account, stripeSubscriptionId } =
+      await seedAccount('stripe-checkout');
 
     const event = buildStripeEvent('checkout.session.completed', {
       id: 'cs_checkout_completed',
@@ -326,7 +314,7 @@ describe('Integration: Stripe Webhook event handling', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest(event),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -388,7 +376,7 @@ describe('Integration: Stripe Webhook event handling', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest(event),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -398,10 +386,10 @@ describe('Integration: Stripe Webhook event handling', () => {
     expect(updatedSubscription!.tier).toBe('family');
     expect(updatedSubscription!.status).toBe('active');
     expect(updatedSubscription!.currentPeriodStart?.toISOString()).toBe(
-      new Date(periodStart * 1000).toISOString()
+      new Date(periodStart * 1000).toISOString(),
     );
     expect(updatedSubscription!.currentPeriodEnd?.toISOString()).toBe(
-      new Date(periodEnd * 1000).toISOString()
+      new Date(periodEnd * 1000).toISOString(),
     );
 
     const quotaPool = await loadQuotaPool(subscription.id);
@@ -444,7 +432,7 @@ describe('Integration: Stripe Webhook event handling', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest(event),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -497,7 +485,7 @@ describe('Integration: Stripe Webhook event handling', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest(event),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
@@ -515,7 +503,7 @@ describe('Integration: Stripe Webhook event handling', () => {
       usedThisMonth: 5,
     });
 
-    expect(mockInngestSend).toHaveBeenCalledWith(
+    expect(getCapturedInngestEvents()).toEqual([
       expect.objectContaining({
         name: 'app/payment.failed',
         data: expect.objectContaining({
@@ -524,8 +512,8 @@ describe('Integration: Stripe Webhook event handling', () => {
           accountId: account.id,
           attempt: 2,
         }),
-      })
-    );
+      }),
+    ]);
   });
 
   it('invoice.payment_succeeded restores the subscription to active', async () => {
@@ -550,7 +538,7 @@ describe('Integration: Stripe Webhook event handling', () => {
     const res = await app.request(
       '/v1/stripe/webhook',
       buildWebhookRequest(event),
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

Cleanup PR-07: Drain 5 Inngest mock allowlist offenders + shared tests/integration/mocks.ts setup. ~~Blocked on PR-05.~~ **Unblocked** — GC1 ratchet (#171) prevents regression during/after drain.

**Cluster**: C2 — Test integration boundary
**Phases**: P4
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P4**: Drain inngest allowlist (commit `c2b16f36`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | `pnpm exec nx run-many -t typecheck` passed for 6 projects. |
| Lint | PASS | `pnpm exec nx run-many -t lint` passed for 6 projects; existing warnings remain. |
| Tests | PASS | Related integration tests passed under Doppler dev: 37 tests, 5 suites. |
| Phase verifications | PASS | 6 per-file `--findRelatedTests` verification runs passed; GC1 ratchet passed. |

## Review Summary

**Verdict**: REQUEST_CHANGES
**Findings**: 0C / 1H / 3M / 3L

---
Generated by Archon workflow `execute-cleanup-pr`
