### PR TITLE
refactor: Cleanup PR-19 — Fix non-monotonic _journal.json timestamps

### DIFF
--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -82,63 +82,63 @@
     {
       "idx": 11,
       "version": "7",
-      "when": 1775379412072,
+      "when": 1775779201000,
       "tag": "0011_good_harrier",
       "breakpoints": true
     },
     {
       "idx": 12,
       "version": "7",
-      "when": 1775389406040,
+      "when": 1775779202000,
       "tag": "0012_tan_exodus",
       "breakpoints": true
     },
     {
       "idx": 13,
       "version": "7",
-      "when": 1775606400000,
+      "when": 1775779203000,
       "tag": "0013_profile_premium_llm",
       "breakpoints": true
     },
     {
       "idx": 14,
       "version": "7",
-      "when": 1775493977146,
+      "when": 1775779204000,
       "tag": "0014_young_ravenous",
       "breakpoints": true
     },
     {
       "idx": 15,
       "version": "7",
-      "when": 1775682565769,
+      "when": 1775779205000,
       "tag": "0015_bored_catseye",
       "breakpoints": true
     },
     {
       "idx": 16,
       "version": "7",
-      "when": 1775723430036,
+      "when": 1775779206000,
       "tag": "0016_overrated_nuke",
       "breakpoints": true
     },
     {
       "idx": 17,
       "version": "7",
-      "when": 1775763738938,
+      "when": 1775779207000,
       "tag": "0017_drop_birth_date_not_null_birth_year",
       "breakpoints": true
     },
     {
       "idx": 18,
       "version": "7",
-      "when": 1775763758398,
+      "when": 1775779208000,
       "tag": "0018_add_birth_year_set_by",
       "breakpoints": true
     },
     {
       "idx": 19,
       "version": "7",
-      "when": 1775765355940,
+      "when": 1775779209000,
       "tag": "0019_dizzy_shooting_star",
       "breakpoints": true
     },
@@ -215,21 +215,21 @@
     {
       "idx": 30,
       "version": "7",
-      "when": 1776514699804,
+      "when": 1776730001000,
       "tag": "0030_magical_ser_duncan",
       "breakpoints": true
     },
     {
       "idx": 31,
       "version": "7",
-      "when": 1776540603477,
+      "when": 1776730002000,
       "tag": "0031_purple_thunderbird",
       "breakpoints": true
     },
     {
       "idx": 32,
       "version": "7",
-      "when": 1776663600000,
+      "when": 1776730003000,
       "tag": "0032_rls_quiz_mastery_items",
       "breakpoints": true
     },
@@ -243,14 +243,14 @@
     {
       "idx": 34,
       "version": "7",
-      "when": 1776600000000,
+      "when": 1776750001000,
       "tag": "0034_parent_session_recap",
       "breakpoints": true
     },
     {
       "idx": 35,
       "version": "7",
-      "when": 1776700000000,
+      "when": 1776750002000,
       "tag": "0035_onboarding_dimensions",
       "breakpoints": true
     },
@@ -327,63 +327,63 @@
     {
       "idx": 46,
       "version": "7",
-      "when": 1777671422482,
+      "when": 1778600001000,
       "tag": "0046_stormy_cassandra_nova",
       "breakpoints": true
     },
     {
       "idx": 47,
       "version": "7",
-      "when": 1777805004045,
+      "when": 1778600002000,
       "tag": "0047_mean_la_nuit",
       "breakpoints": true
     },
     {
       "idx": 48,
       "version": "7",
-      "when": 1777806109532,
+      "when": 1778600003000,
       "tag": "0048_sticky_genesis",
       "breakpoints": true
     },
     {
       "idx": 49,
       "version": "7",
-      "when": 1777810531138,
+      "when": 1778600004000,
       "tag": "0049_flimsy_sister_grimm",
       "breakpoints": true
     },
     {
       "idx": 50,
       "version": "7",
-      "when": 1777817311627,
+      "when": 1778600005000,
       "tag": "0050_romantic_demogoblin",
       "breakpoints": true
     },
     {
       "idx": 51,
       "version": "7",
-      "when": 1777819196348,
+      "when": 1778600006000,
       "tag": "0051_special_ronan",
       "breakpoints": true
     },
     {
       "idx": 52,
       "version": "7",
-      "when": 1777821765933,
+      "when": 1778600007000,
       "tag": "0052_fixed_hex",
       "breakpoints": true
     },
     {
       "idx": 53,
       "version": "7",
-      "when": 1778025600000,
+      "when": 1778600008000,
       "tag": "0053_topic_notes_session_idx",
       "breakpoints": true
     },
     {
       "idx": 54,
       "version": "7",
-      "when": 1777979260892,
+      "when": 1778600009000,
       "tag": "0054_session_summary_retention",
       "breakpoints": true
     },
@@ -474,28 +474,28 @@
     {
       "idx": 67,
       "version": "7",
-      "when": 1778247099027,
+      "when": 1779000013000,
       "tag": "0067_plain_spyke",
       "breakpoints": true
     },
     {
       "idx": 68,
       "version": "7",
-      "when": 1779000013000,
+      "when": 1779000014000,
       "tag": "0068_session_events_client_id_conflict_target",
       "breakpoints": true
     },
     {
       "idx": 69,
       "version": "7",
-      "when": 1779000014000,
+      "when": 1779000015000,
       "tag": "0069_learning_profile_celebration_level",
       "breakpoints": true
     },
     {
       "idx": 70,
       "version": "7",
-      "when": 1778491978458,
+      "when": 1779000016000,
       "tag": "0070_omniscient_landau",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary

Cleanup PR-19: Fix non-monotonic _journal.json timestamps

**Cluster**: C8 — Track C archeology
**Phases**: P2
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P2**: AUDIT-MIGRATIONS-2 — Fix non-monotonic `_journal.json` timestamps (commit `912411cd`)
- `apps/api/drizzle/meta/_journal.json` — rewrote `when` values for idx 11–19, 30–35, 46–54, 67–70 to be monotonically increasing (synthetic timestamps consistent with existing idx 55–66 pattern)

## Scope changes during execution

The work order claimed the following file(s), but `fix-locally` reverted them after review (typically because the adversarial reviewer caught a problem with the implementation). They are NOT in this PR's diff:

- `.archon/governance-constraints.md` — reverted by fix-locally (no matching CRITICAL/HIGH finding; see review artifacts)

## Verification

- [x] TypeCheck
- [x] Lint
- [x] Tests
- [x] GC1 ratchet

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 1M / 0L (Medium: PR description inconsistency — fixed)

---
Generated by Archon workflow `execute-cleanup-pr`