### PR TITLE
chore(deps): PR-13 — declare @react-navigation/native + consolidate onlyBuiltDependencies

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@react-native-community/datetimepicker": "^8.6.0",
     "@react-native-community/netinfo": "^12.0.1",
     "@react-native-ml-kit/text-recognition": "^2.0.0",
+    "@react-navigation/native": "^7.1.28",
     "@sentry/react-native": "^8.1.0",
     "@tanstack/react-query": "^5.90.21",
     "expo": "~54.0.29",

--- a/package.json
+++ b/package.json
@@ -107,10 +107,6 @@
   },
   "packageManager": "pnpm@10.19.0",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ],
     "overrides": {
       "react": "19.1.0",
       "react-native-worklets": "0.7.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@react-native-ml-kit/text-recognition':
         specifier: ^2.0.0
         version: 2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@react-navigation/native':
+        specifier: ^7.1.28
+        version: 7.1.28(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
       '@sentry/react-native':
         specifier: ^8.1.0
         version: 8.1.0(expo@54.0.29)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
@@ -18975,7 +18978,7 @@ snapshots:
       '@react-navigation/routers': 7.5.3
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       query-string: 7.1.3
       react: 19.1.0
       react-is: 19.2.3
@@ -19037,7 +19040,7 @@ snapshots:
       '@react-navigation/core': 7.14.0(react@19.1.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
       use-latest-callback: 0.2.6(react@19.1.0)
@@ -19048,14 +19051,14 @@ snapshots:
       '@react-navigation/core': 7.14.0(react@19.1.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@19.1.0)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
       use-latest-callback: 0.2.6(react@19.1.0)
 
   '@react-navigation/routers@7.5.3':
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
 
   '@revenuecat/purchases-js-hybrid-mappings@17.41.1':
     dependencies:
@@ -21008,8 +21011,8 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -24553,7 +24556,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -26519,8 +26522,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.12:
-    optional: true
+  nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -27434,7 +27436,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -27453,7 +27455,7 @@ snapshots:
 
   postcss@8.5.6:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,6 @@ packages:
 
 onlyBuiltDependencies:
   - '@swc/core'
+  - esbuild
   - nx
+  - sharp


### PR DESCRIPTION
## Summary

Recovers the implementation produced by Archon workflow run [`7499db60`](http://ramtop.ruffe-alligator.ts.net:3090/workflows/runs/7499db600a9ee0bd0e4ee059b0e4702e) (`execute-cleanup-pr` for PR-13). The workflow completed the `implement` and `scope-guard-post-implement` steps successfully (risk-class: tiny, scope-guard: clean — 5 files match work order), but skipped `push` and `create-pr`, so no PR was opened.

These two commits are cherry-picked from the original worktree (`archon/thread-6264034d`) onto current `main`.

## Cluster

**C5 — Manifest & dep-declaration hygiene** (Phases P3 + P7 from `docs/audit/cleanup-plan.md`)

## Changes

### P3 — Declare `@react-navigation/native` as a direct dependency
- `apps/mobile/package.json`
- `pnpm-lock.yaml`

### P7 — Consolidate `onlyBuiltDependencies` into `pnpm-workspace.yaml`
- `package.json`
- `pnpm-workspace.yaml`

## Verification

Per the work order:
```bash
pnpm exec nx run-many -t typecheck
```

## Provenance

- Workflow run: `7499db600a9ee0bd0e4ee059b0e4702e`
- Original commits: `168174a0`, `e083406b` (on `archon/thread-6264034d`, not pushed)
- Cherry-picked as: `e4e46ad8`, `3497ea30`