### PR TITLE
fix(archon): expand brace shorthand in cleanup-extract.sh + PR-18 plan closure

### DIFF
--- a/.archon/scripts/cleanup-extract.sh
+++ b/.archon/scripts/cleanup-extract.sh
@@ -40,6 +40,52 @@ safe_field() {
         | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
+# Expand brace patterns like `prefix{a,b,c}suffix` into one path per option.
+# Authors of docs/audit/cleanup-plan.md routinely use brace shorthand in the
+# Files-claimed column (e.g. `packages/{database,schemas}/README.md`).
+# Without expansion, downstream consumers (scope-guard, Files Summary table,
+# Notion follow-up filer) see a literal token that no real file matches.
+#
+# Supports cartesian products across multiple groups on the same path
+# (e.g. `{a,b}/{c,d}.ts` → 4 paths). Does NOT support nested braces;
+# the cleanup-plan format has never used them, and supporting them invites
+# parser ambiguity. Tokens without braces pass through unchanged.
+#
+# Pure bash (no eval) — the input is a controlled markdown file, but treating
+# it as code via `eval echo $pattern` would still be a foot-gun if someone
+# ever pastes a shell metachar into a path cell. Safer to walk the regex.
+expand_braces() {
+    local pat="$1"
+    if [[ "$pat" =~ ^([^{}]*)\{([^{}]+)\}(.*)$ ]]; then
+        local prefix="${BASH_REMATCH[1]}"
+        local options="${BASH_REMATCH[2]}"
+        local suffix="${BASH_REMATCH[3]}"
+        local opt
+        # Split on commas WITHOUT pathname expansion. Plain `for opt in $options`
+        # word-splits AND glob-expands each token against the working directory,
+        # so an option containing `*`, `?`, or `[` would silently expand to
+        # filesystem matches. `read -ra` with IFS=',' splits on commas only.
+        local _opts
+        IFS=',' read -ra _opts <<< "$options"
+        for opt in "${_opts[@]}"; do
+            # Trim whitespace from each option
+            opt="${opt#"${opt%%[![:space:]]*}"}"
+            opt="${opt%"${opt##*[![:space:]]}"}"
+            # Skip empty options from accidental `{a,,b}` shorthand — without
+            # this guard, the empty string emits `prefix + suffix` (the brace
+            # group silently erased) which looks like a valid path.
+            [[ -z "$opt" ]] && continue
+            # Recurse on suffix to expand any further brace groups (cartesian).
+            local expanded
+            while IFS= read -r expanded; do
+                printf '%s%s%s\n' "$prefix" "$opt" "$expanded"
+            done < <(expand_braces "$suffix")
+        done
+    else
+        printf '%s\n' "$pat"
+    fi
+}
+
 # Normalize PR number: PR-08, PR-8, 08, 8 → 08 (two-digit zero-padded).
 # Optional lowercase letter suffix is preserved for sub-PRs: PR-15a, 15b, etc.
 pr_token="$(echo "$raw_pr" | grep -oE '[0-9]+[a-z]*' | head -1)"
@@ -114,10 +160,22 @@ for pid in "${phase_ids[@]}"; do
     p_files="$(safe_field "$phase_row" 7)"
     p_notes="$(safe_field "$phase_row" 8)"
 
-    # Extract individual file paths from backticks (no mapfile — macOS bash 3.x compat)
+    # Extract individual file paths from backticks (no mapfile — macOS bash 3.x compat).
+    # Then expand any brace shorthand (e.g. `packages/{a,b}/README.md` → 2 paths)
+    # so the work-order, Files Summary table, and scope-guard all see literal paths.
+    #
+    # ORDERING CAVEAT: the extension filter (`\.[a-zA-Z][a-zA-Z0-9]*$`) runs on
+    # the RAW brace token, not on expanded paths. Tokens ending in `}` (e.g.
+    # `apps/{api,mobile}` or `src/{a.ts,b.tsx}` where the extension is inside
+    # the brace group) are dropped here BEFORE expansion. The cleanup-plan
+    # format has never used those shapes; if it ever does, move the extension
+    # filter to a post-expansion pass.
     files=()
-    while IFS= read -r _f; do
-        [[ -n "$_f" ]] && files+=("$_f")
+    while IFS= read -r _raw; do
+        [[ -z "$_raw" ]] && continue
+        while IFS= read -r _expanded; do
+            [[ -n "$_expanded" ]] && files+=("$_expanded")
+        done < <(expand_braces "$_raw")
     done < <(echo "$p_files" | grep -oE '`[^`]+`' | tr -d '`' | grep -E '\.[a-zA-Z][a-zA-Z0-9]*$' || true)
     for f in ${files[@]+"${files[@]}"}; do
         all_files_claimed+=("$f")


### PR DESCRIPTION
## Why

The `execute-cleanup-pr` workflow's `scope-guard-post-implement` node failed on PR-24 because the work-order's allowed-files list contained an unexpanded brace token:

```
packages/{database,schemas,test-utils,retention}/README.md
```

The implement node correctly produced the 4 real `packages/*/README.md` files, but the guard's literal `grep -qxF` match rejected all four as "unexpected." See the original [Archon run](http://ramtop.ruffe-alligator.ts.net:3090/workflows/runs/c6d90bc9d6b56817a3f5ad768d19e4a1) and the auto-filed [Notion follow-up](https://www.notion.so/Scope-guard-fired-work-order-incomplete-for-PR-24-35e8bce91f7c81bf99b4daf475454a70).

## What

**`fix(archon)`** — add `expand_braces()` to `cleanup-extract.sh`:
- Pure bash, no `eval`, supports cartesian products across multiple brace groups (e.g. `packages/{a,b}/{c,d}.ts` → 4 paths)
- Wired into the file-extraction loop so the work-order, Files Summary table, and Notion follow-up filer all receive literal paths
- Nested braces intentionally not supported (never used in cleanup-plan format)

**`docs(audit)`** — separate small commit marking PR-18 / C8-P1 as done in `docs/audit/cleanup-plan.md`. Hitchhiking because it's already on `consistency2`; can be dropped if you'd rather it land separately.

## Why option 1 (fix extract) over option 2 (teach scope-guard to expand)

Discussed pre-fix: the scope-guard's security value is its mechanical simplicity (literal match, no interpretation). Adding brace expansion *there* widens the trust surface. Fixing it at extract means the work-order is the single source of truth and is literally what humans / downstream tooling see.

## Verification

Ran locally against PR-24:

```
Before: work-order's Phase Files list had 1 literal + 1 brace token (3 files claimed)
After:  6 literal paths in both the Phase Files list and the Files Summary table
```

Once this lands on `main`, re-launching `execute-cleanup-pr "PR-24"` should clear scope-guard and proceed through implement → review → push → create-pr.

## Scope

- `.archon/scripts/cleanup-extract.sh` (+45 / -3)
- `docs/audit/cleanup-plan.md` (PR-18 closure marker only — no functional impact)

No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal documentation processing script to correctly handle brace pattern expansion in file paths, ensuring more reliable path resolution in automated workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->