### PR TITLE
fix(archon): unblock cleanup-pr workflow — extract resilience + tiny-PR cascade

### DIFF
--- a/.archon/scripts/cleanup-extract.sh
+++ b/.archon/scripts/cleanup-extract.sh
@@ -91,7 +91,7 @@ cluster_title="$(sed -n "${cluster_header_line}p" "$PLAN" | sed 's/^###[[:space:
 
 # Extract cluster metadata (Severity, Headline)
 cluster_block="$(sed -n "${cluster_header_line},${next_section_line}p" "$PLAN")"
-cluster_severity="$(echo "$cluster_block" | grep -oE '\*\*(RED|YELLOW-RED|YELLOW|GREEN-YELLOW|GREEN)\*\*' | head -1 | tr -d '*')"
+cluster_severity="$(echo "$cluster_block" | grep -oE '\*\*(RED|YELLOW-RED|YELLOW|GREEN-YELLOW|GREEN)\*\*' | head -1 | tr -d '*' || true)"
 cluster_severity="${cluster_severity:-UNKNOWN}"
 
 # ── Step 3: Phase details from cluster table ───────────────────────────

--- a/.archon/workflows/execute-cleanup-pr.yaml
+++ b/.archon/workflows/execute-cleanup-pr.yaml
@@ -1,7 +1,7 @@
-name: execute-cleanup-pr-merged
+name: execute-cleanup-pr
 description: |
   Execute a cleanup-plan.md work package by PR number.
-  Usage: archon workflow run execute-cleanup-pr-merged --branch cleanup-pr-XX "PR-16"
+  Usage: archon workflow run execute-cleanup-pr --branch cleanup-pr-XX "PR-16"
   Input: PR identifier (e.g. "PR-08", "PR-15", "08", "15")
   Output: GitHub PR ready for human review.
 
@@ -24,9 +24,11 @@ description: |
     and we keep model-family consistency with reviewers).
 
   Structural change vs current flavors:
-  - `risk-class` runs BEFORE `validate`. `validate` is now gated by
-    `risk-class != 'tiny'`, mirroring code-review/test-coverage.
-    Saves ~$0.22 + 120s per tiny PR.
+  - `risk-class` runs BEFORE `validate`. `validate` and `re-validate` are
+    now gated by `risk-class != 'tiny'`, mirroring code-review/test-coverage.
+    Saves ~$0.44 + 240s per tiny PR (both LLM validates skipped).
+    `review-scope` and `push` use `trigger_rule: none_failed_min_one_success`
+    so the skipped validates don't cascade-skip the rest of the workflow.
 
   Flow:
   1. Parse cleanup-plan.md → deterministic extraction (shell)
@@ -54,7 +56,7 @@ nodes:
   # ── PHASE 0: INIT ────────────────────────────────────────────────────
 
   - id: init-tracing
-    bash: ./.archon/scripts/init-tracing.sh --workflow execute-cleanup-pr-merged "$ARGUMENTS"
+    bash: ./.archon/scripts/init-tracing.sh --workflow execute-cleanup-pr "$ARGUMENTS"
 
   # ── PHASE 1: EXTRACT ─────────────────────────────────────────────────
   # Deterministic shell parser. Produces work-order.md, patterns.md,
@@ -172,7 +174,7 @@ nodes:
   - id: review-scope
     command: cleanup-pr-review-scope
     depends_on: [risk-class, validate]
-    trigger_rule: all_success   # validate must succeed before reviews fan out (one_success previously let a failed validate slip past — risk-class always succeeds)
+    trigger_rule: none_failed_min_one_success   # validate failure blocks reviews; validate skipped (tiny) is OK. one_success previously let a failed validate slip past (risk-class always succeeds); all_success cascade-skipped tiny PRs into orphaning the whole post-implement chain (no push, no PR).
     context: fresh
     idle_timeout: 300000
     provider: claude
@@ -233,7 +235,12 @@ nodes:
     modelReasoningEffort: high
 
   # ── PHASE 5.5: SCOPE GUARD + RE-VALIDATE (post-fix) ──────────────────
-  # Same idle_timeout cap on re-validate as on validate.
+  # scope-guard-post-fix always runs (cheap shell, catches file drift from
+  # fix-locally). re-validate is gated by risk-class != 'tiny' for symmetry
+  # with validate: same Claude/sonnet/low cost, same rationale. Defense-in-
+  # depth for tiny PRs is preserved by scope-guard-post-fix, pre-commit
+  # hooks (lint-staged, tsc --build, scripts/pre-commit-tests.sh), and
+  # ci-watch-and-fix.
 
   - id: scope-guard-post-fix
     depends_on: [fix-locally]
@@ -242,6 +249,7 @@ nodes:
   - id: re-validate
     command: cleanup-validate
     depends_on: [scope-guard-post-fix]
+    when: "$risk-class.output != 'tiny'"
     context: fresh
     idle_timeout: 300000
     provider: claude
@@ -249,9 +257,13 @@ nodes:
     modelReasoningEffort: low
 
   # ── PHASE 6: PUSH + CREATE PR ─────────────────────────────────────────
