### PR TITLE
cfg(ci): add token-2 and token-3 fallback steps to Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,10 +64,13 @@ jobs:
 
       # Fallback to token 2 if token 1's account hit its monthly quota (429).
       # `outcome` reflects the step result before `continue-on-error`, so it
-      # captures the 429 even though the job is advisory.
+      # captures the 429 even though the job is advisory. The leading
+      # `failure()` is required: without a status check function, GitHub
+      # defaults the `if:` to `success()` and skips this step after step 1
+      # fails.
       - name: Run Claude Code Review (token 2 fallback)
         id: claude-review-2
-        if: steps.claude-review.outcome == 'failure'
+        if: failure() && steps.claude-review.outcome == 'failure'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
@@ -93,7 +96,7 @@ jobs:
 
       - name: Run Claude Code Review (token 3 fallback)
         id: claude-review-3
-        if: steps.claude-review.outcome == 'failure' && steps.claude-review-2.outcome == 'failure'
+        if: failure() && steps.claude-review.outcome == 'failure' && steps.claude-review-2.outcome == 'failure'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,11 +37,66 @@ jobs:
       - name: Prepare Claude Code install directory
         run: mkdir -p "$HOME/.local/bin"
 
-      - name: Run Claude Code Review
+      - name: Run Claude Code Review (token 1)
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and adherence to the project's CLAUDE.md conventions
+            - Potential bugs or logic errors
+            - Security implications (OWASP top 10)
+            - TypeScript strict mode compliance
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Only post GitHub comments — don't submit review text as messages.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+
+      # Fallback to token 2 if token 1's account hit its monthly quota (429).
+      # `outcome` reflects the step result before `continue-on-error`, so it
+      # captures the 429 even though the job is advisory.
+      - name: Run Claude Code Review (token 2 fallback)
+        id: claude-review-2
+        if: steps.claude-review.outcome == 'failure'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          show_full_output: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and adherence to the project's CLAUDE.md conventions
+            - Potential bugs or logic errors
+            - Security implications (OWASP top 10)
+            - TypeScript strict mode compliance
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Only post GitHub comments — don't submit review text as messages.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+
+      - name: Run Claude Code Review (token 3 fallback)
+        id: claude-review-3
+        if: steps.claude-review.outcome == 'failure' && steps.claude-review-2.outcome == 'failure'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
           show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Why

The Claude code review workflow uses a single OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) tied to one team member's Claude Max subscription. When that account hits its monthly org quota, every subsequent review fails with `429 You've hit your org's monthly usage limit` (e.g. [run 25741085121](https://github.com/cognoco/eduagent-build/actions/runs/25741085121/job/75591331638?pr=221)).

The action doesn't natively support multiple tokens or rotation, so this implements fallback at the workflow level.

## What

Adds two additional `claude-code-action@v1` steps that run only if the previous step's `outcome == 'failure'`:

- Step 1 → `secrets.CLAUDE_CODE_OAUTH_TOKEN` (existing)
- Step 2 → `secrets.CLAUDE_CODE_OAUTH_TOKEN_2` (new, runs on step 1 failure)
- Step 3 → `secrets.CLAUDE_CODE_OAUTH_TOKEN_3` (new, runs on step 1 AND 2 failure)

`outcome` reflects the raw step result before `continue-on-error` is applied, so the gating works correctly even though the job is advisory.

## Follow-up (required before merge takes effect)

The two new secrets must be added to the repo for fallback steps to do anything:

```bash
# Each from a different team member's Claude Max account:
claude setup-token   # run locally, copy token
gh secret set CLAUDE_CODE_OAUTH_TOKEN_2 --repo cognoco/eduagent-build
gh secret set CLAUDE_CODE_OAUTH_TOKEN_3 --repo cognoco/eduagent-build
```

Until the secrets are set, steps 2 and 3 will fail-fast with an empty token — harmless (job is advisory and `continue-on-error: true`), just noisy in logs.

## Trade-offs

- Prompt and `claude_args` are duplicated across all three steps because GitHub Actions doesn't support YAML anchors. Future prompt edits need to be applied to all three.
- Each fallback step re-installs the action and Bun (~10–15s overhead), but only fires on failure.
- This is a workaround, not a real fix. Long-term, switching to `anthropic_api_key` (Console pay-as-you-go) would eliminate the quota cliff entirely.