### PR TITLE
chore(db): regenerate 11 missing drizzle migration snapshots

### DIFF
--- a/apps/api/drizzle/meta/0006_watery_birth_year_snapshot.json
+++ b/apps/api/drizzle/meta/0006_watery_birth_year_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "1193a11a-42a7-4064-9fc4-ee221fee9396",
+  "prevId": "ed145e47-f1e6-49ef-8e3d-7d1ceb6ed0f4",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -377,12 +377,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "retention_cards_interval_days_positive": {
-          "name": "retention_cards_interval_days_positive",
-          "value": "\"retention_cards\".\"interval_days\" >= 1"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.teaching_preferences": {
@@ -418,12 +413,6 @@
           "name": "analogy_domain",
           "type": "analogy_domain",
           "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "native_language": {
-          "name": "native_language",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -464,13 +453,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "teaching_preferences_profile_subject_unique": {
-          "name": "teaching_preferences_profile_subject_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -598,12 +581,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "quota_pools_used_this_month_non_negative": {
-          "name": "quota_pools_used_this_month_non_negative",
-          "value": "\"quota_pools\".\"used_this_month\" >= 0"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.subscriptions": {
@@ -688,12 +666,6 @@
         },
         "last_revenuecat_event_id": {
           "name": "last_revenuecat_event_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_revenuecat_event_timestamp_ms": {
-          "name": "last_revenuecat_event_timestamp_ms",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -817,21 +789,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "top_up_credits_rc_txn_id_idx": {
-          "name": "top_up_credits_rc_txn_id_idx",
-          "columns": [
-            {
-              "expression": "revenuecat_transaction_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
@@ -840,107 +797,6 @@
           "tableFrom": "top_up_credits",
           "tableTo": "subscriptions",
           "columnsFrom": ["subscription_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "top_up_credits_remaining_non_negative": {
-          "name": "top_up_credits_remaining_non_negative",
-          "value": "\"top_up_credits\".\"remaining\" >= 0"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1303,20 +1159,9 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "family_links_parent_child_unique": {
-          "name": "family_links_parent_child_unique",
-          "nullsNotDistinct": false,
-          "columns": ["parent_profile_id", "child_profile_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "family_links_no_self_link": {
-          "name": "family_links_no_self_link",
-          "value": "\"family_links\".\"parent_profile_id\" != \"family_links\".\"child_profile_id\""
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.profiles": {
@@ -1347,17 +1192,19 @@
           "primaryKey": false,
           "notNull": false
         },
-        "birth_year": {
-          "name": "birth_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "birth_year_set_by": {
-          "name": "birth_year_set_by",
-          "type": "uuid",
+        "birth_date": {
+          "name": "birth_date",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "persona_type": {
+          "name": "persona_type",
+          "type": "persona_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LEARNER'"
         },
         "location": {
           "name": "location",
@@ -1368,13 +1215,6 @@
         },
         "is_owner": {
           "name": "is_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "has_premium_llm": {
-          "name": "has_premium_llm",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -1418,97 +1258,6 @@
           "tableFrom": "profiles",
           "tableTo": "accounts",
           "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "profiles_birth_year_set_by_profiles_id_fk": {
-          "name": "profiles_birth_year_set_by_profiles_id_fk",
-          "tableFrom": "profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["birth_year_set_by"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.book_suggestions": {
-      "name": "book_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "picked_at": {
-          "name": "picked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "book_suggestions_subject_id_idx": {
-          "name": "book_suggestions_subject_id_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "book_suggestions_subject_id_subjects_id_fk": {
-          "name": "book_suggestions_subject_id_subjects_id_fk",
-          "tableFrom": "book_suggestions",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1565,29 +1314,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curricula_subject_version_idx": {
-          "name": "curricula_subject_version_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curricula_subject_id_subjects_id_fk": {
           "name": "curricula_subject_id_subjects_id_fk",
@@ -1696,108 +1423,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.curriculum_books": {
-      "name": "curriculum_books",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sort_order": {
-          "name": "sort_order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topics_generated": {
-          "name": "topics_generated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "curriculum_books_subject_id_subjects_id_fk": {
-          "name": "curriculum_books_subject_id_subjects_id_fk",
-          "tableFrom": "curriculum_books",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.curriculum_topics": {
       "name": "curriculum_topics",
       "schema": "",
@@ -1854,62 +1479,12 @@
           "primaryKey": false,
           "notNull": true
         },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "chapter": {
-          "name": "chapter",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "skipped": {
           "name": "skipped",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
           "default": false
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cefr_sublevel": {
-          "name": "cefr_sublevel",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_word_count": {
-          "name": "target_word_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_chunk_count": {
-          "name": "target_chunk_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "filed_from": {
-          "name": "filed_from",
-          "type": "filed_from",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pre_generated'"
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -1926,50 +1501,13 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
           "tableFrom": "curriculum_topics",
           "tableTo": "curricula",
           "columnsFrom": ["curriculum_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "curriculum_topics_book_id_curriculum_books_id_fk": {
-          "name": "curriculum_topics_book_id_curriculum_books_id_fk",
-          "tableFrom": "curriculum_topics",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2017,20 +1555,6 @@
           "notNull": true,
           "default": "'active'"
         },
-        "pedagogy_mode": {
-          "name": "pedagogy_mode",
-          "type": "pedagogy_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'socratic'"
-        },
-        "language_code": {
-          "name": "language_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2044,18 +1568,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "urgency_boost_until": {
-          "name": "urgency_boost_until",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "urgency_boost_reason": {
-          "name": "urgency_boost_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
@@ -2081,133 +1593,6 @@
           "tableFrom": "subjects",
           "tableTo": "profiles",
           "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_connections": {
-      "name": "topic_connections",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_a_id": {
-          "name": "topic_a_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topic_b_id": {
-          "name": "topic_b_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_connections_topic_a_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_a_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_a_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_connections_topic_b_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_b_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_b_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_suggestions": {
-      "name": "topic_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "used_at": {
-          "name": "used_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "topic_suggestions_book_id_idx": {
-          "name": "topic_suggestions_book_id_idx",
-          "columns": [
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "topic_suggestions_book_id_curriculum_books_id_fk": {
-          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
-          "tableFrom": "topic_suggestions",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2260,13 +1645,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "input_mode": {
-          "name": "input_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text'"
         },
         "status": {
           "name": "status",
@@ -2328,12 +1706,6 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
-        },
-        "raw_input": {
-          "name": "raw_input",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3090,13 +2462,6 @@
           "notNull": true,
           "default": false
         },
-        "weekly_progress_push": {
-          "name": "weekly_progress_push",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
         "push_enabled": {
           "name": "push_enabled",
           "type": "boolean",
@@ -3366,933 +2731,6 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
-    },
-    "public.milestones": {
-      "name": "milestones",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "milestone_type": {
-          "name": "milestone_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "threshold": {
-          "name": "threshold",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "celebrated_at": {
-          "name": "celebrated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "milestones_scope_uq": {
-          "name": "milestones_scope_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "milestone_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "threshold",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "milestones_profile_created_idx": {
-          "name": "milestones_profile_created_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "milestones_profile_id_profiles_id_fk": {
-          "name": "milestones_profile_id_profiles_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_subject_id_subjects_id_fk": {
-          "name": "milestones_subject_id_subjects_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_book_id_curriculum_books_id_fk": {
-          "name": "milestones_book_id_curriculum_books_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.monthly_reports": {
-      "name": "monthly_reports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "child_profile_id": {
-          "name": "child_profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_month": {
-          "name": "report_month",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_data": {
-          "name": "report_data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "viewed_at": {
-          "name": "viewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "monthly_reports_parent_child_month_uq": {
-          "name": "monthly_reports_parent_child_month_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "monthly_reports_child_month_idx": {
-          "name": "monthly_reports_child_month_idx",
-          "columns": [
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "monthly_reports_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "monthly_reports_child_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_child_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["child_profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.progress_snapshots": {
-      "name": "progress_snapshots",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "snapshot_date": {
-          "name": "snapshot_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "progress_snapshots_profile_date_uq": {
-          "name": "progress_snapshots_profile_date_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "progress_snapshots_profile_date_idx": {
-          "name": "progress_snapshots_profile_date_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "progress_snapshots_profile_id_profiles_id_fk": {
-          "name": "progress_snapshots_profile_id_profiles_id_fk",
-          "tableFrom": "progress_snapshots",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary": {
-      "name": "vocabulary",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term": {
-          "name": "term",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term_normalized": {
-          "name": "term_normalized",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "translation": {
-          "name": "translation",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "vocab_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'word'"
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "milestone_id": {
-          "name": "milestone_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mastered": {
-          "name": "mastered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocabulary_profile_subject_idx": {
-          "name": "vocabulary_profile_subject_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_profile_id_profiles_id_fk": {
-          "name": "vocabulary_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_subject_id_subjects_id_fk": {
-          "name": "vocabulary_subject_id_subjects_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_milestone_id_curriculum_topics_id_fk": {
-          "name": "vocabulary_milestone_id_curriculum_topics_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["milestone_id"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocabulary_profile_subject_term_unique": {
-          "name": "vocabulary_profile_subject_term_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id", "term_normalized"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary_retention_cards": {
-      "name": "vocabulary_retention_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "vocabulary_id": {
-          "name": "vocabulary_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ease_factor": {
-          "name": "ease_factor",
-          "type": "numeric(4, 2)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2.50'"
-        },
-        "interval_days": {
-          "name": "interval_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "repetitions": {
-          "name": "repetitions",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_reviewed_at": {
-          "name": "last_reviewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "next_review_at": {
-          "name": "next_review_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "failure_count": {
-          "name": "failure_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "consecutive_successes": {
-          "name": "consecutive_successes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocab_retention_cards_review_idx": {
-          "name": "vocab_retention_cards_review_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "next_review_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_retention_cards_profile_id_profiles_id_fk": {
-          "name": "vocabulary_retention_cards_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk": {
-          "name": "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "vocabulary",
-          "columnsFrom": ["vocabulary_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocab_retention_cards_vocabulary_unique": {
-          "name": "vocab_retention_cards_vocabulary_unique",
-          "nullsNotDistinct": false,
-          "columns": ["vocabulary_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_notes": {
-      "name": "topic_notes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_notes_topic_id_curriculum_topics_id_fk": {
-          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_notes_profile_id_profiles_id_fk": {
-          "name": "topic_notes_profile_id_profiles_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.learning_profiles": {
-      "name": "learning_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "learning_style": {
-          "name": "learning_style",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interests": {
-          "name": "interests",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "strengths": {
-          "name": "strengths",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "struggles": {
-          "name": "struggles",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "communication_notes": {
-          "name": "communication_notes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "suppressed_inferences": {
-          "name": "suppressed_inferences",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "interest_timestamps": {
-          "name": "interest_timestamps",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "effectiveness_session_count": {
-          "name": "effectiveness_session_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "memory_enabled": {
-          "name": "memory_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "memory_consent_status": {
-          "name": "memory_consent_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "consent_prompt_dismissed_at": {
-          "name": "consent_prompt_dismissed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memory_collection_enabled": {
-          "name": "memory_collection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "memory_injection_enabled": {
-          "name": "memory_injection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "version": {
-          "name": "version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "learning_profiles_profile_id_idx": {
-          "name": "learning_profiles_profile_id_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "learning_profiles_profile_id_profiles_id_fk": {
-          "name": "learning_profiles_profile_id_profiles_id_fk",
-          "tableFrom": "learning_profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "learning_profiles_profile_id_unique": {
-          "name": "learning_profiles_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4341,11 +2779,6 @@
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
     },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
-    },
     "public.consent_status": {
       "name": "consent_status",
       "schema": "public",
@@ -4366,20 +2799,15 @@
       "schema": "public",
       "values": ["EU", "US", "OTHER"]
     },
+    "public.persona_type": {
+      "name": "persona_type",
+      "schema": "public",
+      "values": ["TEEN", "LEARNER", "PARENT"]
+    },
     "public.curriculum_topic_source": {
       "name": "curriculum_topic_source",
       "schema": "public",
       "values": ["generated", "user"]
-    },
-    "public.filed_from": {
-      "name": "filed_from",
-      "schema": "public",
-      "values": ["pre_generated", "session_filing", "freeform_filing"]
-    },
-    "public.pedagogy_mode": {
-      "name": "pedagogy_mode",
-      "schema": "public",
-      "values": ["socratic", "four_strands"]
     },
     "public.subject_status": {
       "name": "subject_status",
@@ -4458,20 +2886,8 @@
         "consent_reminder",
         "consent_warning",
         "consent_expired",
-        "subscribe_request",
-        "recall_nudge",
-        "weekly_progress",
-        "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "subscribe_request"
       ]
-    },
-    "public.vocab_type": {
-      "name": "vocab_type",
-      "schema": "public",
-      "values": ["word", "chunk"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0007_teaching_preferences_unique_snapshot.json
+++ b/apps/api/drizzle/meta/0007_teaching_preferences_unique_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "111aa14b-aac5-481d-82da-75b51b9087c9",
+  "prevId": "1193a11a-42a7-4064-9fc4-ee221fee9396",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -377,12 +377,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "retention_cards_interval_days_positive": {
-          "name": "retention_cards_interval_days_positive",
-          "value": "\"retention_cards\".\"interval_days\" >= 1"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.teaching_preferences": {
@@ -418,12 +413,6 @@
           "name": "analogy_domain",
           "type": "analogy_domain",
           "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "native_language": {
-          "name": "native_language",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -464,13 +453,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "teaching_preferences_profile_subject_unique": {
-          "name": "teaching_preferences_profile_subject_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -598,12 +581,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "quota_pools_used_this_month_non_negative": {
-          "name": "quota_pools_used_this_month_non_negative",
-          "value": "\"quota_pools\".\"used_this_month\" >= 0"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.subscriptions": {
@@ -688,12 +666,6 @@
         },
         "last_revenuecat_event_id": {
           "name": "last_revenuecat_event_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_revenuecat_event_timestamp_ms": {
-          "name": "last_revenuecat_event_timestamp_ms",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -817,21 +789,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "top_up_credits_rc_txn_id_idx": {
-          "name": "top_up_credits_rc_txn_id_idx",
-          "columns": [
-            {
-              "expression": "revenuecat_transaction_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
@@ -840,107 +797,6 @@
           "tableFrom": "top_up_credits",
           "tableTo": "subscriptions",
           "columnsFrom": ["subscription_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "top_up_credits_remaining_non_negative": {
-          "name": "top_up_credits_remaining_non_negative",
-          "value": "\"top_up_credits\".\"remaining\" >= 0"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1303,20 +1159,9 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "family_links_parent_child_unique": {
-          "name": "family_links_parent_child_unique",
-          "nullsNotDistinct": false,
-          "columns": ["parent_profile_id", "child_profile_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "family_links_no_self_link": {
-          "name": "family_links_no_self_link",
-          "value": "\"family_links\".\"parent_profile_id\" != \"family_links\".\"child_profile_id\""
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.profiles": {
@@ -1347,17 +1192,19 @@
           "primaryKey": false,
           "notNull": false
         },
-        "birth_year": {
-          "name": "birth_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "birth_year_set_by": {
-          "name": "birth_year_set_by",
-          "type": "uuid",
+        "birth_date": {
+          "name": "birth_date",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "persona_type": {
+          "name": "persona_type",
+          "type": "persona_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LEARNER'"
         },
         "location": {
           "name": "location",
@@ -1368,13 +1215,6 @@
         },
         "is_owner": {
           "name": "is_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "has_premium_llm": {
-          "name": "has_premium_llm",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -1418,97 +1258,6 @@
           "tableFrom": "profiles",
           "tableTo": "accounts",
           "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "profiles_birth_year_set_by_profiles_id_fk": {
-          "name": "profiles_birth_year_set_by_profiles_id_fk",
-          "tableFrom": "profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["birth_year_set_by"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.book_suggestions": {
-      "name": "book_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "picked_at": {
-          "name": "picked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "book_suggestions_subject_id_idx": {
-          "name": "book_suggestions_subject_id_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "book_suggestions_subject_id_subjects_id_fk": {
-          "name": "book_suggestions_subject_id_subjects_id_fk",
-          "tableFrom": "book_suggestions",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1565,29 +1314,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curricula_subject_version_idx": {
-          "name": "curricula_subject_version_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curricula_subject_id_subjects_id_fk": {
           "name": "curricula_subject_id_subjects_id_fk",
@@ -1696,108 +1423,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.curriculum_books": {
-      "name": "curriculum_books",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sort_order": {
-          "name": "sort_order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topics_generated": {
-          "name": "topics_generated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "curriculum_books_subject_id_subjects_id_fk": {
-          "name": "curriculum_books_subject_id_subjects_id_fk",
-          "tableFrom": "curriculum_books",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.curriculum_topics": {
       "name": "curriculum_topics",
       "schema": "",
@@ -1854,62 +1479,12 @@
           "primaryKey": false,
           "notNull": true
         },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "chapter": {
-          "name": "chapter",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "skipped": {
           "name": "skipped",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
           "default": false
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cefr_sublevel": {
-          "name": "cefr_sublevel",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_word_count": {
-          "name": "target_word_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_chunk_count": {
-          "name": "target_chunk_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "filed_from": {
-          "name": "filed_from",
-          "type": "filed_from",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pre_generated'"
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -1926,50 +1501,13 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
           "tableFrom": "curriculum_topics",
           "tableTo": "curricula",
           "columnsFrom": ["curriculum_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "curriculum_topics_book_id_curriculum_books_id_fk": {
-          "name": "curriculum_topics_book_id_curriculum_books_id_fk",
-          "tableFrom": "curriculum_topics",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2017,20 +1555,6 @@
           "notNull": true,
           "default": "'active'"
         },
-        "pedagogy_mode": {
-          "name": "pedagogy_mode",
-          "type": "pedagogy_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'socratic'"
-        },
-        "language_code": {
-          "name": "language_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2044,18 +1568,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "urgency_boost_until": {
-          "name": "urgency_boost_until",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "urgency_boost_reason": {
-          "name": "urgency_boost_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
@@ -2081,133 +1593,6 @@
           "tableFrom": "subjects",
           "tableTo": "profiles",
           "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_connections": {
-      "name": "topic_connections",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_a_id": {
-          "name": "topic_a_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topic_b_id": {
-          "name": "topic_b_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_connections_topic_a_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_a_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_a_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_connections_topic_b_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_b_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_b_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_suggestions": {
-      "name": "topic_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "used_at": {
-          "name": "used_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "topic_suggestions_book_id_idx": {
-          "name": "topic_suggestions_book_id_idx",
-          "columns": [
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "topic_suggestions_book_id_curriculum_books_id_fk": {
-          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
-          "tableFrom": "topic_suggestions",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2260,13 +1645,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "input_mode": {
-          "name": "input_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text'"
         },
         "status": {
           "name": "status",
@@ -2328,12 +1706,6 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
-        },
-        "raw_input": {
-          "name": "raw_input",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3090,13 +2462,6 @@
           "notNull": true,
           "default": false
         },
-        "weekly_progress_push": {
-          "name": "weekly_progress_push",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
         "push_enabled": {
           "name": "push_enabled",
           "type": "boolean",
@@ -3366,933 +2731,6 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
-    },
-    "public.milestones": {
-      "name": "milestones",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "milestone_type": {
-          "name": "milestone_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "threshold": {
-          "name": "threshold",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "celebrated_at": {
-          "name": "celebrated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "milestones_scope_uq": {
-          "name": "milestones_scope_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "milestone_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "threshold",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "milestones_profile_created_idx": {
-          "name": "milestones_profile_created_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "milestones_profile_id_profiles_id_fk": {
-          "name": "milestones_profile_id_profiles_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_subject_id_subjects_id_fk": {
-          "name": "milestones_subject_id_subjects_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_book_id_curriculum_books_id_fk": {
-          "name": "milestones_book_id_curriculum_books_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.monthly_reports": {
-      "name": "monthly_reports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "child_profile_id": {
-          "name": "child_profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_month": {
-          "name": "report_month",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_data": {
-          "name": "report_data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "viewed_at": {
-          "name": "viewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "monthly_reports_parent_child_month_uq": {
-          "name": "monthly_reports_parent_child_month_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "monthly_reports_child_month_idx": {
-          "name": "monthly_reports_child_month_idx",
-          "columns": [
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "monthly_reports_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "monthly_reports_child_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_child_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["child_profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.progress_snapshots": {
-      "name": "progress_snapshots",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "snapshot_date": {
-          "name": "snapshot_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "progress_snapshots_profile_date_uq": {
-          "name": "progress_snapshots_profile_date_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "progress_snapshots_profile_date_idx": {
-          "name": "progress_snapshots_profile_date_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "progress_snapshots_profile_id_profiles_id_fk": {
-          "name": "progress_snapshots_profile_id_profiles_id_fk",
-          "tableFrom": "progress_snapshots",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary": {
-      "name": "vocabulary",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term": {
-          "name": "term",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term_normalized": {
-          "name": "term_normalized",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "translation": {
-          "name": "translation",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "vocab_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'word'"
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "milestone_id": {
-          "name": "milestone_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mastered": {
-          "name": "mastered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocabulary_profile_subject_idx": {
-          "name": "vocabulary_profile_subject_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_profile_id_profiles_id_fk": {
-          "name": "vocabulary_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_subject_id_subjects_id_fk": {
-          "name": "vocabulary_subject_id_subjects_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_milestone_id_curriculum_topics_id_fk": {
-          "name": "vocabulary_milestone_id_curriculum_topics_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["milestone_id"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocabulary_profile_subject_term_unique": {
-          "name": "vocabulary_profile_subject_term_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id", "term_normalized"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary_retention_cards": {
-      "name": "vocabulary_retention_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "vocabulary_id": {
-          "name": "vocabulary_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ease_factor": {
-          "name": "ease_factor",
-          "type": "numeric(4, 2)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2.50'"
-        },
-        "interval_days": {
-          "name": "interval_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "repetitions": {
-          "name": "repetitions",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_reviewed_at": {
-          "name": "last_reviewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "next_review_at": {
-          "name": "next_review_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "failure_count": {
-          "name": "failure_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "consecutive_successes": {
-          "name": "consecutive_successes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocab_retention_cards_review_idx": {
-          "name": "vocab_retention_cards_review_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "next_review_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_retention_cards_profile_id_profiles_id_fk": {
-          "name": "vocabulary_retention_cards_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk": {
-          "name": "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "vocabulary",
-          "columnsFrom": ["vocabulary_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocab_retention_cards_vocabulary_unique": {
-          "name": "vocab_retention_cards_vocabulary_unique",
-          "nullsNotDistinct": false,
-          "columns": ["vocabulary_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_notes": {
-      "name": "topic_notes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_notes_topic_id_curriculum_topics_id_fk": {
-          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_notes_profile_id_profiles_id_fk": {
-          "name": "topic_notes_profile_id_profiles_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.learning_profiles": {
-      "name": "learning_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "learning_style": {
-          "name": "learning_style",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interests": {
-          "name": "interests",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "strengths": {
-          "name": "strengths",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "struggles": {
-          "name": "struggles",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "communication_notes": {
-          "name": "communication_notes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "suppressed_inferences": {
-          "name": "suppressed_inferences",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "interest_timestamps": {
-          "name": "interest_timestamps",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "effectiveness_session_count": {
-          "name": "effectiveness_session_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "memory_enabled": {
-          "name": "memory_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "memory_consent_status": {
-          "name": "memory_consent_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "consent_prompt_dismissed_at": {
-          "name": "consent_prompt_dismissed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memory_collection_enabled": {
-          "name": "memory_collection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "memory_injection_enabled": {
-          "name": "memory_injection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "version": {
-          "name": "version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "learning_profiles_profile_id_idx": {
-          "name": "learning_profiles_profile_id_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "learning_profiles_profile_id_profiles_id_fk": {
-          "name": "learning_profiles_profile_id_profiles_id_fk",
-          "tableFrom": "learning_profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "learning_profiles_profile_id_unique": {
-          "name": "learning_profiles_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4341,11 +2779,6 @@
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
     },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
-    },
     "public.consent_status": {
       "name": "consent_status",
       "schema": "public",
@@ -4366,20 +2799,15 @@
       "schema": "public",
       "values": ["EU", "US", "OTHER"]
     },
+    "public.persona_type": {
+      "name": "persona_type",
+      "schema": "public",
+      "values": ["TEEN", "LEARNER", "PARENT"]
+    },
     "public.curriculum_topic_source": {
       "name": "curriculum_topic_source",
       "schema": "public",
       "values": ["generated", "user"]
-    },
-    "public.filed_from": {
-      "name": "filed_from",
-      "schema": "public",
-      "values": ["pre_generated", "session_filing", "freeform_filing"]
-    },
-    "public.pedagogy_mode": {
-      "name": "pedagogy_mode",
-      "schema": "public",
-      "values": ["socratic", "four_strands"]
     },
     "public.subject_status": {
       "name": "subject_status",
@@ -4458,20 +2886,8 @@
         "consent_reminder",
         "consent_warning",
         "consent_expired",
-        "subscribe_request",
-        "recall_nudge",
-        "weekly_progress",
-        "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "subscribe_request"
       ]
-    },
-    "public.vocab_type": {
-      "name": "vocab_type",
-      "schema": "public",
-      "values": ["word", "chunk"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0008_language_learning_schema_snapshot.json
+++ b/apps/api/drizzle/meta/0008_language_learning_schema_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "d90b9064-cd70-4aa5-979f-8295a28eae12",
+  "prevId": "111aa14b-aac5-481d-82da-75b51b9087c9",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -377,12 +377,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "retention_cards_interval_days_positive": {
-          "name": "retention_cards_interval_days_positive",
-          "value": "\"retention_cards\".\"interval_days\" >= 1"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.teaching_preferences": {
@@ -418,12 +413,6 @@
           "name": "analogy_domain",
           "type": "analogy_domain",
           "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "native_language": {
-          "name": "native_language",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -464,13 +453,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "teaching_preferences_profile_subject_unique": {
-          "name": "teaching_preferences_profile_subject_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -598,12 +581,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "quota_pools_used_this_month_non_negative": {
-          "name": "quota_pools_used_this_month_non_negative",
-          "value": "\"quota_pools\".\"used_this_month\" >= 0"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.subscriptions": {
@@ -688,12 +666,6 @@
         },
         "last_revenuecat_event_id": {
           "name": "last_revenuecat_event_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_revenuecat_event_timestamp_ms": {
-          "name": "last_revenuecat_event_timestamp_ms",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -817,21 +789,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "top_up_credits_rc_txn_id_idx": {
-          "name": "top_up_credits_rc_txn_id_idx",
-          "columns": [
-            {
-              "expression": "revenuecat_transaction_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
@@ -840,107 +797,6 @@
           "tableFrom": "top_up_credits",
           "tableTo": "subscriptions",
           "columnsFrom": ["subscription_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "top_up_credits_remaining_non_negative": {
-          "name": "top_up_credits_remaining_non_negative",
-          "value": "\"top_up_credits\".\"remaining\" >= 0"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1303,20 +1159,9 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "family_links_parent_child_unique": {
-          "name": "family_links_parent_child_unique",
-          "nullsNotDistinct": false,
-          "columns": ["parent_profile_id", "child_profile_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "family_links_no_self_link": {
-          "name": "family_links_no_self_link",
-          "value": "\"family_links\".\"parent_profile_id\" != \"family_links\".\"child_profile_id\""
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.profiles": {
@@ -1347,17 +1192,19 @@
           "primaryKey": false,
           "notNull": false
         },
-        "birth_year": {
-          "name": "birth_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "birth_year_set_by": {
-          "name": "birth_year_set_by",
-          "type": "uuid",
+        "birth_date": {
+          "name": "birth_date",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "persona_type": {
+          "name": "persona_type",
+          "type": "persona_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LEARNER'"
         },
         "location": {
           "name": "location",
@@ -1368,13 +1215,6 @@
         },
         "is_owner": {
           "name": "is_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "has_premium_llm": {
-          "name": "has_premium_llm",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -1418,97 +1258,6 @@
           "tableFrom": "profiles",
           "tableTo": "accounts",
           "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "profiles_birth_year_set_by_profiles_id_fk": {
-          "name": "profiles_birth_year_set_by_profiles_id_fk",
-          "tableFrom": "profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["birth_year_set_by"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.book_suggestions": {
-      "name": "book_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "picked_at": {
-          "name": "picked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "book_suggestions_subject_id_idx": {
-          "name": "book_suggestions_subject_id_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "book_suggestions_subject_id_subjects_id_fk": {
-          "name": "book_suggestions_subject_id_subjects_id_fk",
-          "tableFrom": "book_suggestions",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1565,29 +1314,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curricula_subject_version_idx": {
-          "name": "curricula_subject_version_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curricula_subject_id_subjects_id_fk": {
           "name": "curricula_subject_id_subjects_id_fk",
@@ -1696,108 +1423,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.curriculum_books": {
-      "name": "curriculum_books",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sort_order": {
-          "name": "sort_order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topics_generated": {
-          "name": "topics_generated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "curriculum_books_subject_id_subjects_id_fk": {
-          "name": "curriculum_books_subject_id_subjects_id_fk",
-          "tableFrom": "curriculum_books",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.curriculum_topics": {
       "name": "curriculum_topics",
       "schema": "",
@@ -1854,62 +1479,12 @@
           "primaryKey": false,
           "notNull": true
         },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "chapter": {
-          "name": "chapter",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "skipped": {
           "name": "skipped",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
           "default": false
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cefr_sublevel": {
-          "name": "cefr_sublevel",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_word_count": {
-          "name": "target_word_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_chunk_count": {
-          "name": "target_chunk_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "filed_from": {
-          "name": "filed_from",
-          "type": "filed_from",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pre_generated'"
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -1926,50 +1501,13 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
           "tableFrom": "curriculum_topics",
           "tableTo": "curricula",
           "columnsFrom": ["curriculum_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "curriculum_topics_book_id_curriculum_books_id_fk": {
-          "name": "curriculum_topics_book_id_curriculum_books_id_fk",
-          "tableFrom": "curriculum_topics",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2017,20 +1555,6 @@
           "notNull": true,
           "default": "'active'"
         },
-        "pedagogy_mode": {
-          "name": "pedagogy_mode",
-          "type": "pedagogy_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'socratic'"
-        },
-        "language_code": {
-          "name": "language_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2044,18 +1568,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "urgency_boost_until": {
-          "name": "urgency_boost_until",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "urgency_boost_reason": {
-          "name": "urgency_boost_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
@@ -2081,133 +1593,6 @@
           "tableFrom": "subjects",
           "tableTo": "profiles",
           "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_connections": {
-      "name": "topic_connections",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_a_id": {
-          "name": "topic_a_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topic_b_id": {
-          "name": "topic_b_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_connections_topic_a_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_a_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_a_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_connections_topic_b_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_b_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_b_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_suggestions": {
-      "name": "topic_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "used_at": {
-          "name": "used_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "topic_suggestions_book_id_idx": {
-          "name": "topic_suggestions_book_id_idx",
-          "columns": [
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "topic_suggestions_book_id_curriculum_books_id_fk": {
-          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
-          "tableFrom": "topic_suggestions",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2260,13 +1645,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "input_mode": {
-          "name": "input_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text'"
         },
         "status": {
           "name": "status",
@@ -2328,12 +1706,6 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
-        },
-        "raw_input": {
-          "name": "raw_input",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3090,13 +2462,6 @@
           "notNull": true,
           "default": false
         },
-        "weekly_progress_push": {
-          "name": "weekly_progress_push",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
         "push_enabled": {
           "name": "push_enabled",
           "type": "boolean",
@@ -3366,933 +2731,6 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
-    },
-    "public.milestones": {
-      "name": "milestones",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "milestone_type": {
-          "name": "milestone_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "threshold": {
-          "name": "threshold",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "celebrated_at": {
-          "name": "celebrated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "milestones_scope_uq": {
-          "name": "milestones_scope_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "milestone_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "threshold",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "milestones_profile_created_idx": {
-          "name": "milestones_profile_created_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "milestones_profile_id_profiles_id_fk": {
-          "name": "milestones_profile_id_profiles_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_subject_id_subjects_id_fk": {
-          "name": "milestones_subject_id_subjects_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_book_id_curriculum_books_id_fk": {
-          "name": "milestones_book_id_curriculum_books_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.monthly_reports": {
-      "name": "monthly_reports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "child_profile_id": {
-          "name": "child_profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_month": {
-          "name": "report_month",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_data": {
-          "name": "report_data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "viewed_at": {
-          "name": "viewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "monthly_reports_parent_child_month_uq": {
-          "name": "monthly_reports_parent_child_month_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "monthly_reports_child_month_idx": {
-          "name": "monthly_reports_child_month_idx",
-          "columns": [
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "monthly_reports_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "monthly_reports_child_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_child_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["child_profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.progress_snapshots": {
-      "name": "progress_snapshots",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "snapshot_date": {
-          "name": "snapshot_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "progress_snapshots_profile_date_uq": {
-          "name": "progress_snapshots_profile_date_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "progress_snapshots_profile_date_idx": {
-          "name": "progress_snapshots_profile_date_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "progress_snapshots_profile_id_profiles_id_fk": {
-          "name": "progress_snapshots_profile_id_profiles_id_fk",
-          "tableFrom": "progress_snapshots",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary": {
-      "name": "vocabulary",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term": {
-          "name": "term",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term_normalized": {
-          "name": "term_normalized",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "translation": {
-          "name": "translation",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "vocab_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'word'"
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "milestone_id": {
-          "name": "milestone_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mastered": {
-          "name": "mastered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocabulary_profile_subject_idx": {
-          "name": "vocabulary_profile_subject_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_profile_id_profiles_id_fk": {
-          "name": "vocabulary_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_subject_id_subjects_id_fk": {
-          "name": "vocabulary_subject_id_subjects_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_milestone_id_curriculum_topics_id_fk": {
-          "name": "vocabulary_milestone_id_curriculum_topics_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["milestone_id"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocabulary_profile_subject_term_unique": {
-          "name": "vocabulary_profile_subject_term_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id", "term_normalized"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary_retention_cards": {
-      "name": "vocabulary_retention_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "vocabulary_id": {
-          "name": "vocabulary_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ease_factor": {
-          "name": "ease_factor",
-          "type": "numeric(4, 2)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2.50'"
-        },
-        "interval_days": {
-          "name": "interval_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "repetitions": {
-          "name": "repetitions",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_reviewed_at": {
-          "name": "last_reviewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "next_review_at": {
-          "name": "next_review_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "failure_count": {
-          "name": "failure_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "consecutive_successes": {
-          "name": "consecutive_successes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocab_retention_cards_review_idx": {
-          "name": "vocab_retention_cards_review_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "next_review_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_retention_cards_profile_id_profiles_id_fk": {
-          "name": "vocabulary_retention_cards_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk": {
-          "name": "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "vocabulary",
-          "columnsFrom": ["vocabulary_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocab_retention_cards_vocabulary_unique": {
-          "name": "vocab_retention_cards_vocabulary_unique",
-          "nullsNotDistinct": false,
-          "columns": ["vocabulary_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_notes": {
-      "name": "topic_notes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_notes_topic_id_curriculum_topics_id_fk": {
-          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_notes_profile_id_profiles_id_fk": {
-          "name": "topic_notes_profile_id_profiles_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.learning_profiles": {
-      "name": "learning_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "learning_style": {
-          "name": "learning_style",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interests": {
-          "name": "interests",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "strengths": {
-          "name": "strengths",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "struggles": {
-          "name": "struggles",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "communication_notes": {
-          "name": "communication_notes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "suppressed_inferences": {
-          "name": "suppressed_inferences",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "interest_timestamps": {
-          "name": "interest_timestamps",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "effectiveness_session_count": {
-          "name": "effectiveness_session_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "memory_enabled": {
-          "name": "memory_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "memory_consent_status": {
-          "name": "memory_consent_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "consent_prompt_dismissed_at": {
-          "name": "consent_prompt_dismissed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memory_collection_enabled": {
-          "name": "memory_collection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "memory_injection_enabled": {
-          "name": "memory_injection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "version": {
-          "name": "version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "learning_profiles_profile_id_idx": {
-          "name": "learning_profiles_profile_id_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "learning_profiles_profile_id_profiles_id_fk": {
-          "name": "learning_profiles_profile_id_profiles_id_fk",
-          "tableFrom": "learning_profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "learning_profiles_profile_id_unique": {
-          "name": "learning_profiles_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4341,11 +2779,6 @@
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
     },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
-    },
     "public.consent_status": {
       "name": "consent_status",
       "schema": "public",
@@ -4366,20 +2799,15 @@
       "schema": "public",
       "values": ["EU", "US", "OTHER"]
     },
+    "public.persona_type": {
+      "name": "persona_type",
+      "schema": "public",
+      "values": ["TEEN", "LEARNER", "PARENT"]
+    },
     "public.curriculum_topic_source": {
       "name": "curriculum_topic_source",
       "schema": "public",
       "values": ["generated", "user"]
-    },
-    "public.filed_from": {
-      "name": "filed_from",
-      "schema": "public",
-      "values": ["pre_generated", "session_filing", "freeform_filing"]
-    },
-    "public.pedagogy_mode": {
-      "name": "pedagogy_mode",
-      "schema": "public",
-      "values": ["socratic", "four_strands"]
     },
     "public.subject_status": {
       "name": "subject_status",
@@ -4458,20 +2886,8 @@
         "consent_reminder",
         "consent_warning",
         "consent_expired",
-        "subscribe_request",
-        "recall_nudge",
-        "weekly_progress",
-        "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "subscribe_request"
       ]
-    },
-    "public.vocab_type": {
-      "name": "vocab_type",
-      "schema": "public",
-      "values": ["word", "chunk"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0009_backfill_owner_profiles_snapshot.json
+++ b/apps/api/drizzle/meta/0009_backfill_owner_profiles_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "619d12c2-1018-493d-99ca-c391d23b2082",
+  "prevId": "d90b9064-cd70-4aa5-979f-8295a28eae12",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -377,12 +377,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "retention_cards_interval_days_positive": {
-          "name": "retention_cards_interval_days_positive",
-          "value": "\"retention_cards\".\"interval_days\" >= 1"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.teaching_preferences": {
@@ -418,12 +413,6 @@
           "name": "analogy_domain",
           "type": "analogy_domain",
           "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "native_language": {
-          "name": "native_language",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -464,13 +453,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "teaching_preferences_profile_subject_unique": {
-          "name": "teaching_preferences_profile_subject_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -598,12 +581,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "quota_pools_used_this_month_non_negative": {
-          "name": "quota_pools_used_this_month_non_negative",
-          "value": "\"quota_pools\".\"used_this_month\" >= 0"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.subscriptions": {
@@ -688,12 +666,6 @@
         },
         "last_revenuecat_event_id": {
           "name": "last_revenuecat_event_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_revenuecat_event_timestamp_ms": {
-          "name": "last_revenuecat_event_timestamp_ms",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -817,21 +789,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "top_up_credits_rc_txn_id_idx": {
-          "name": "top_up_credits_rc_txn_id_idx",
-          "columns": [
-            {
-              "expression": "revenuecat_transaction_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
@@ -840,107 +797,6 @@
           "tableFrom": "top_up_credits",
           "tableTo": "subscriptions",
           "columnsFrom": ["subscription_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "top_up_credits_remaining_non_negative": {
-          "name": "top_up_credits_remaining_non_negative",
-          "value": "\"top_up_credits\".\"remaining\" >= 0"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1303,20 +1159,9 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "family_links_parent_child_unique": {
-          "name": "family_links_parent_child_unique",
-          "nullsNotDistinct": false,
-          "columns": ["parent_profile_id", "child_profile_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "family_links_no_self_link": {
-          "name": "family_links_no_self_link",
-          "value": "\"family_links\".\"parent_profile_id\" != \"family_links\".\"child_profile_id\""
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.profiles": {
@@ -1347,17 +1192,19 @@
           "primaryKey": false,
           "notNull": false
         },
-        "birth_year": {
-          "name": "birth_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "birth_year_set_by": {
-          "name": "birth_year_set_by",
-          "type": "uuid",
+        "birth_date": {
+          "name": "birth_date",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "persona_type": {
+          "name": "persona_type",
+          "type": "persona_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LEARNER'"
         },
         "location": {
           "name": "location",
@@ -1368,13 +1215,6 @@
         },
         "is_owner": {
           "name": "is_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "has_premium_llm": {
-          "name": "has_premium_llm",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -1418,97 +1258,6 @@
           "tableFrom": "profiles",
           "tableTo": "accounts",
           "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "profiles_birth_year_set_by_profiles_id_fk": {
-          "name": "profiles_birth_year_set_by_profiles_id_fk",
-          "tableFrom": "profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["birth_year_set_by"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.book_suggestions": {
-      "name": "book_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "picked_at": {
-          "name": "picked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "book_suggestions_subject_id_idx": {
-          "name": "book_suggestions_subject_id_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "book_suggestions_subject_id_subjects_id_fk": {
-          "name": "book_suggestions_subject_id_subjects_id_fk",
-          "tableFrom": "book_suggestions",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1565,29 +1314,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curricula_subject_version_idx": {
-          "name": "curricula_subject_version_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curricula_subject_id_subjects_id_fk": {
           "name": "curricula_subject_id_subjects_id_fk",
@@ -1696,108 +1423,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.curriculum_books": {
-      "name": "curriculum_books",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sort_order": {
-          "name": "sort_order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topics_generated": {
-          "name": "topics_generated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "curriculum_books_subject_id_subjects_id_fk": {
-          "name": "curriculum_books_subject_id_subjects_id_fk",
-          "tableFrom": "curriculum_books",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.curriculum_topics": {
       "name": "curriculum_topics",
       "schema": "",
@@ -1854,62 +1479,12 @@
           "primaryKey": false,
           "notNull": true
         },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "chapter": {
-          "name": "chapter",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "skipped": {
           "name": "skipped",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
           "default": false
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cefr_sublevel": {
-          "name": "cefr_sublevel",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_word_count": {
-          "name": "target_word_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_chunk_count": {
-          "name": "target_chunk_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "filed_from": {
-          "name": "filed_from",
-          "type": "filed_from",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pre_generated'"
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -1926,50 +1501,13 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
           "tableFrom": "curriculum_topics",
           "tableTo": "curricula",
           "columnsFrom": ["curriculum_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "curriculum_topics_book_id_curriculum_books_id_fk": {
-          "name": "curriculum_topics_book_id_curriculum_books_id_fk",
-          "tableFrom": "curriculum_topics",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2017,20 +1555,6 @@
           "notNull": true,
           "default": "'active'"
         },
-        "pedagogy_mode": {
-          "name": "pedagogy_mode",
-          "type": "pedagogy_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'socratic'"
-        },
-        "language_code": {
-          "name": "language_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2044,18 +1568,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "urgency_boost_until": {
-          "name": "urgency_boost_until",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "urgency_boost_reason": {
-          "name": "urgency_boost_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
@@ -2081,133 +1593,6 @@
           "tableFrom": "subjects",
           "tableTo": "profiles",
           "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_connections": {
-      "name": "topic_connections",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_a_id": {
-          "name": "topic_a_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topic_b_id": {
-          "name": "topic_b_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_connections_topic_a_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_a_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_a_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_connections_topic_b_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_b_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_b_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_suggestions": {
-      "name": "topic_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "used_at": {
-          "name": "used_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "topic_suggestions_book_id_idx": {
-          "name": "topic_suggestions_book_id_idx",
-          "columns": [
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "topic_suggestions_book_id_curriculum_books_id_fk": {
-          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
-          "tableFrom": "topic_suggestions",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2260,13 +1645,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "input_mode": {
-          "name": "input_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text'"
         },
         "status": {
           "name": "status",
@@ -2328,12 +1706,6 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
-        },
-        "raw_input": {
-          "name": "raw_input",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3090,13 +2462,6 @@
           "notNull": true,
           "default": false
         },
-        "weekly_progress_push": {
-          "name": "weekly_progress_push",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
         "push_enabled": {
           "name": "push_enabled",
           "type": "boolean",
@@ -3366,933 +2731,6 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
-    },
-    "public.milestones": {
-      "name": "milestones",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "milestone_type": {
-          "name": "milestone_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "threshold": {
-          "name": "threshold",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "celebrated_at": {
-          "name": "celebrated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "milestones_scope_uq": {
-          "name": "milestones_scope_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "milestone_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "threshold",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "milestones_profile_created_idx": {
-          "name": "milestones_profile_created_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "milestones_profile_id_profiles_id_fk": {
-          "name": "milestones_profile_id_profiles_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_subject_id_subjects_id_fk": {
-          "name": "milestones_subject_id_subjects_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_book_id_curriculum_books_id_fk": {
-          "name": "milestones_book_id_curriculum_books_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.monthly_reports": {
-      "name": "monthly_reports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "child_profile_id": {
-          "name": "child_profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_month": {
-          "name": "report_month",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_data": {
-          "name": "report_data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "viewed_at": {
-          "name": "viewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "monthly_reports_parent_child_month_uq": {
-          "name": "monthly_reports_parent_child_month_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "monthly_reports_child_month_idx": {
-          "name": "monthly_reports_child_month_idx",
-          "columns": [
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "monthly_reports_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "monthly_reports_child_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_child_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["child_profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.progress_snapshots": {
-      "name": "progress_snapshots",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "snapshot_date": {
-          "name": "snapshot_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "progress_snapshots_profile_date_uq": {
-          "name": "progress_snapshots_profile_date_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "progress_snapshots_profile_date_idx": {
-          "name": "progress_snapshots_profile_date_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "progress_snapshots_profile_id_profiles_id_fk": {
-          "name": "progress_snapshots_profile_id_profiles_id_fk",
-          "tableFrom": "progress_snapshots",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary": {
-      "name": "vocabulary",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term": {
-          "name": "term",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term_normalized": {
-          "name": "term_normalized",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "translation": {
-          "name": "translation",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "vocab_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'word'"
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "milestone_id": {
-          "name": "milestone_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mastered": {
-          "name": "mastered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocabulary_profile_subject_idx": {
-          "name": "vocabulary_profile_subject_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_profile_id_profiles_id_fk": {
-          "name": "vocabulary_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_subject_id_subjects_id_fk": {
-          "name": "vocabulary_subject_id_subjects_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_milestone_id_curriculum_topics_id_fk": {
-          "name": "vocabulary_milestone_id_curriculum_topics_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["milestone_id"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocabulary_profile_subject_term_unique": {
-          "name": "vocabulary_profile_subject_term_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id", "term_normalized"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary_retention_cards": {
-      "name": "vocabulary_retention_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "vocabulary_id": {
-          "name": "vocabulary_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ease_factor": {
-          "name": "ease_factor",
-          "type": "numeric(4, 2)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2.50'"
-        },
-        "interval_days": {
-          "name": "interval_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "repetitions": {
-          "name": "repetitions",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_reviewed_at": {
-          "name": "last_reviewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "next_review_at": {
-          "name": "next_review_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "failure_count": {
-          "name": "failure_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "consecutive_successes": {
-          "name": "consecutive_successes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocab_retention_cards_review_idx": {
-          "name": "vocab_retention_cards_review_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "next_review_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_retention_cards_profile_id_profiles_id_fk": {
-          "name": "vocabulary_retention_cards_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk": {
-          "name": "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "vocabulary",
-          "columnsFrom": ["vocabulary_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocab_retention_cards_vocabulary_unique": {
-          "name": "vocab_retention_cards_vocabulary_unique",
-          "nullsNotDistinct": false,
-          "columns": ["vocabulary_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_notes": {
-      "name": "topic_notes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_notes_topic_id_curriculum_topics_id_fk": {
-          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_notes_profile_id_profiles_id_fk": {
-          "name": "topic_notes_profile_id_profiles_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.learning_profiles": {
-      "name": "learning_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "learning_style": {
-          "name": "learning_style",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interests": {
-          "name": "interests",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "strengths": {
-          "name": "strengths",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "struggles": {
-          "name": "struggles",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "communication_notes": {
-          "name": "communication_notes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "suppressed_inferences": {
-          "name": "suppressed_inferences",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "interest_timestamps": {
-          "name": "interest_timestamps",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "effectiveness_session_count": {
-          "name": "effectiveness_session_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "memory_enabled": {
-          "name": "memory_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "memory_consent_status": {
-          "name": "memory_consent_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "consent_prompt_dismissed_at": {
-          "name": "consent_prompt_dismissed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memory_collection_enabled": {
-          "name": "memory_collection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "memory_injection_enabled": {
-          "name": "memory_injection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "version": {
-          "name": "version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "learning_profiles_profile_id_idx": {
-          "name": "learning_profiles_profile_id_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "learning_profiles_profile_id_profiles_id_fk": {
-          "name": "learning_profiles_profile_id_profiles_id_fk",
-          "tableFrom": "learning_profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "learning_profiles_profile_id_unique": {
-          "name": "learning_profiles_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4341,11 +2779,6 @@
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
     },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
-    },
     "public.consent_status": {
       "name": "consent_status",
       "schema": "public",
@@ -4366,20 +2799,15 @@
       "schema": "public",
       "values": ["EU", "US", "OTHER"]
     },
+    "public.persona_type": {
+      "name": "persona_type",
+      "schema": "public",
+      "values": ["TEEN", "LEARNER", "PARENT"]
+    },
     "public.curriculum_topic_source": {
       "name": "curriculum_topic_source",
       "schema": "public",
       "values": ["generated", "user"]
-    },
-    "public.filed_from": {
-      "name": "filed_from",
-      "schema": "public",
-      "values": ["pre_generated", "session_filing", "freeform_filing"]
-    },
-    "public.pedagogy_mode": {
-      "name": "pedagogy_mode",
-      "schema": "public",
-      "values": ["socratic", "four_strands"]
     },
     "public.subject_status": {
       "name": "subject_status",
@@ -4458,20 +2886,8 @@
         "consent_reminder",
         "consent_warning",
         "consent_expired",
-        "subscribe_request",
-        "recall_nudge",
-        "weekly_progress",
-        "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "subscribe_request"
       ]
-    },
-    "public.vocab_type": {
-      "name": "vocab_type",
-      "schema": "public",
-      "values": ["word", "chunk"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0010_missing_schema_catchup_snapshot.json
+++ b/apps/api/drizzle/meta/0010_missing_schema_catchup_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "499d064f-7f05-4ed9-b0bf-1bb1e974c570",
+  "prevId": "619d12c2-1018-493d-99ca-c391d23b2082",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -377,12 +377,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "retention_cards_interval_days_positive": {
-          "name": "retention_cards_interval_days_positive",
-          "value": "\"retention_cards\".\"interval_days\" >= 1"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.teaching_preferences": {
@@ -418,12 +413,6 @@
           "name": "analogy_domain",
           "type": "analogy_domain",
           "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "native_language": {
-          "name": "native_language",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -464,13 +453,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "teaching_preferences_profile_subject_unique": {
-          "name": "teaching_preferences_profile_subject_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -598,12 +581,7 @@
         }
       },
       "policies": {},
-      "checkConstraints": {
-        "quota_pools_used_this_month_non_negative": {
-          "name": "quota_pools_used_this_month_non_negative",
-          "value": "\"quota_pools\".\"used_this_month\" >= 0"
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.subscriptions": {
@@ -688,12 +666,6 @@
         },
         "last_revenuecat_event_id": {
           "name": "last_revenuecat_event_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_revenuecat_event_timestamp_ms": {
-          "name": "last_revenuecat_event_timestamp_ms",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -817,21 +789,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "top_up_credits_rc_txn_id_idx": {
-          "name": "top_up_credits_rc_txn_id_idx",
-          "columns": [
-            {
-              "expression": "revenuecat_transaction_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
@@ -840,107 +797,6 @@
           "tableFrom": "top_up_credits",
           "tableTo": "subscriptions",
           "columnsFrom": ["subscription_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {
-        "top_up_credits_remaining_non_negative": {
-          "name": "top_up_credits_remaining_non_negative",
-          "value": "\"top_up_credits\".\"remaining\" >= 0"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1303,20 +1159,9 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "family_links_parent_child_unique": {
-          "name": "family_links_parent_child_unique",
-          "nullsNotDistinct": false,
-          "columns": ["parent_profile_id", "child_profile_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {
-        "family_links_no_self_link": {
-          "name": "family_links_no_self_link",
-          "value": "\"family_links\".\"parent_profile_id\" != \"family_links\".\"child_profile_id\""
-        }
-      },
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.profiles": {
@@ -1347,17 +1192,19 @@
           "primaryKey": false,
           "notNull": false
         },
-        "birth_year": {
-          "name": "birth_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "birth_year_set_by": {
-          "name": "birth_year_set_by",
-          "type": "uuid",
+        "birth_date": {
+          "name": "birth_date",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "persona_type": {
+          "name": "persona_type",
+          "type": "persona_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LEARNER'"
         },
         "location": {
           "name": "location",
@@ -1368,13 +1215,6 @@
         },
         "is_owner": {
           "name": "is_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "has_premium_llm": {
-          "name": "has_premium_llm",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -1418,97 +1258,6 @@
           "tableFrom": "profiles",
           "tableTo": "accounts",
           "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "profiles_birth_year_set_by_profiles_id_fk": {
-          "name": "profiles_birth_year_set_by_profiles_id_fk",
-          "tableFrom": "profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["birth_year_set_by"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.book_suggestions": {
-      "name": "book_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "picked_at": {
-          "name": "picked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "book_suggestions_subject_id_idx": {
-          "name": "book_suggestions_subject_id_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "book_suggestions_subject_id_subjects_id_fk": {
-          "name": "book_suggestions_subject_id_subjects_id_fk",
-          "tableFrom": "book_suggestions",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1565,29 +1314,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curricula_subject_version_idx": {
-          "name": "curricula_subject_version_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curricula_subject_id_subjects_id_fk": {
           "name": "curricula_subject_id_subjects_id_fk",
@@ -1696,108 +1423,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.curriculum_books": {
-      "name": "curriculum_books",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sort_order": {
-          "name": "sort_order",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topics_generated": {
-          "name": "topics_generated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "curriculum_books_subject_id_subjects_id_fk": {
-          "name": "curriculum_books_subject_id_subjects_id_fk",
-          "tableFrom": "curriculum_books",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.curriculum_topics": {
       "name": "curriculum_topics",
       "schema": "",
@@ -1854,62 +1479,12 @@
           "primaryKey": false,
           "notNull": true
         },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "chapter": {
-          "name": "chapter",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "skipped": {
           "name": "skipped",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
           "default": false
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cefr_sublevel": {
-          "name": "cefr_sublevel",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_word_count": {
-          "name": "target_word_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_chunk_count": {
-          "name": "target_chunk_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "filed_from": {
-          "name": "filed_from",
-          "type": "filed_from",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pre_generated'"
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -1926,50 +1501,13 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
           "tableFrom": "curriculum_topics",
           "tableTo": "curricula",
           "columnsFrom": ["curriculum_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "curriculum_topics_book_id_curriculum_books_id_fk": {
-          "name": "curriculum_topics_book_id_curriculum_books_id_fk",
-          "tableFrom": "curriculum_topics",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2017,20 +1555,6 @@
           "notNull": true,
           "default": "'active'"
         },
-        "pedagogy_mode": {
-          "name": "pedagogy_mode",
-          "type": "pedagogy_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'socratic'"
-        },
-        "language_code": {
-          "name": "language_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2044,18 +1568,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "urgency_boost_until": {
-          "name": "urgency_boost_until",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "urgency_boost_reason": {
-          "name": "urgency_boost_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
@@ -2081,133 +1593,6 @@
           "tableFrom": "subjects",
           "tableTo": "profiles",
           "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_connections": {
-      "name": "topic_connections",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_a_id": {
-          "name": "topic_a_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "topic_b_id": {
-          "name": "topic_b_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_connections_topic_a_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_a_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_a_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_connections_topic_b_id_curriculum_topics_id_fk": {
-          "name": "topic_connections_topic_b_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_connections",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_b_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_suggestions": {
-      "name": "topic_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "used_at": {
-          "name": "used_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "topic_suggestions_book_id_idx": {
-          "name": "topic_suggestions_book_id_idx",
-          "columns": [
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "topic_suggestions_book_id_curriculum_books_id_fk": {
-          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
-          "tableFrom": "topic_suggestions",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -2260,13 +1645,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "input_mode": {
-          "name": "input_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'text'"
         },
         "status": {
           "name": "status",
@@ -2328,12 +1706,6 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
-        },
-        "raw_input": {
-          "name": "raw_input",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3090,13 +2462,6 @@
           "notNull": true,
           "default": false
         },
-        "weekly_progress_push": {
-          "name": "weekly_progress_push",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
         "push_enabled": {
           "name": "push_enabled",
           "type": "boolean",
@@ -3366,933 +2731,6 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
-    },
-    "public.milestones": {
-      "name": "milestones",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "milestone_type": {
-          "name": "milestone_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "threshold": {
-          "name": "threshold",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "celebrated_at": {
-          "name": "celebrated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "milestones_scope_uq": {
-          "name": "milestones_scope_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "milestone_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "threshold",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "milestones_profile_created_idx": {
-          "name": "milestones_profile_created_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "milestones_profile_id_profiles_id_fk": {
-          "name": "milestones_profile_id_profiles_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_subject_id_subjects_id_fk": {
-          "name": "milestones_subject_id_subjects_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_book_id_curriculum_books_id_fk": {
-          "name": "milestones_book_id_curriculum_books_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.monthly_reports": {
-      "name": "monthly_reports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "child_profile_id": {
-          "name": "child_profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_month": {
-          "name": "report_month",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_data": {
-          "name": "report_data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "viewed_at": {
-          "name": "viewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "monthly_reports_parent_child_month_uq": {
-          "name": "monthly_reports_parent_child_month_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "monthly_reports_child_month_idx": {
-          "name": "monthly_reports_child_month_idx",
-          "columns": [
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "monthly_reports_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "monthly_reports_child_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_child_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["child_profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.progress_snapshots": {
-      "name": "progress_snapshots",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "snapshot_date": {
-          "name": "snapshot_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "progress_snapshots_profile_date_uq": {
-          "name": "progress_snapshots_profile_date_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "progress_snapshots_profile_date_idx": {
-          "name": "progress_snapshots_profile_date_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "progress_snapshots_profile_id_profiles_id_fk": {
-          "name": "progress_snapshots_profile_id_profiles_id_fk",
-          "tableFrom": "progress_snapshots",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary": {
-      "name": "vocabulary",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term": {
-          "name": "term",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "term_normalized": {
-          "name": "term_normalized",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "translation": {
-          "name": "translation",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "vocab_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'word'"
-        },
-        "cefr_level": {
-          "name": "cefr_level",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "milestone_id": {
-          "name": "milestone_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mastered": {
-          "name": "mastered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocabulary_profile_subject_idx": {
-          "name": "vocabulary_profile_subject_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_profile_id_profiles_id_fk": {
-          "name": "vocabulary_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_subject_id_subjects_id_fk": {
-          "name": "vocabulary_subject_id_subjects_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_milestone_id_curriculum_topics_id_fk": {
-          "name": "vocabulary_milestone_id_curriculum_topics_id_fk",
-          "tableFrom": "vocabulary",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["milestone_id"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocabulary_profile_subject_term_unique": {
-          "name": "vocabulary_profile_subject_term_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id", "subject_id", "term_normalized"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vocabulary_retention_cards": {
-      "name": "vocabulary_retention_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "vocabulary_id": {
-          "name": "vocabulary_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ease_factor": {
-          "name": "ease_factor",
-          "type": "numeric(4, 2)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2.50'"
-        },
-        "interval_days": {
-          "name": "interval_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "repetitions": {
-          "name": "repetitions",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_reviewed_at": {
-          "name": "last_reviewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "next_review_at": {
-          "name": "next_review_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "failure_count": {
-          "name": "failure_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "consecutive_successes": {
-          "name": "consecutive_successes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "vocab_retention_cards_review_idx": {
-          "name": "vocab_retention_cards_review_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "next_review_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vocabulary_retention_cards_profile_id_profiles_id_fk": {
-          "name": "vocabulary_retention_cards_profile_id_profiles_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk": {
-          "name": "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk",
-          "tableFrom": "vocabulary_retention_cards",
-          "tableTo": "vocabulary",
-          "columnsFrom": ["vocabulary_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "vocab_retention_cards_vocabulary_unique": {
-          "name": "vocab_retention_cards_vocabulary_unique",
-          "nullsNotDistinct": false,
-          "columns": ["vocabulary_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.topic_notes": {
-      "name": "topic_notes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_notes_topic_id_curriculum_topics_id_fk": {
-          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_notes_profile_id_profiles_id_fk": {
-          "name": "topic_notes_profile_id_profiles_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.learning_profiles": {
-      "name": "learning_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "learning_style": {
-          "name": "learning_style",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interests": {
-          "name": "interests",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "strengths": {
-          "name": "strengths",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "struggles": {
-          "name": "struggles",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "communication_notes": {
-          "name": "communication_notes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "suppressed_inferences": {
-          "name": "suppressed_inferences",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "interest_timestamps": {
-          "name": "interest_timestamps",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "effectiveness_session_count": {
-          "name": "effectiveness_session_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "memory_enabled": {
-          "name": "memory_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "memory_consent_status": {
-          "name": "memory_consent_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "consent_prompt_dismissed_at": {
-          "name": "consent_prompt_dismissed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memory_collection_enabled": {
-          "name": "memory_collection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "memory_injection_enabled": {
-          "name": "memory_injection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "version": {
-          "name": "version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "learning_profiles_profile_id_idx": {
-          "name": "learning_profiles_profile_id_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "learning_profiles_profile_id_profiles_id_fk": {
-          "name": "learning_profiles_profile_id_profiles_id_fk",
-          "tableFrom": "learning_profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "learning_profiles_profile_id_unique": {
-          "name": "learning_profiles_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4341,11 +2779,6 @@
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
     },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
-    },
     "public.consent_status": {
       "name": "consent_status",
       "schema": "public",
@@ -4366,20 +2799,15 @@
       "schema": "public",
       "values": ["EU", "US", "OTHER"]
     },
+    "public.persona_type": {
+      "name": "persona_type",
+      "schema": "public",
+      "values": ["TEEN", "LEARNER", "PARENT"]
+    },
     "public.curriculum_topic_source": {
       "name": "curriculum_topic_source",
       "schema": "public",
       "values": ["generated", "user"]
-    },
-    "public.filed_from": {
-      "name": "filed_from",
-      "schema": "public",
-      "values": ["pre_generated", "session_filing", "freeform_filing"]
-    },
-    "public.pedagogy_mode": {
-      "name": "pedagogy_mode",
-      "schema": "public",
-      "values": ["socratic", "four_strands"]
     },
     "public.subject_status": {
       "name": "subject_status",
@@ -4458,20 +2886,8 @@
         "consent_reminder",
         "consent_warning",
         "consent_expired",
-        "subscribe_request",
-        "recall_nudge",
-        "weekly_progress",
-        "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "subscribe_request"
       ]
-    },
-    "public.vocab_type": {
-      "name": "vocab_type",
-      "schema": "public",
-      "values": ["word", "chunk"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0011_snapshot.json
+++ b/apps/api/drizzle/meta/0011_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "15609dcb-6cca-4aff-83ee-9718f902a7a1",
-  "prevId": "ed145e47-f1e6-49ef-8e3d-7d1ceb6ed0f4",
+  "prevId": "499d064f-7f05-4ed9-b0bf-1bb1e974c570",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/apps/api/drizzle/meta/0013_profile_premium_llm_snapshot.json
+++ b/apps/api/drizzle/meta/0013_profile_premium_llm_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "0a64fab9-e7ae-437f-a788-a86670a34b52",
+  "prevId": "14c624be-fbaf-4113-8de6-26673f701019",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -856,102 +856,6 @@
       },
       "isRLSEnabled": false
     },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.session_embeddings": {
       "name": "session_embeddings",
       "schema": "",
@@ -1347,15 +1251,15 @@
           "primaryKey": false,
           "notNull": false
         },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
         "birth_year": {
           "name": "birth_year",
           "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "birth_year_set_by": {
-          "name": "birth_year_set_by",
-          "type": "uuid",
           "primaryKey": false,
           "notNull": false
         },
@@ -1368,13 +1272,6 @@
         },
         "is_owner": {
           "name": "is_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "has_premium_llm": {
-          "name": "has_premium_llm",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,
@@ -1418,97 +1315,6 @@
           "tableFrom": "profiles",
           "tableTo": "accounts",
           "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "profiles_birth_year_set_by_profiles_id_fk": {
-          "name": "profiles_birth_year_set_by_profiles_id_fk",
-          "tableFrom": "profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["birth_year_set_by"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.book_suggestions": {
-      "name": "book_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "emoji": {
-          "name": "emoji",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "picked_at": {
-          "name": "picked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "book_suggestions_subject_id_idx": {
-          "name": "book_suggestions_subject_id_idx",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "book_suggestions_subject_id_subjects_id_fk": {
-          "name": "book_suggestions_subject_id_subjects_id_fk",
-          "tableFrom": "book_suggestions",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1758,29 +1564,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_books_subject_id_subjects_id_fk": {
           "name": "curriculum_books_subject_id_subjects_id_fk",
@@ -1858,7 +1642,7 @@
           "name": "book_id",
           "type": "uuid",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "chapter": {
           "name": "chapter",
@@ -1897,20 +1681,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "filed_from": {
-          "name": "filed_from",
-          "type": "filed_from",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pre_generated'"
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -1926,35 +1696,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
@@ -2149,76 +1891,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.topic_suggestions": {
-      "name": "topic_suggestions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "used_at": {
-          "name": "used_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "topic_suggestions_book_id_idx": {
-          "name": "topic_suggestions_book_id_idx",
-          "columns": [
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "topic_suggestions_book_id_curriculum_books_id_fk": {
-          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
-          "tableFrom": "topic_suggestions",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.learning_sessions": {
       "name": "learning_sessions",
       "schema": "",
@@ -2328,12 +2000,6 @@
           "primaryKey": false,
           "notNull": false,
           "default": "'{}'::jsonb"
-        },
-        "raw_input": {
-          "name": "raw_input",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3090,13 +2756,6 @@
           "notNull": true,
           "default": false
         },
-        "weekly_progress_push": {
-          "name": "weekly_progress_push",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
         "push_enabled": {
           "name": "push_enabled",
           "type": "boolean",
@@ -3356,391 +3015,6 @@
           "tableFrom": "xp_ledger",
           "tableTo": "subjects",
           "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.milestones": {
-      "name": "milestones",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "milestone_type": {
-          "name": "milestone_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "threshold": {
-          "name": "threshold",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "subject_id": {
-          "name": "subject_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "book_id": {
-          "name": "book_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "celebrated_at": {
-          "name": "celebrated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "milestones_scope_uq": {
-          "name": "milestones_scope_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "milestone_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "threshold",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "milestones_profile_created_idx": {
-          "name": "milestones_profile_created_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "milestones_profile_id_profiles_id_fk": {
-          "name": "milestones_profile_id_profiles_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_subject_id_subjects_id_fk": {
-          "name": "milestones_subject_id_subjects_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "subjects",
-          "columnsFrom": ["subject_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "milestones_book_id_curriculum_books_id_fk": {
-          "name": "milestones_book_id_curriculum_books_id_fk",
-          "tableFrom": "milestones",
-          "tableTo": "curriculum_books",
-          "columnsFrom": ["book_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.monthly_reports": {
-      "name": "monthly_reports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "child_profile_id": {
-          "name": "child_profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_month": {
-          "name": "report_month",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "report_data": {
-          "name": "report_data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "viewed_at": {
-          "name": "viewed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "monthly_reports_parent_child_month_uq": {
-          "name": "monthly_reports_parent_child_month_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "monthly_reports_child_month_idx": {
-          "name": "monthly_reports_child_month_idx",
-          "columns": [
-            {
-              "expression": "child_profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "report_month",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "monthly_reports_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "monthly_reports_child_profile_id_profiles_id_fk": {
-          "name": "monthly_reports_child_profile_id_profiles_id_fk",
-          "tableFrom": "monthly_reports",
-          "tableTo": "profiles",
-          "columnsFrom": ["child_profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.progress_snapshots": {
-      "name": "progress_snapshots",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "snapshot_date": {
-          "name": "snapshot_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "progress_snapshots_profile_date_uq": {
-          "name": "progress_snapshots_profile_date_uq",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "progress_snapshots_profile_date_idx": {
-          "name": "progress_snapshots_profile_date_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "snapshot_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "progress_snapshots_profile_id_profiles_id_fk": {
-          "name": "progress_snapshots_profile_id_profiles_id_fk",
-          "tableFrom": "progress_snapshots",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -4036,263 +3310,6 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
-    },
-    "public.topic_notes": {
-      "name": "topic_notes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "topic_notes_topic_id_curriculum_topics_id_fk": {
-          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "curriculum_topics",
-          "columnsFrom": ["topic_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "topic_notes_profile_id_profiles_id_fk": {
-          "name": "topic_notes_profile_id_profiles_id_fk",
-          "tableFrom": "topic_notes",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.learning_profiles": {
-      "name": "learning_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "learning_style": {
-          "name": "learning_style",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interests": {
-          "name": "interests",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "strengths": {
-          "name": "strengths",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "struggles": {
-          "name": "struggles",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "communication_notes": {
-          "name": "communication_notes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "suppressed_inferences": {
-          "name": "suppressed_inferences",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "interest_timestamps": {
-          "name": "interest_timestamps",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "effectiveness_session_count": {
-          "name": "effectiveness_session_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "memory_enabled": {
-          "name": "memory_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "memory_consent_status": {
-          "name": "memory_consent_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "consent_prompt_dismissed_at": {
-          "name": "consent_prompt_dismissed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memory_collection_enabled": {
-          "name": "memory_collection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "memory_injection_enabled": {
-          "name": "memory_injection_enabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "version": {
-          "name": "version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "learning_profiles_profile_id_idx": {
-          "name": "learning_profiles_profile_id_idx",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "learning_profiles_profile_id_profiles_id_fk": {
-          "name": "learning_profiles_profile_id_profiles_id_fk",
-          "tableFrom": "learning_profiles",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "learning_profiles_profile_id_unique": {
-          "name": "learning_profiles_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["profile_id"]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4341,11 +3358,6 @@
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
     },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
-    },
     "public.consent_status": {
       "name": "consent_status",
       "schema": "public",
@@ -4370,11 +3382,6 @@
       "name": "curriculum_topic_source",
       "schema": "public",
       "values": ["generated", "user"]
-    },
-    "public.filed_from": {
-      "name": "filed_from",
-      "schema": "public",
-      "values": ["pre_generated", "session_filing", "freeform_filing"]
     },
     "public.pedagogy_mode": {
       "name": "pedagogy_mode",
@@ -4458,14 +3465,7 @@
         "consent_reminder",
         "consent_warning",
         "consent_expired",
-        "subscribe_request",
-        "recall_nudge",
-        "weekly_progress",
-        "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "subscribe_request"
       ]
     },
     "public.vocab_type": {

--- a/apps/api/drizzle/meta/0014_snapshot.json
+++ b/apps/api/drizzle/meta/0014_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "206f7ad3-c2c1-46ea-9dfd-07e838e6dc80",
-  "prevId": "14c624be-fbaf-4113-8de6-26673f701019",
+  "prevId": "0a64fab9-e7ae-437f-a788-a86670a34b52",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/apps/api/drizzle/meta/0021_book_sort_order_unique_snapshot.json
+++ b/apps/api/drizzle/meta/0021_book_sort_order_unique_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "f1ceb0b2-e8b2-441f-af7b-6255142d9b2a",
+  "prevId": "e88e068c-6f0d-4133-930d-38f88d1adcc3",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -856,102 +856,6 @@
       },
       "isRLSEnabled": false
     },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.session_embeddings": {
       "name": "session_embeddings",
       "schema": "",
@@ -1758,29 +1662,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_books_subject_sort_order_uq": {
-          "name": "curriculum_books_subject_sort_order_uq",
-          "columns": [
-            {
-              "expression": "subject_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_books_subject_id_subjects_id_fk": {
           "name": "curriculum_books_subject_id_subjects_id_fk",
@@ -1926,35 +1808,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "curriculum_topics_book_sort_order_uq": {
-          "name": "curriculum_topics_book_sort_order_uq",
-          "columns": [
-            {
-              "expression": "curriculum_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "book_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "sort_order",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "curriculum_topics_curriculum_id_curricula_id_fk": {
           "name": "curriculum_topics_curriculum_id_curricula_id_fk",
@@ -4218,20 +4072,6 @@
           "notNull": true,
           "default": true
         },
-        "accommodation_mode": {
-          "name": "accommodation_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "recently_resolved_topics": {
-          "name": "recently_resolved_topics",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
         "version": {
           "name": "version",
           "type": "integer",
@@ -4340,11 +4180,6 @@
       "name": "subscription_tier",
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
-    },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
     },
     "public.consent_status": {
       "name": "consent_status",
@@ -4462,10 +4297,7 @@
         "recall_nudge",
         "weekly_progress",
         "monthly_report",
-        "progress_refresh",
-        "struggle_noticed",
-        "struggle_flagged",
-        "struggle_resolved"
+        "progress_refresh"
       ]
     },
     "public.vocab_type": {

--- a/apps/api/drizzle/meta/0022_snapshot.json
+++ b/apps/api/drizzle/meta/0022_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "a2894048-4043-42ef-b729-44e447522729",
-  "prevId": "e88e068c-6f0d-4133-930d-38f88d1adcc3",
+  "prevId": "f1ceb0b2-e8b2-441f-af7b-6255142d9b2a",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/apps/api/drizzle/meta/0025_accommodation_mode_check_snapshot.json
+++ b/apps/api/drizzle/meta/0025_accommodation_mode_check_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "prevId": "950e942f-da3f-47bd-a900-79c06859e5d5",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -854,102 +854,6 @@
           "value": "\"top_up_credits\".\"remaining\" >= 0"
         }
       },
-      "isRLSEnabled": false
-    },
-    "public.dictation_results": {
-      "name": "dictation_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "profile_id": {
-          "name": "profile_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sentence_count": {
-          "name": "sentence_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mistake_count": {
-          "name": "mistake_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mode": {
-          "name": "mode",
-          "type": "dictation_mode",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reviewed": {
-          "name": "reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "idx_dictation_results_profile_date": {
-          "name": "idx_dictation_results_profile_date",
-          "columns": [
-            {
-              "expression": "profile_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "dictation_results_profile_id_profiles_id_fk": {
-          "name": "dictation_results_profile_id_profiles_id_fk",
-          "tableFrom": "dictation_results",
-          "tableTo": "profiles",
-          "columnsFrom": ["profile_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.session_embeddings": {
@@ -4340,11 +4244,6 @@
       "name": "subscription_tier",
       "schema": "public",
       "values": ["free", "plus", "family", "pro"]
-    },
-    "public.dictation_mode": {
-      "name": "dictation_mode",
-      "schema": "public",
-      "values": ["homework", "surprise"]
     },
     "public.consent_status": {
       "name": "consent_status",

--- a/apps/api/drizzle/meta/0043_topic_dedup_unique_index_snapshot.json
+++ b/apps/api/drizzle/meta/0043_topic_dedup_unique_index_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "009e2096-8345-4db5-85da-237c4a05c969",
+  "prevId": "2c603f49-f8ff-43de-8abd-39a65375f8d7",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -88,7 +88,44 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "assessments_profile_topic_idx": {
+          "name": "assessments_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assessments_topic_id_idx": {
+          "name": "assessments_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "assessments_profile_id_profiles_id_fk": {
           "name": "assessments_profile_id_profiles_id_fk",
@@ -130,7 +167,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "assessments_mastery_score_range": {
+          "name": "assessments_mastery_score_range",
+          "value": "\"assessments\".\"mastery_score\" IS NULL OR (\"assessments\".\"mastery_score\" >= 0 AND \"assessments\".\"mastery_score\" <= 1)"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.needs_deepening_topics": {
@@ -191,7 +233,44 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "needs_deepening_profile_topic_idx": {
+          "name": "needs_deepening_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "needs_deepening_topic_id_idx": {
+          "name": "needs_deepening_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "needs_deepening_topics_profile_id_profiles_id_fk": {
           "name": "needs_deepening_topics_profile_id_profiles_id_fk",
@@ -254,7 +333,7 @@
           "type": "numeric(4, 2)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'2.50'"
+          "default": 2.5
         },
         "interval_days": {
           "name": "interval_days",
@@ -856,6 +935,148 @@
       },
       "isRLSEnabled": false
     },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_profile_id_idx": {
+          "name": "bookmarks_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_session_id_idx": {
+          "name": "bookmarks_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_profile_event_unique": {
+          "name": "bookmarks_profile_event_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_profile_id_profiles_id_fk": {
+          "name": "bookmarks_profile_id_profiles_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_subject_id_subjects_id_fk": {
+          "name": "bookmarks_subject_id_subjects_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_topic_id_curriculum_topics_id_fk": {
+          "name": "bookmarks_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.dictation_results": {
       "name": "dictation_results",
       "schema": "",
@@ -1380,6 +1601,19 @@
           "notNull": true,
           "default": false
         },
+        "conversation_language": {
+          "name": "conversation_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -1435,7 +1669,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "profiles_conversation_language_check": {
+          "name": "profiles_conversation_language_check",
+          "value": "\"profiles\".\"conversation_language\" IN ('en','cs','es','fr','de','it','pt','pl')"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.book_suggestions": {
@@ -1953,6 +2192,21 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "curriculum_topics_book_id_idx": {
+          "name": "curriculum_topics_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -2335,6 +2589,26 @@
           "primaryKey": false,
           "notNull": false
         },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_status": {
+          "name": "filing_status",
+          "type": "filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_retry_count": {
+          "name": "filing_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2362,6 +2636,49 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_profile_subject_exchange_idx": {
+          "name": "learning_sessions_profile_subject_exchange_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exchange_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_filing_status_idx": {
+          "name": "learning_sessions_filing_status_idx",
+          "columns": [
+            {
+              "expression": "filing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"learning_sessions\".\"filing_status\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -2662,6 +2979,33 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "session_events_profile_event_created_idx": {
+          "name": "session_events_profile_event_created_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -2748,6 +3092,54 @@
           "primaryKey": false,
           "notNull": false
         },
+        "highlight": {
+          "name": "highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_prompt": {
+          "name": "conversation_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_signal": {
+          "name": "engagement_signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_line": {
+          "name": "closing_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_recap": {
+          "name": "learner_recap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_id": {
+          "name": "next_topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_reason": {
+          "name": "next_topic_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "status": {
           "name": "status",
           "type": "summary_status",
@@ -2798,6 +3190,15 @@
           "columnsFrom": ["topic_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_summaries_next_topic_id_curriculum_topics_id_fk": {
+          "name": "session_summaries_next_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["next_topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -3752,6 +4153,130 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.weekly_reports": {
+      "name": "weekly_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_profile_id": {
+          "name": "child_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_week": {
+          "name": "report_week",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_data": {
+          "name": "report_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weekly_reports_parent_child_week_uq": {
+          "name": "weekly_reports_parent_child_week_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_reports_child_week_idx": {
+          "name": "weekly_reports_child_week_idx",
+          "columns": [
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_reports_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_reports_child_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_child_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["child_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.vocabulary": {
       "name": "vocabulary",
       "schema": "",
@@ -3925,14 +4450,14 @@
           "type": "numeric(4, 2)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'2.50'"
+          "default": 2.5
         },
         "interval_days": {
           "name": "interval_days",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
+          "default": 1
         },
         "repetitions": {
           "name": "repetitions",
@@ -4034,7 +4559,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "vocab_retention_cards_interval_days_positive": {
+          "name": "vocab_retention_cards_interval_days_positive",
+          "value": "\"vocabulary_retention_cards\".\"interval_days\" >= 1"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.topic_notes": {
@@ -4293,6 +4823,417 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
+    },
+    "public.quiz_missed_items": {
+      "name": "quiz_missed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_round_id": {
+          "name": "source_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surfaced": {
+          "name": "surfaced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "converted_to_topic": {
+          "name": "converted_to_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_missed_items_profile": {
+          "name": "idx_quiz_missed_items_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surfaced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_missed_items_profile_id_profiles_id_fk": {
+          "name": "quiz_missed_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_missed_items_source_round_id_quiz_rounds_id_fk": {
+          "name": "quiz_missed_items_source_round_id_quiz_rounds_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "quiz_rounds",
+          "columnsFrom": ["source_round_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rounds": {
+      "name": "quiz_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "library_question_indices": {
+          "name": "library_question_indices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "quiz_round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_quiz_rounds_profile_activity": {
+          "name": "idx_quiz_rounds_profile_activity",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quiz_rounds_profile_status": {
+          "name": "idx_quiz_rounds_profile_status",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_rounds_profile_id_profiles_id_fk": {
+          "name": "quiz_rounds_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_rounds",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_mastery_items": {
+      "name": "quiz_mastery_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_answer": {
+          "name": "item_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mc_success_count": {
+          "name": "mc_success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_mastery_due": {
+          "name": "idx_quiz_mastery_due",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_mastery_items_profile_id_profiles_id_fk": {
+          "name": "quiz_mastery_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_mastery_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quiz_mastery_profile_activity_key": {
+          "name": "uq_quiz_mastery_profile_activity_key",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "activity_type", "item_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4396,6 +5337,11 @@
       "schema": "public",
       "values": ["in_progress", "completed", "expired"]
     },
+    "public.filing_status": {
+      "name": "filing_status",
+      "schema": "public",
+      "values": ["filing_pending", "filing_failed", "filing_recovered"]
+    },
     "public.session_event_type": {
       "name": "session_event_type",
       "schema": "public",
@@ -4465,13 +5411,25 @@
         "progress_refresh",
         "struggle_noticed",
         "struggle_flagged",
-        "struggle_resolved"
+        "struggle_resolved",
+        "dictation_review",
+        "session_filing_failed"
       ]
     },
     "public.vocab_type": {
       "name": "vocab_type",
       "schema": "public",
       "values": ["word", "chunk"]
+    },
+    "public.quiz_activity_type": {
+      "name": "quiz_activity_type",
+      "schema": "public",
+      "values": ["capitals", "vocabulary", "guess_who"]
+    },
+    "public.quiz_round_status": {
+      "name": "quiz_round_status",
+      "schema": "public",
+      "values": ["active", "completed", "abandoned"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0044_shelf_book_dedup_unique_indexes_snapshot.json
+++ b/apps/api/drizzle/meta/0044_shelf_book_dedup_unique_indexes_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "d57e5c44-f7d5-444a-9e65-6f8382e855c0",
+  "prevId": "009e2096-8345-4db5-85da-237c4a05c969",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -88,7 +88,44 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "assessments_profile_topic_idx": {
+          "name": "assessments_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assessments_topic_id_idx": {
+          "name": "assessments_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "assessments_profile_id_profiles_id_fk": {
           "name": "assessments_profile_id_profiles_id_fk",
@@ -130,7 +167,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "assessments_mastery_score_range": {
+          "name": "assessments_mastery_score_range",
+          "value": "\"assessments\".\"mastery_score\" IS NULL OR (\"assessments\".\"mastery_score\" >= 0 AND \"assessments\".\"mastery_score\" <= 1)"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.needs_deepening_topics": {
@@ -191,7 +233,44 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "needs_deepening_profile_topic_idx": {
+          "name": "needs_deepening_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "needs_deepening_topic_id_idx": {
+          "name": "needs_deepening_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "needs_deepening_topics_profile_id_profiles_id_fk": {
           "name": "needs_deepening_topics_profile_id_profiles_id_fk",
@@ -254,7 +333,7 @@
           "type": "numeric(4, 2)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'2.50'"
+          "default": 2.5
         },
         "interval_days": {
           "name": "interval_days",
@@ -856,6 +935,148 @@
       },
       "isRLSEnabled": false
     },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_profile_id_idx": {
+          "name": "bookmarks_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_session_id_idx": {
+          "name": "bookmarks_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_profile_event_unique": {
+          "name": "bookmarks_profile_event_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_profile_id_profiles_id_fk": {
+          "name": "bookmarks_profile_id_profiles_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_subject_id_subjects_id_fk": {
+          "name": "bookmarks_subject_id_subjects_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_topic_id_curriculum_topics_id_fk": {
+          "name": "bookmarks_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.dictation_results": {
       "name": "dictation_results",
       "schema": "",
@@ -1380,6 +1601,19 @@
           "notNull": true,
           "default": false
         },
+        "conversation_language": {
+          "name": "conversation_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -1435,7 +1669,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "profiles_conversation_language_check": {
+          "name": "profiles_conversation_language_check",
+          "value": "\"profiles\".\"conversation_language\" IN ('en','cs','es','fr','de','it','pt','pl')"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.book_suggestions": {
@@ -1953,6 +2192,21 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "curriculum_topics_book_id_idx": {
+          "name": "curriculum_topics_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -2335,6 +2589,26 @@
           "primaryKey": false,
           "notNull": false
         },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_status": {
+          "name": "filing_status",
+          "type": "filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_retry_count": {
+          "name": "filing_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2362,6 +2636,49 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_profile_subject_exchange_idx": {
+          "name": "learning_sessions_profile_subject_exchange_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exchange_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_filing_status_idx": {
+          "name": "learning_sessions_filing_status_idx",
+          "columns": [
+            {
+              "expression": "filing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"learning_sessions\".\"filing_status\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -2662,6 +2979,33 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "session_events_profile_event_created_idx": {
+          "name": "session_events_profile_event_created_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -2748,6 +3092,54 @@
           "primaryKey": false,
           "notNull": false
         },
+        "highlight": {
+          "name": "highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_prompt": {
+          "name": "conversation_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_signal": {
+          "name": "engagement_signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_line": {
+          "name": "closing_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_recap": {
+          "name": "learner_recap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_id": {
+          "name": "next_topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_reason": {
+          "name": "next_topic_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "status": {
           "name": "status",
           "type": "summary_status",
@@ -2798,6 +3190,15 @@
           "columnsFrom": ["topic_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_summaries_next_topic_id_curriculum_topics_id_fk": {
+          "name": "session_summaries_next_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["next_topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -3752,6 +4153,130 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.weekly_reports": {
+      "name": "weekly_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_profile_id": {
+          "name": "child_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_week": {
+          "name": "report_week",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_data": {
+          "name": "report_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weekly_reports_parent_child_week_uq": {
+          "name": "weekly_reports_parent_child_week_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_reports_child_week_idx": {
+          "name": "weekly_reports_child_week_idx",
+          "columns": [
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_reports_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_reports_child_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_child_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["child_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.vocabulary": {
       "name": "vocabulary",
       "schema": "",
@@ -3925,14 +4450,14 @@
           "type": "numeric(4, 2)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'2.50'"
+          "default": 2.5
         },
         "interval_days": {
           "name": "interval_days",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
+          "default": 1
         },
         "repetitions": {
           "name": "repetitions",
@@ -4034,7 +4559,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "vocab_retention_cards_interval_days_positive": {
+          "name": "vocab_retention_cards_interval_days_positive",
+          "value": "\"vocabulary_retention_cards\".\"interval_days\" >= 1"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.topic_notes": {
@@ -4293,6 +4823,417 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
+    },
+    "public.quiz_missed_items": {
+      "name": "quiz_missed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_round_id": {
+          "name": "source_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surfaced": {
+          "name": "surfaced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "converted_to_topic": {
+          "name": "converted_to_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_missed_items_profile": {
+          "name": "idx_quiz_missed_items_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surfaced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_missed_items_profile_id_profiles_id_fk": {
+          "name": "quiz_missed_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_missed_items_source_round_id_quiz_rounds_id_fk": {
+          "name": "quiz_missed_items_source_round_id_quiz_rounds_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "quiz_rounds",
+          "columnsFrom": ["source_round_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rounds": {
+      "name": "quiz_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "library_question_indices": {
+          "name": "library_question_indices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "quiz_round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_quiz_rounds_profile_activity": {
+          "name": "idx_quiz_rounds_profile_activity",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quiz_rounds_profile_status": {
+          "name": "idx_quiz_rounds_profile_status",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_rounds_profile_id_profiles_id_fk": {
+          "name": "quiz_rounds_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_rounds",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_mastery_items": {
+      "name": "quiz_mastery_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_answer": {
+          "name": "item_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mc_success_count": {
+          "name": "mc_success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_mastery_due": {
+          "name": "idx_quiz_mastery_due",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_mastery_items_profile_id_profiles_id_fk": {
+          "name": "quiz_mastery_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_mastery_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quiz_mastery_profile_activity_key": {
+          "name": "uq_quiz_mastery_profile_activity_key",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "activity_type", "item_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4396,6 +5337,11 @@
       "schema": "public",
       "values": ["in_progress", "completed", "expired"]
     },
+    "public.filing_status": {
+      "name": "filing_status",
+      "schema": "public",
+      "values": ["filing_pending", "filing_failed", "filing_recovered"]
+    },
     "public.session_event_type": {
       "name": "session_event_type",
       "schema": "public",
@@ -4465,13 +5411,25 @@
         "progress_refresh",
         "struggle_noticed",
         "struggle_flagged",
-        "struggle_resolved"
+        "struggle_resolved",
+        "dictation_review",
+        "session_filing_failed"
       ]
     },
     "public.vocab_type": {
       "name": "vocab_type",
       "schema": "public",
       "values": ["word", "chunk"]
+    },
+    "public.quiz_activity_type": {
+      "name": "quiz_activity_type",
+      "schema": "public",
+      "values": ["capitals", "vocabulary", "guess_who"]
+    },
+    "public.quiz_round_status": {
+      "name": "quiz_round_status",
+      "schema": "public",
+      "values": ["active", "completed", "abandoned"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0045_snapshot.json
+++ b/apps/api/drizzle/meta/0045_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "9634cbd5-348a-4e7a-a95f-e6447e964689",
-  "prevId": "2c603f49-f8ff-43de-8abd-39a65375f8d7",
+  "prevId": "d57e5c44-f7d5-444a-9e65-6f8382e855c0",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/apps/api/drizzle/meta/0055_retention_query_indexes_snapshot.json
+++ b/apps/api/drizzle/meta/0055_retention_query_indexes_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "17878839-badb-42a8-952a-3555b6640a49",
-  "prevId": "d62293e4-7361-43f9-9a1f-4f6de0d1cca4",
+  "id": "b8f20384-101d-4069-919f-712444a5c804",
+  "prevId": "94a96332-428b-4559-b6de-c71b31685e7d",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -88,7 +88,44 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "assessments_profile_topic_idx": {
+          "name": "assessments_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assessments_topic_id_idx": {
+          "name": "assessments_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "assessments_profile_id_profiles_id_fk": {
           "name": "assessments_profile_id_profiles_id_fk",
@@ -130,7 +167,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "assessments_mastery_score_range": {
+          "name": "assessments_mastery_score_range",
+          "value": "\"assessments\".\"mastery_score\" IS NULL OR (\"assessments\".\"mastery_score\" >= 0 AND \"assessments\".\"mastery_score\" <= 1)"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.needs_deepening_topics": {
@@ -191,7 +233,44 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "needs_deepening_profile_topic_idx": {
+          "name": "needs_deepening_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "needs_deepening_topic_id_idx": {
+          "name": "needs_deepening_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "needs_deepening_topics_profile_id_profiles_id_fk": {
           "name": "needs_deepening_topics_profile_id_profiles_id_fk",
@@ -254,7 +333,7 @@
           "type": "numeric(4, 2)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'2.50'"
+          "default": 2.5
         },
         "interval_days": {
           "name": "interval_days",
@@ -856,6 +935,148 @@
       },
       "isRLSEnabled": false
     },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_profile_id_idx": {
+          "name": "bookmarks_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_session_id_idx": {
+          "name": "bookmarks_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_profile_event_unique": {
+          "name": "bookmarks_profile_event_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_profile_id_profiles_id_fk": {
+          "name": "bookmarks_profile_id_profiles_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_subject_id_subjects_id_fk": {
+          "name": "bookmarks_subject_id_subjects_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_topic_id_curriculum_topics_id_fk": {
+          "name": "bookmarks_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.dictation_results": {
       "name": "dictation_results",
       "schema": "",
@@ -1380,6 +1601,19 @@
           "notNull": true,
           "default": false
         },
+        "conversation_language": {
+          "name": "conversation_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -1435,7 +1669,16 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "profiles_conversation_language_check": {
+          "name": "profiles_conversation_language_check",
+          "value": "\"profiles\".\"conversation_language\" IN ('en','cs','es','fr','de','it','pt','pl')"
+        },
+        "profiles_pronouns_length_check": {
+          "name": "profiles_pronouns_length_check",
+          "value": "\"profiles\".\"pronouns\" IS NULL OR char_length(\"profiles\".\"pronouns\") <= 32"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.book_suggestions": {
@@ -1953,6 +2196,21 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "curriculum_topics_book_id_idx": {
+          "name": "curriculum_topics_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -2335,6 +2593,26 @@
           "primaryKey": false,
           "notNull": false
         },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_status": {
+          "name": "filing_status",
+          "type": "filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_retry_count": {
+          "name": "filing_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2362,6 +2640,49 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_profile_subject_exchange_idx": {
+          "name": "learning_sessions_profile_subject_exchange_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exchange_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_filing_status_idx": {
+          "name": "learning_sessions_filing_status_idx",
+          "columns": [
+            {
+              "expression": "filing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"learning_sessions\".\"filing_status\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -2445,6 +2766,12 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'in_progress'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "expires_at": {
           "name": "expires_at",
@@ -2639,6 +2966,18 @@
           "primaryKey": false,
           "notNull": false
         },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphan_reason": {
+          "name": "orphan_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -2659,6 +2998,55 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_events_profile_event_created_idx": {
+          "name": "session_events_profile_event_created_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_events_session_client_id_uniq": {
+          "name": "session_events_session_client_id_uniq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_events\".\"client_id\" IS NOT NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -2748,6 +3136,54 @@
           "primaryKey": false,
           "notNull": false
         },
+        "highlight": {
+          "name": "highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_prompt": {
+          "name": "conversation_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_signal": {
+          "name": "engagement_signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_line": {
+          "name": "closing_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_recap": {
+          "name": "learner_recap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_id": {
+          "name": "next_topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_reason": {
+          "name": "next_topic_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "status": {
           "name": "status",
           "type": "summary_status",
@@ -2769,6 +3205,24 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "llm_summary": {
+          "name": "llm_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_generated_at": {
+          "name": "summary_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {},
@@ -2796,6 +3250,148 @@
           "tableFrom": "session_summaries",
           "tableTo": "curriculum_topics",
           "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_summaries_next_topic_id_curriculum_topics_id_fk": {
+          "name": "session_summaries_next_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["next_topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_messages": {
+      "name": "support_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_key": {
+          "name": "surface_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_attempted_at": {
+          "name": "first_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "support_messages_profile_idx": {
+          "name": "support_messages_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_messages_profile_client_id_uniq": {
+          "name": "support_messages_profile_client_id_uniq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_messages_profile_id_profiles_id_fk": {
+          "name": "support_messages_profile_id_profiles_id_fk",
+          "tableFrom": "support_messages",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -3298,6 +3894,19 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "reflection_multiplier_applied": {
+          "name": "reflection_multiplier_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reflection_applied_by_session_id": {
+          "name": "reflection_applied_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
@@ -3330,6 +3939,27 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "xp_ledger_profile_topic_unique": {
+          "name": "xp_ledger_profile_topic_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -3358,6 +3988,15 @@
           "columnsFrom": ["subject_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "xp_ledger_reflection_applied_by_session_id_learning_sessions_id_fk": {
+          "name": "xp_ledger_reflection_applied_by_session_id_learning_sessions_id_fk",
+          "tableFrom": "xp_ledger",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["reflection_applied_by_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -3752,6 +4391,130 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.weekly_reports": {
+      "name": "weekly_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_profile_id": {
+          "name": "child_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_week": {
+          "name": "report_week",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_data": {
+          "name": "report_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weekly_reports_parent_child_week_uq": {
+          "name": "weekly_reports_parent_child_week_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_reports_child_week_idx": {
+          "name": "weekly_reports_child_week_idx",
+          "columns": [
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_reports_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_reports_child_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_child_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["child_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.vocabulary": {
       "name": "vocabulary",
       "schema": "",
@@ -3925,14 +4688,14 @@
           "type": "numeric(4, 2)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'2.50'"
+          "default": 2.5
         },
         "interval_days": {
           "name": "interval_days",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
+          "default": 1
         },
         "repetitions": {
           "name": "repetitions",
@@ -4034,7 +4797,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "vocab_retention_cards_interval_days_positive": {
+          "name": "vocab_retention_cards_interval_days_positive",
+          "value": "\"vocabulary_retention_cards\".\"interval_days\" >= 1"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.topic_notes": {
@@ -4059,6 +4827,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
         "content": {
           "name": "content",
           "type": "text",
@@ -4080,7 +4854,59 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "topic_notes_topic_profile_idx": {
+          "name": "topic_notes_topic_profile_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_notes_session_id_idx": {
+          "name": "topic_notes_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_notes_content_trgm_idx": {
+          "name": "topic_notes_content_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"content\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "topic_notes_topic_id_curriculum_topics_id_fk": {
           "name": "topic_notes_topic_id_curriculum_topics_id_fk",
@@ -4099,16 +4925,19 @@
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
+        },
+        "topic_notes_session_id_learning_sessions_id_fk": {
+          "name": "topic_notes_session_id_learning_sessions_id_fk",
+          "tableFrom": "topic_notes",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "topic_notes_topic_id_profile_id_unique": {
-          "name": "topic_notes_topic_id_profile_id_unique",
-          "nullsNotDistinct": false,
-          "columns": ["topic_id", "profile_id"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -4293,6 +5122,417 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
+    },
+    "public.quiz_missed_items": {
+      "name": "quiz_missed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_round_id": {
+          "name": "source_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surfaced": {
+          "name": "surfaced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "converted_to_topic": {
+          "name": "converted_to_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_missed_items_profile": {
+          "name": "idx_quiz_missed_items_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surfaced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_missed_items_profile_id_profiles_id_fk": {
+          "name": "quiz_missed_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_missed_items_source_round_id_quiz_rounds_id_fk": {
+          "name": "quiz_missed_items_source_round_id_quiz_rounds_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "quiz_rounds",
+          "columnsFrom": ["source_round_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rounds": {
+      "name": "quiz_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "library_question_indices": {
+          "name": "library_question_indices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "quiz_round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_quiz_rounds_profile_activity": {
+          "name": "idx_quiz_rounds_profile_activity",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quiz_rounds_profile_status": {
+          "name": "idx_quiz_rounds_profile_status",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_rounds_profile_id_profiles_id_fk": {
+          "name": "quiz_rounds_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_rounds",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_mastery_items": {
+      "name": "quiz_mastery_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_answer": {
+          "name": "item_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mc_success_count": {
+          "name": "mc_success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_mastery_due": {
+          "name": "idx_quiz_mastery_due",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_mastery_items_profile_id_profiles_id_fk": {
+          "name": "quiz_mastery_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_mastery_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quiz_mastery_profile_activity_key": {
+          "name": "uq_quiz_mastery_profile_activity_key",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "activity_type", "item_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -4394,7 +5634,12 @@
     "public.draft_status": {
       "name": "draft_status",
       "schema": "public",
-      "values": ["in_progress", "completed", "expired"]
+      "values": ["in_progress", "completing", "completed", "failed", "expired"]
+    },
+    "public.filing_status": {
+      "name": "filing_status",
+      "schema": "public",
+      "values": ["filing_pending", "filing_failed", "filing_recovered"]
     },
     "public.session_event_type": {
       "name": "session_event_type",
@@ -4465,13 +5710,26 @@
         "progress_refresh",
         "struggle_noticed",
         "struggle_flagged",
-        "struggle_resolved"
+        "struggle_resolved",
+        "dictation_review",
+        "session_filing_failed",
+        "interview_ready"
       ]
     },
     "public.vocab_type": {
       "name": "vocab_type",
       "schema": "public",
       "values": ["word", "chunk"]
+    },
+    "public.quiz_activity_type": {
+      "name": "quiz_activity_type",
+      "schema": "public",
+      "values": ["capitals", "vocabulary", "guess_who"]
+    },
+    "public.quiz_round_status": {
+      "name": "quiz_round_status",
+      "schema": "public",
+      "values": ["active", "completed", "abandoned"]
     }
   },
   "schemas": {},

--- a/apps/api/drizzle/meta/0056_snapshot.json
+++ b/apps/api/drizzle/meta/0056_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "a8dfc7f1-de55-4300-86f6-3622f1ffcd32",
-  "prevId": "94a96332-428b-4559-b6de-c71b31685e7d",
+  "prevId": "b8f20384-101d-4069-919f-712444a5c804",
   "version": "7",
   "dialect": "postgresql",
   "tables": {


### PR DESCRIPTION
## PR-18 (Cleanup Plan C8-P1)

Regenerates 11 missing drizzle migration snapshots that were absent from `apps/api/drizzle/meta/`.

### What changed

- **11 new snapshot files** created for migrations 0006, 0007, 0008, 0009, 0010, 0013, 0021, 0025, 0043, 0044, 0055
- **6 existing snapshots updated** (0011, 0014, 0022, 0026, 0045, 0056) — `prevId` field corrected to point to the newly-generated preceding snapshot's `id`, maintaining the drizzle snapshot chain

### Why

The repo had 69 migrations but only 58 snapshots. Missing snapshots can cause `drizzle-kit generate` to produce incorrect diffs. This is a meta-only fix — no migration SQL content was added or changed.

### Verification

- `pnpm run db:generate:dev` completes without errors
- Snapshot chain integrity verified (each `prevId` references the correct preceding snapshot `id`)

### Governance

`.archon/governance-constraints.md` §5 (DB — snapshot regeneration must not introduce migration content; this is a meta-only fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration snapshots to maintain schema consistency across application versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->