### PR TITLE
refactor: Cleanup PR-06 — Drain 2 remaining LLM mock allowlist offenders (~7-10 hr).

### DIFF
--- a/apps/api/src/services/llm/integration-mock-guard.test.ts
+++ b/apps/api/src/services/llm/integration-mock-guard.test.ts
@@ -9,17 +9,11 @@ import { resolve } from 'node:path';
 // prompt drift, envelope contract drift, and shape-of-response bugs.
 //
 // This guard fails if ANY new *.integration.test.ts file adds a jest.mock for
-// the internal LLM router (`./llm`, `../llm`, `services/llm`). Two pre-
-// existing offenders are listed in KNOWN_OFFENDERS pending migration to
-// HTTP-boundary mocking (see weekly-progress-push.integration.test.ts for
-// the right pattern — intercept globalThis.fetch instead).
+// the internal LLM router (`./llm`, `../llm`, `services/llm`). The right
+// pattern is to intercept globalThis.fetch for HTTP SDKs, or register a
+// provider in the LLM provider registry when the service boundary is the router.
 
-const KNOWN_OFFENDERS = new Set<string>([
-  // BUG-743 follow-up: migrate to HTTP-boundary mocking (see Expo Push pattern
-  // in src/inngest/functions/weekly-progress-push.integration.test.ts).
-  'apps/api/src/services/session-summary.integration.test.ts',
-  'apps/api/src/services/quiz/vocabulary.integration.test.ts',
-]);
+const KNOWN_OFFENDERS = new Set<string>();
 
 function listIntegrationTests(): string[] {
   const repoRoot = resolve(__dirname, '../../../../..');
@@ -62,12 +56,12 @@ describe('integration tests — BUG-743 internal LLM mock guard', () => {
 
   it('does not introduce NEW jest.mock(...llm) calls outside the known offender allowlist', () => {
     const offenders = files.filter((f) =>
-      fileMocksInternalLlm(resolve(repoRoot, f))
+      fileMocksInternalLlm(resolve(repoRoot, f)),
     );
     // Normalize separators so the test passes on Windows + POSIX.
     const offendersNormalized = offenders.map((f) => f.replace(/\\/g, '/'));
     const newOffenders = offendersNormalized.filter(
-      (f) => !KNOWN_OFFENDERS.has(f)
+      (f) => !KNOWN_OFFENDERS.has(f),
     );
     if (newOffenders.length > 0) {
       throw new Error(
@@ -76,7 +70,7 @@ describe('integration tests — BUG-743 internal LLM mock guard', () => {
           `\n\nIntegration tests must mock at the HTTP boundary (intercept ` +
           `globalThis.fetch for provider URLs) — not jest.mock internal ` +
           `services. See weekly-progress-push.integration.test.ts for the ` +
-          `right pattern.`
+          `right pattern.`,
       );
     }
   });
@@ -88,7 +82,7 @@ describe('integration tests — BUG-743 internal LLM mock guard', () => {
     const stillOffending = Array.from(KNOWN_OFFENDERS).filter((f) =>
       files.some((g) => g.replace(/\\/g, '/') === f)
         ? fileMocksInternalLlm(resolve(repoRoot, f))
-        : false
+        : false,
     );
     expect(stillOffending.sort()).toEqual(Array.from(KNOWN_OFFENDERS).sort());
   });

--- a/apps/api/src/services/quiz/vocabulary.integration.test.ts
+++ b/apps/api/src/services/quiz/vocabulary.integration.test.ts
@@ -1,10 +1,3 @@
-// EXTERNAL boundary mock — routeAndCall is the LLM provider HTTP call. Per C1 D-MOCK-1 this is the formalized LLM external boundary.
-const mockRouteAndCall = jest.fn();
-jest.mock('../llm', () => ({
-  ...(jest.requireActual('../llm') as Record<string, unknown>),
-  routeAndCall: (...args: unknown[]) => mockRouteAndCall(...args),
-}));
-
 import { and, eq, inArray } from 'drizzle-orm';
 import {
   accounts,
@@ -24,6 +17,8 @@ import { completeQuizRound } from './complete-round';
 import { generateQuizRound } from './generate-round';
 import { getVocabularyRoundContext } from './queries';
 import { QUIZ_CONFIG } from './config';
+import type { ChatMessage, LLMProvider, ModelConfig } from '../llm';
+import { _clearProviders, _resetCircuits, registerProvider } from '../llm';
 
 // [CR-758] Single source of truth for the expected vocabulary round size.
 // Previously the test asserted `toHaveLength(6)` and `total).toBe(6)` with
@@ -35,11 +30,30 @@ const VOCAB_ROUND_SIZE = QUIZ_CONFIG.perActivity.vocabulary.roundSize;
 
 loadDatabaseEnv(resolve(__dirname, '../../../../..'));
 
+let llmResponse = '';
+const llmProviderCalls: Array<{
+  messages: ChatMessage[];
+  config: ModelConfig;
+}> = [];
+
+function createVocabularyProvider(): LLMProvider {
+  return {
+    id: 'gemini',
+    async chat(messages, config) {
+      llmProviderCalls.push({ messages, config });
+      return { content: llmResponse, stopReason: 'stop' };
+    },
+    chatStream() {
+      throw new Error('vocabulary integration test does not stream');
+    },
+  };
+}
+
 function requireDatabaseUrl(): string {
   const url = process.env.DATABASE_URL;
   if (!url) {
     throw new Error(
-      'DATABASE_URL is not set. Create .env.test.local or .env.development.local.'
+      'DATABASE_URL is not set. Create .env.test.local or .env.development.local.',
     );
   }
   return url;
@@ -65,8 +79,8 @@ async function cleanupTestAccounts() {
     await db.delete(accounts).where(
       inArray(
         accounts.id,
-        rows.map((row) => row.id)
-      )
+        rows.map((row) => row.id),
+      ),
     );
   }
 }
@@ -183,12 +197,17 @@ beforeEach(async () => {
   // in CI's PostgreSQL service container. The SM-2 assertions use the
   // same sm2() function as the production code, so both sides compute
   // from the same real Date and the assertions still match.
-  jest.clearAllMocks();
+  llmProviderCalls.length = 0;
+  _clearProviders();
+  _resetCircuits();
+  registerProvider(createVocabularyProvider());
   await cleanupTestAccounts();
 });
 
 afterAll(async () => {
   await cleanupTestAccounts();
+  _clearProviders();
+  _resetCircuits();
 });
 
 describe('vocabulary quiz round lifecycle (integration)', () => {
@@ -198,40 +217,35 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
     const { db, profile, subject } = await seedProfileAndSubject();
     await seedVocabularyBank(profile.id, subject.id);
 
-    mockRouteAndCall.mockResolvedValue({
-      response: JSON.stringify({
-        theme: 'German Animals',
-        targetLanguage: 'German',
-        questions: [
-          {
-            term: 'das Schwein',
-            correctAnswer: 'pig',
-            acceptedAnswers: ['pig'],
-            distractors: ['dog', 'cat', 'bird'],
-            funFact: 'Schwein also appears in some lucky sayings.',
-            cefrLevel: 'A1',
-          },
-          {
-            term: 'der Bär',
-            correctAnswer: 'bear',
-            acceptedAnswers: ['bear'],
-            distractors: ['horse', 'cow', 'fish'],
-            funFact: 'Bär is common in fairy tales.',
-            cefrLevel: 'A2',
-          },
-          {
-            term: 'der Frosch',
-            correctAnswer: 'frog',
-            acceptedAnswers: ['frog'],
-            distractors: ['duck', 'rabbit', 'mouse'],
-            funFact: 'Frosch shows up in many beginner stories.',
-            cefrLevel: 'A1',
-          },
-        ],
-      }),
-      provider: 'mock',
-      model: 'mock',
-      latencyMs: 25,
+    llmResponse = JSON.stringify({
+      theme: 'German Animals',
+      targetLanguage: 'German',
+      questions: [
+        {
+          term: 'das Schwein',
+          correctAnswer: 'pig',
+          acceptedAnswers: ['pig'],
+          distractors: ['dog', 'cat', 'bird'],
+          funFact: 'Schwein also appears in some lucky sayings.',
+          cefrLevel: 'A1',
+        },
+        {
+          term: 'der Bär',
+          correctAnswer: 'bear',
+          acceptedAnswers: ['bear'],
+          distractors: ['horse', 'cow', 'fish'],
+          funFact: 'Bär is common in fairy tales.',
+          cefrLevel: 'A2',
+        },
+        {
+          term: 'der Frosch',
+          correctAnswer: 'frog',
+          acceptedAnswers: ['frog'],
+          distractors: ['duck', 'rabbit', 'mouse'],
+          funFact: 'Frosch shows up in many beginner stories.',
+          cefrLevel: 'A1',
+        },
+      ],
     });
 
     const context = await getVocabularyRoundContext(db, profile.id, subject.id);
@@ -258,8 +272,8 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
     // bare stub, the real prompt builder no longer runs, and these
     // content/shape assertions fail. A simple `toHaveBeenCalledTimes(1)`
     // would pass even with a full barrel mock — these don't.
-    expect(mockRouteAndCall).toHaveBeenCalledTimes(1);
-    expect(mockRouteAndCall).toHaveBeenCalledWith(
+    expect(llmProviderCalls).toHaveLength(1);
+    expect(llmProviderCalls[0]?.messages).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           role: 'system',
@@ -270,30 +284,28 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
           content: 'Generate the quiz round.',
         }),
       ]),
-      1,
-      expect.objectContaining({ ageBracket: expect.any(String) })
     );
-    const [systemPrompt] = mockRouteAndCall.mock.calls[0][0] as Array<{
+    const [systemPrompt] = llmProviderCalls[0]!.messages as Array<{
       role: string;
       content: string;
     }>;
     expect(systemPrompt.content).toContain(
-      `Maximum CEFR level: ${context.cefrCeiling}`
+      `Maximum CEFR level: ${context.cefrCeiling}`,
     );
     const masteryQuestions = round.questions.filter(
       (question): question is Extract<QuizQuestion, { type: 'vocabulary' }> =>
-        question.type === 'vocabulary' && question.isLibraryItem
+        question.type === 'vocabulary' && question.isLibraryItem,
     );
     expect(masteryQuestions).toHaveLength(3);
 
     const masteryIds = masteryQuestions.map(
-      (question) => question.vocabularyId!
+      (question) => question.vocabularyId!,
     );
     const beforeCards = await db.query.vocabularyRetentionCards.findMany({
       where: inArray(vocabularyRetentionCards.vocabularyId, masteryIds),
     });
     const beforeById = new Map(
-      beforeCards.map((card) => [card.vocabularyId, card] as const)
+      beforeCards.map((card) => [card.vocabularyId, card] as const),
     );
 
     let wrongDiscoveryRecorded = false;
@@ -331,7 +343,7 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
       db,
       profile.id,
       round.id,
-      results
+      results,
     );
     expect(completion.total).toBe(VOCAB_ROUND_SIZE);
 
@@ -363,17 +375,17 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
       // Date assertions use day-level precision — the production and test
       // sm2() calls run milliseconds apart, so exact ISO match is fragile.
       expect(card.lastReviewedAt?.toISOString().slice(0, 10)).toBe(
-        expected.card.lastReviewedAt.slice(0, 10)
+        expected.card.lastReviewedAt.slice(0, 10),
       );
       expect(card.nextReviewAt?.toISOString().slice(0, 10)).toBe(
-        expected.card.nextReviewAt.slice(0, 10)
+        expected.card.nextReviewAt.slice(0, 10),
       );
     }
 
     const storedRound = await db.query.quizRounds.findFirst({
       where: and(
         eq(quizRounds.id, round.id),
-        eq(quizRounds.profileId, profile.id)
+        eq(quizRounds.profileId, profile.id),
       ),
     });
     expect(storedRound?.status).toBe('completed');
@@ -383,7 +395,7 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
     });
     expect(missedItems.length).toBeGreaterThanOrEqual(1);
     expect(
-      missedItems.some((item) => item.questionText.startsWith('Translate: '))
+      missedItems.some((item) => item.questionText.startsWith('Translate: ')),
     ).toBe(true);
   }, 15_000);
 });

