### PR TITLE
docs: sweep db:generate → db:generate:dev in README and AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ cd apps/mobile && pnpm exec tsc --noEmit
 
 # Database
 pnpm run db:push:dev
-pnpm run db:generate
+pnpm run db:generate:dev
 pnpm run db:migrate:dev
 
 # LLM Eval Harness

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pnpm exec nx run-many -t typecheck
 pnpm run db:push:dev
 
 # Generate migration
-pnpm run db:generate
+pnpm run db:generate:dev
 
 # Apply migration
 pnpm run db:migrate:dev


### PR DESCRIPTION
## Summary

Completes the sweep of `pnpm run db:generate` → `pnpm run db:generate:dev` in live onboarding docs.

A prior PR renamed the script but did not update `README.md` and `AGENTS.md`. Both are action-oriented onboarding documents; a new contributor following either would run a nonexistent script.

## Changes

- `README.md:77` — `pnpm run db:generate` → `pnpm run db:generate:dev`
- `AGENTS.md:159` — `pnpm run db:generate` → `pnpm run db:generate:dev`

No logic, no tests, no migrations affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database setup instructions in developer guides to reflect the correct development workflow command.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->