### PR TITLE
refactor: Cleanup PR-16 — Drop broken nx e2e block + rename db:generate → db:generate:dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ cd apps/mobile && pnpm exec tsc --noEmit
 
 # Database
 pnpm run db:push:dev
-pnpm run db:generate
+pnpm run db:generate:dev
 pnpm run db:migrate:dev
 
 # LLM Eval Harness

--- a/nx.json
+++ b/nx.json
@@ -68,24 +68,6 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "e2e": {
-      "dependsOn": ["build"],
-      "inputs": [
-        "{projectRoot}/e2e/**",
-        "{projectRoot}/src/**",
-        "{workspaceRoot}/packages/schemas/src/**"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "maestro test e2e/flows/",
-        "cwd": "apps/mobile"
-      },
-      "configurations": {
-        "smoke": {
-          "command": "maestro test e2e/flows/ --include-tags=smoke"
-        }
-      }
-    },
     "format:check": {
       "cache": true,
       "inputs": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,scss,html}\"",
     "prepare": "husky",
     "db:push:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs push",
-    "db:generate": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs generate",
+    "db:generate:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs generate",
     "db:migrate:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs migrate",
     "db:studio:dev": "C:/Tools/doppler/doppler.exe run -- pnpm --filter @eduagent/database exec tsx node_modules/drizzle-kit/bin.cjs studio",
     "test:integration": "C:/Tools/doppler/doppler.exe run -- jest --config tests/integration/jest.config.cjs --no-coverage",


### PR DESCRIPTION
## Summary

Cleanup PR-16: Drop broken nx e2e block + rename db:generate → db:generate:dev

**Cluster**: C6 — apps/api config & E2E symmetry
**Phases**: P4+P5
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P4**: AUDIT-PACKAGE-SCRIPTS-2d — Drop broken `nx.json` e2e block (commit `a4113481`)
- **P5**: AUDIT-EXTREFS-1 — Rename db:generate → db:generate:dev (commit `2fa23d01`)

## Scope changes during execution

The work order claimed the following file(s), but `fix-locally` reverted them after review (typically because the adversarial reviewer caught a problem with the implementation). They are NOT in this PR's diff:

- `.archon/governance-constraints.md` — reverted by fix-locally (no matching CRITICAL/HIGH finding; see review artifacts)
- `docs/architecture.md` — reverted by fix-locally (no matching CRITICAL/HIGH finding; see review artifacts)
- `docs/audit/2026-05-02-artefact-consistency-punchlist.md` — reverted by fix-locally (no matching CRITICAL/HIGH finding; see review artifacts)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | 6 projects, all cached (no TS source changes) |
| Lint | PASS | 0 errors, 322 pre-existing grandfathered warnings (`gov/no-internal-jest-mock`) |
| Tests | PASS | No test files for changed config/doc files (nx.json, package.json, CLAUDE.md) — expected |
| Phase verifications | PASS | P4 + P5 both verified via `nx run-many -t typecheck` |
| GC1 ratchet | PASS | No new internal `jest.mock()` calls introduced |
| Governance constraint | PASS | No CI workflows or deploy scripts reference bare `db:generate`; stale refs are docs/plans only |

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 0M / 0L

---
Generated by Archon workflow `execute-cleanup-pr`