--- a/apps/api/src/services/quiz/vocabulary.integration.test.ts
+++ b/apps/api/src/services/quiz/vocabulary.integration.test.ts
@@ -285,10 +285,14 @@ describe('vocabulary quiz round lifecycle (integration)', () => {
         }),
       ]),
     );
+    expect(llmProviderCalls[0]!.config.model).toBe('gemini-2.5-flash');
     const [systemPrompt] = llmProviderCalls[0]!.messages as Array<{
       role: string;
       content: string;
     }>;
+    expect(systemPrompt.content).toContain(
+      'You are an educational AI assistant for young learners.',
+    );
     expect(systemPrompt.content).toContain(
       `Maximum CEFR level: ${context.cefrCeiling}`,
     );

--- a/apps/api/src/services/session-summary.integration.test.ts
+++ b/apps/api/src/services/session-summary.integration.test.ts
@@ -229,5 +229,26 @@ describe('session summary integration', () => {
     );
     expect(learningModeRow?.consecutiveSummarySkips).toBe(0);
     expect(llmProviderCalls).toHaveLength(1);
+    expect(llmProviderCalls[0]!.config.model).toBe('gemini-2.5-flash');
+    expect(llmProviderCalls[0]!.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'system',
+          content: expect.stringContaining('summary evaluator'),
+        }),
+        expect.objectContaining({
+          role: 'user',
+          content: expect.stringContaining(
+            '<topic_title>Science</topic_title>',
+          ),
+        }),
+      ]),
+    );
+    const userPrompt = llmProviderCalls[0]!.messages.find(
+      (message) => message.role === 'user',
+    )!.content;
+    expect(userPrompt).toContain(
+      '<learner_summary>Plants use sunlight, water, and carbon dioxide to make the food they need.</learner_summary>',
+    );
   });
 });