+  # push includes risk-class in deps so none_failed_min_one_success has an
+  # always-succeeding anchor when re-validate is skipped (tiny). re-validate
+  # failure still blocks push for non-tiny PRs.
 
   - id: push
-    depends_on: [re-validate]
+    depends_on: [risk-class, re-validate]
+    trigger_rule: none_failed_min_one_success
     bash: ./.archon/scripts/push.sh
 
   - id: create-pr

--- a/docs/audit/cleanup-plan.md
+++ b/docs/audit/cleanup-plan.md
@@ -363,7 +363,7 @@ These PRs need coordinator or human review beyond agent execution:
 ### C8 — Track C archeology
 
 **Source:** Original cleanup-triage + DEP-DRIFT-1 + AUDIT-MIGRATIONS series
-**Severity:** **GREEN-leaning-YELLOW** (unchanged; standalone-shippable janitor work)
+**Severity:** **GREEN-YELLOW** (unchanged; standalone-shippable janitor work)
 **Headline:** Each item ships independently for clean git blame. No cross-coupling.
 
 | Phase | Description | Status | Owner | PR | Files-claimed | Notes |


### PR DESCRIPTION
## Summary

Three related fixes to the Archon `execute-cleanup-pr` workflow, all surfaced by recent failed runs against cluster C8 PRs (PR-18, PR-19, PR-21):

1. **`cleanup-extract.sh` — silent-exit bug.** Line 94's severity-extraction pipeline (`grep -oE '...severity-enum...'`) had no `|| true` guard. Under `set -euo pipefail`, an unknown severity tag (like C8's `GREEN-leaning-YELLOW`) made `grep` exit 1, killing the script *one line before* the `:-UNKNOWN` fallback that would have caught it. Blast radius: every PR in any cluster whose severity didn't match the hardcoded enum. Latent since 2026-05-03; tripped today by the first dispatch against C8.
2. **`execute-cleanup-pr.yaml` — tiny-PR cascade-skip.** `review-scope` had `trigger_rule: all_success` with `depends_on: [risk-class, validate]`. When `risk-class=tiny` caused `validate` to be skipped, the skipped state cascaded through `review-scope → adversarial-review → synthesize → fix-locally → scope-guard-post-fix → re-validate → push → create-pr` — orphaning the implementation with no PR (observed live on workflow run [`7499db60`](http://ramtop.ruffe-alligator.ts.net:3090/workflows/runs/7499db600a9ee0bd0e4ee059b0e4702e), which produced PR-13 commits but never pushed; recovered manually in #225). Fixed by switching to `none_failed_min_one_success` per Archon's `authoring-workflows.md` reference.
3. **Secondary: `re-validate` gating symmetry.** Now also gated by `risk-class != 'tiny'` for cost-symmetry with `validate`. `push.depends_on` updated to `[risk-class, re-validate]` with `trigger_rule: none_failed_min_one_success` so the skip doesn't cascade, while preserving the "failed re-validate blocks push for non-tiny" guard. Doubles the tiny-PR savings to ~\$0.44 + 240s.

A pre-existing cosmetic rename in the YAML (`execute-cleanup-pr-merged` → `execute-cleanup-pr`) that was sitting unstaged on `consistency2` is bundled in.

## Changes

| File | Change |
|---|---|
| `.archon/scripts/cleanup-extract.sh` | Add `\|\| true` to severity-grep on line 94. |
| `.archon/workflows/execute-cleanup-pr.yaml` | `review-scope.trigger_rule` → `none_failed_min_one_success`; `re-validate` gated by tiny; `push` now joins on `[risk-class, re-validate]` with `none_failed_min_one_success`; comments updated. Plus cosmetic `-merged` suffix removal. |
| `docs/audit/cleanup-plan.md` | C8 severity `GREEN-leaning-YELLOW` → `GREEN-YELLOW` (cosmetic alignment with enum; not load-bearing now that the script tolerates unknowns). |

## Verification

```bash
# Reproducer (was: exit 1 silently for PR-18/19/21):
bash .archon/scripts/cleanup-extract.sh PR-18 /tmp/out
# Now: exit 0, full artifact set produced.
```

Verified all three previously-failing extracts now succeed (exit 0, work-order/patterns/rules-digest written). Workflow trigger_rule semantics validated against `packages/docs-web/.../authoring-workflows.md` in the Archon source.

## Provenance

Found while diagnosing failed runs `d511f8a4`, `5e73e2db`, `50d034fe` (all C8, all extract). Tiny-PR cascade discovered earlier from run [`7499db60`](http://ramtop.ruffe-alligator.ts.net:3090/workflows/runs/7499db600a9ee0bd0e4ee059b0e4702e) (PR-13).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced robustness of cleanup script to gracefully handle missing severity information without causing failures.
  * Optimized pull request validation workflow to conditionally skip unnecessary validation checks for small changes, improving efficiency and reducing processing time.

* **Documentation**
  * Updated severity label formatting in audit documentation for consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/227)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->