### PR TITLE
refactor(api): forward-only drizzle-orm import guard test

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default baseConfig;

--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,3 +1,0 @@
-import baseConfig from '../../eslint.config.mjs';
-
-export default baseConfig;

--- a/apps/api/src/routes/no-drizzle-orm-imports.test.ts
+++ b/apps/api/src/routes/no-drizzle-orm-imports.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Forward-only guard: confirms that no route file imports from drizzle-orm.
+//
+// Context: sessions.ts had a sanctioned drizzle-orm import (CLAUDE.md
+// "Known Exceptions") that was silently removed in PR #130 (8672bdcd).
+// The CLAUDE.md exception entry was removed in e622dd15. This test ensures
+// the invariant "zero route files import drizzle-orm" is forward-only:
+// if any route file re-introduces the pattern, jest fails fast.
+//
+// The ESLint G1 rule (root eslint.config.mjs, routes override) is the
+// primary enforcement layer. This test adds a second layer that fires on a
+// plain jest run even without a full lint pass.
+
+const ROUTES_DIR = __dirname;
+
+describe('drizzle-orm import guard — routes/', () => {
+  const routeFiles = readdirSync(ROUTES_DIR).filter(
+    (f) =>
+      f.endsWith('.ts') && !f.endsWith('.test.ts') && !f.endsWith('.spec.ts'),
+  );
+
+  it('has at least one route file to scan', () => {
+    expect(routeFiles.length).toBeGreaterThan(0);
+  });
+
+  it('no route file imports from drizzle-orm (bare or subpath)', () => {
+    const violations: string[] = [];
+    for (const file of routeFiles) {
+      const source = readFileSync(join(ROUTES_DIR, file), 'utf-8');
+      if (/from\s+['"]drizzle-orm(?:\/[^'"]*)?['"]/.test(source)) {
+        violations.push(file);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Cleanup PR-14: Drizzle-import guard test.

**Cluster**: C6 — apps/api config & E2E symmetry
**Phase**: P1b (P2 reverted — see below)
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P1b**: Add forward-only guard test `apps/api/src/routes/no-drizzle-orm-imports.test.ts` that fails CI on any route file importing from `drizzle-orm`. Secondary enforcement layer on top of ESLint G1.

## Reverted in this PR

- **P2** (apps/api/eslint.config.mjs re-export) was implemented in commit `f61c5975` and reverted in `1a079aa1` after adversarial review found that the bare re-export silently breaks G1–G5 governance rules. ESLint flat-config glob patterns like `apps/api/src/routes/**/*.ts` resolve relative to the CWD where eslint is invoked, so a re-export from `apps/api/` causes the patterns to resolve to the nonexistent `apps/api/apps/api/src/routes/**/*.ts`, disabling all governance rules. Net effect of this PR is the guard test only.

## Verification

| Check | Result | Details |
|---|---|---|
| TypeCheck | PASS | 6/6 projects |
| Lint | PASS | 0 errors |
| Tests | PASS | `no-drizzle-orm-imports.test.ts` — 2/2 |
| GC1 ratchet | PASS | No new internal `jest.mock()` calls |

## Review Summary

Original adversarial review verdict: **BLOCK** (1C / 0H / 0M / 4L). The CRITICAL finding (ADV-1, the eslint re-export) was resolved within the PR by reverting P2. The 4 LOW findings are deferrable (non-recursive `readdirSync`; regex matches `from` imports only — ESM-only codebase). Re-review requested.

---
Generated by Archon workflow `execute-cleanup-pr`; metadata reconciled after fix.