--- a/apps/api/src/services/session-summary.integration.test.ts
+++ b/apps/api/src/services/session-summary.integration.test.ts
@@ -11,17 +11,8 @@ import {
   type Database,
 } from '@eduagent/database';
 import { and, eq, like } from 'drizzle-orm';
-
-// EXTERNAL boundary mock — routeAndCall is the LLM provider HTTP call. Per C1 D-MOCK-1 this is the formalized LLM external boundary.
-const mockRouteAndCall = jest.fn();
-
-jest.mock('./llm', () => {
-  const actual = jest.requireActual('./llm') as Record<string, unknown>;
-  return {
-    ...actual,
-    routeAndCall: (...args: unknown[]) => mockRouteAndCall(...args),
-  };
-});
+import type { ChatMessage, LLMProvider, ModelConfig } from './llm';
+import { _clearProviders, _resetCircuits, registerProvider } from './llm';
 
 import {
   closeSession,
@@ -34,9 +25,27 @@ import {
 loadDatabaseEnv(resolve(__dirname, '../../../..'));
 
 let db: Database;
+let llmResponse = '';
+const llmProviderCalls: Array<{
+  messages: ChatMessage[];
+  config: ModelConfig;
+}> = [];
 
 const RUN_ID = generateUUIDv7();
 let seedCounter = 0;
+
+function createSessionSummaryProvider(): LLMProvider {
+  return {
+    id: 'gemini',
+    async chat(messages, config) {
+      llmProviderCalls.push({ messages, config });
+      return { content: llmResponse, stopReason: 'stop' };
+    },
+    chatStream() {
+      throw new Error('session summary integration test does not stream');
+    },
+  };
+}
 
 async function seedProfile(): Promise<{
   accountId: string;
@@ -82,25 +91,24 @@ beforeAll(async () => {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error(
-      'DATABASE_URL is not set for session summary integration tests'
+      'DATABASE_URL is not set for session summary integration tests',
     );
   }
 
   db = createDatabase(databaseUrl);
+  _clearProviders();
+  _resetCircuits();
+  registerProvider(createSessionSummaryProvider());
 });
 
 beforeEach(() => {
-  jest.clearAllMocks();
-  mockRouteAndCall.mockResolvedValue({
-    response: JSON.stringify({
-      feedback: 'Great summary! You captured the key idea.',
-      hasUnderstandingGaps: false,
-      gapAreas: [],
-      isAccepted: true,
-    }),
-    provider: 'mock',
-    model: 'mock',
-    latencyMs: 1,
+  llmProviderCalls.length = 0;
+  _resetCircuits();
+  llmResponse = JSON.stringify({
+    feedback: 'Great summary! You captured the key idea.',
+    hasUnderstandingGaps: false,
+    gapAreas: [],
+    isAccepted: true,
   });
 });
 
@@ -108,6 +116,8 @@ afterAll(async () => {
   await db
     .delete(accounts)
     .where(like(accounts.clerkUserId, `clerk_session_summary_${RUN_ID}%`));
+  _clearProviders();
+  _resetCircuits();
 });
 
 describe('session summary integration', () => {
@@ -195,7 +205,7 @@ describe('session summary integration', () => {
     const storedSummary = await db.query.sessionSummaries.findFirst({
       where: and(
         eq(sessionSummaries.sessionId, session.id),
-        eq(sessionSummaries.profileId, profileId)
+        eq(sessionSummaries.profileId, profileId),
       ),
     });
     const learningModeRow = await db.query.learningModes.findFirst({
@@ -207,7 +217,7 @@ describe('session summary integration', () => {
         sessionId: session.id,
         status: 'accepted',
         aiFeedback: 'Great summary! You captured the key idea.',
-      })
+      }),
     );
     expect(storedSummary).toEqual(
       expect.objectContaining({
@@ -215,9 +225,9 @@ describe('session summary integration', () => {
           'Plants use sunlight, water, and carbon dioxide to make the food they need.',
         aiFeedback: 'Great summary! You captured the key idea.',
         status: 'accepted',
-      })
+      }),
     );
     expect(learningModeRow?.consecutiveSummarySkips).toBe(0);
-    expect(mockRouteAndCall).toHaveBeenCalled();
+    expect(llmProviderCalls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Cleanup PR-06: Drain 2 remaining LLM mock allowlist offenders (~7-10 hr).

**Cluster**: C2 — Test integration boundary
**Phases**: P3
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P3**: AUDIT-TESTS-2C — Drain LLM allowlist (commit `fd8d0634`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | `pnpm exec nx run-many -t typecheck` passed for 6 projects. |
| Lint | PASS | `pnpm exec nx run-many -t lint` passed for 6 projects; existing warnings only. |
| Tests | PASS | DB-backed related API integration tests passed under `doppler run -p mentomate -c dev`: 2 suites, 5 tests. Guard test passed separately: 1 suite, 3 tests. |
| Phase verifications | PASS | 1 work-order verification command rerun: `pnpm exec nx run-many -t typecheck`. |
| GC1 ratchet | PASS | `origin/main...HEAD` diff clean for new internal relative `jest.mock()` calls. |

## Review Summary

**Verdict**: REQUEST_CHANGES
**Findings**: 0C / 2H / 2M / 1L

---
Generated by Archon workflow `execute-cleanup-pr`
