### PR TITLE
fix(tests): remove internal mock cleanup debt

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -127,6 +127,7 @@ Two production dead-code branches removed 2026-04-19 in commit `970a82a5`: `AgeB
 - [feedback_adversarial_review_patterns.md](feedback_adversarial_review_patterns.md) — Body double-consumption, classify-before-format, dead code cleanup.
 - [feedback_llm_prompt_injection_surfacing.md](feedback_llm_prompt_injection_surfacing.md) — LLM reads user A → surfaces to user B = injection vector.
 - [feedback_verify_full_ci.md](feedback_verify_full_ci.md) — On CI failure, run full validation.
+- [feedback_pr_required_checks.md](feedback_pr_required_checks.md) — Missing required PR checks can be branch-protection/workflow-trigger drift; diagnose before changing product tests.
 - [feedback_thorough_investigation.md](feedback_thorough_investigation.md) — NEVER take shortcuts in codebase analysis.
 - [feedback_verify_before_declaring_done.md](feedback_verify_before_declaring_done.md) — Never declare a fix done without testing it first.
 - [feedback_verify_before_marking_done.md](feedback_verify_before_marking_done.md) — Never mark bugs Done in Notion unless 100% confident.

--- a/.claude/memory/feedback_pr_required_checks.md
+++ b/.claude/memory/feedback_pr_required_checks.md
@@ -8,7 +8,7 @@ When a PR shows an expected required check stuck on "Waiting for status to be re
 
 **Why:** PR #233 had passing CI and Playwright, but `API Quality Gate` was required and never reported because it lived in `deploy.yml`, which did not run on pull requests.
 
-**How to apply:** Add the PR trigger only for the reporting gate, and explicitly guard deploy/build jobs so pull requests cannot deploy. In deploy workflows, do not rely on skipped `needs` results alone; include an event guard such as `github.event_name == 'push' || github.event_name == 'workflow_dispatch'` on deploy jobs.
+**How to apply:** Prefer a small PR-only workflow/job that reports the required check name without starting deploy machinery. If adding a PR trigger to an existing deploy workflow is unavoidable, explicitly guard deploy/build jobs so pull requests cannot deploy. In deploy workflows, do not rely on skipped `needs` results alone; include an event guard such as `github.event_name == 'push' || github.event_name == 'workflow_dispatch'` on deploy jobs.
 
 For Playwright web smoke failures, inspect `error-context.md` plus the trace network log before changing selectors. If the UI shows offline/profile fallbacks and `0-trace.network` has `net::ERR_FAILED`/CORS failures, fix the staging/API target or workflow configuration instead of weakening the assertion.
 

--- a/.claude/memory/feedback_pr_required_checks.md
+++ b/.claude/memory/feedback_pr_required_checks.md
@@ -1,0 +1,15 @@
+---
+name: PR Required Check Triage
+description: Lessons from PR #233 where green CI was still blocked by a missing required API Quality Gate.
+type: feedback
+---
+
+When a PR shows an expected required check stuck on "Waiting for status to be reported", first search workflows for the exact check/job name. A required check can be configured in branch protection even if its workflow only runs on `push` or `workflow_dispatch`, so the fix may be workflow trigger drift rather than failing code.
+
+**Why:** PR #233 had passing CI and Playwright, but `API Quality Gate` was required and never reported because it lived in `deploy.yml`, which did not run on pull requests.
+
+**How to apply:** Add the PR trigger only for the reporting gate, and explicitly guard deploy/build jobs so pull requests cannot deploy. In deploy workflows, do not rely on skipped `needs` results alone; include an event guard such as `github.event_name == 'push' || github.event_name == 'workflow_dispatch'` on deploy jobs.
+
+For Playwright web smoke failures, inspect `error-context.md` plus the trace network log before changing selectors. If the UI shows offline/profile fallbacks and `0-trace.network` has `net::ERR_FAILED`/CORS failures, fix the staging/API target or workflow configuration instead of weakening the assertion.
+
+After pushing a PR fix, `gh pr checks --watch` may briefly say no checks are reported. Wait a few seconds or inspect `gh pr view --json statusCheckRollup` before assuming the push failed to trigger workflows.

--- a/.github/workflows/api-quality-gate.yml
+++ b/.github/workflows/api-quality-gate.yml
@@ -1,0 +1,38 @@
+name: API Quality Gate
+
+on:
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: api-quality-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  api-quality-gate:
+    name: API Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          standalone: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint API
+        run: pnpm exec nx run api:lint
+
+      - name: Typecheck API
+        run: pnpm exec nx run api:typecheck

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -49,11 +52,11 @@ jobs:
   # API: Cloudflare Workers deployment
   # ---------------------------------------------------------------------------
 
-  # Push-to-main: lightweight lint+typecheck (CI ran full suite on PR).
+  # PR / push-to-main: lightweight lint+typecheck (CI ran full suite on PR).
   # Dispatch: full quality gate with unit + integration tests.
   api-quality-gate:
     name: API Quality Gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.api_environment != 'skip')
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.api_environment != 'skip')
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -122,11 +125,12 @@ jobs:
         run: echo "Production deployment approved via GitHub Environment protection rules."
 
   api-deploy:
-    name: Deploy API (${{ github.event_name == 'push' && 'staging' || inputs.api_environment }})
+    name: Deploy API (${{ github.event_name == 'push' && 'staging' || github.event_name == 'workflow_dispatch' && inputs.api_environment || 'skip' }})
     needs: [api-quality-gate, api-confirm-production]
     # Always require quality gate to pass before deploying.
     if: |
       always() &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       needs.api-quality-gate.result == 'success' &&
       (github.event_name == 'push' ||
        (needs.api-confirm-production.result == 'success' || needs.api-confirm-production.result == 'skipped'))

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Deploy
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -52,11 +49,11 @@ jobs:
   # API: Cloudflare Workers deployment
   # ---------------------------------------------------------------------------
 
-  # PR / push-to-main: lightweight lint+typecheck (CI ran full suite on PR).
+  # Push-to-main: lightweight lint+typecheck (CI ran full suite on PR).
   # Dispatch: full quality gate with unit + integration tests.
   api-quality-gate:
     name: API Quality Gate
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.api_environment != 'skip')
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.api_environment != 'skip')
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -125,7 +122,7 @@ jobs:
         run: echo "Production deployment approved via GitHub Environment protection rules."
 
   api-deploy:
-    name: Deploy API (${{ github.event_name == 'push' && 'staging' || github.event_name == 'workflow_dispatch' && inputs.api_environment || 'skip' }})
+    name: Deploy API (${{ github.event_name == 'push' && 'staging' || inputs.api_environment }})
     needs: [api-quality-gate, api-confirm-production]
     # Always require quality gate to pass before deploying.
     if: |

--- a/.github/workflows/e2e-web-cleanup.yml
+++ b/.github/workflows/e2e-web-cleanup.yml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - name: Reset seeded staging accounts
         env:
+          # Match the web smoke fallback; repos can override with E2E_API_URL.
           API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
           TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}

--- a/.github/workflows/e2e-web-cleanup.yml
+++ b/.github/workflows/e2e-web-cleanup.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Reset seeded staging accounts
         env:
-          API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
+          API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
           TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -24,9 +24,9 @@ jobs:
     timeout-minutes: 20
     env:
       CI: true
-      EXPO_PUBLIC_API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
+      EXPO_PUBLIC_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
       EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY_PREVIEW }}
-      PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
+      PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
       PLAYWRIGHT_SKIP_LOCAL_API: '1'
       PLAYWRIGHT_TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -70,7 +70,7 @@ jobs:
       - name: Reset seeded staging accounts (always)
         if: always()
         env:
-          PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
+          PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
           PLAYWRIGHT_TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
           PLAYWRIGHT_RUN_ID: ${{ env.PLAYWRIGHT_RUN_ID }}
         run: |

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -24,6 +24,8 @@ jobs:
     timeout-minutes: 20
     env:
       CI: true
+      # Keep the fallback aligned with the committed staging worker mapping in
+      # docs/deployment-and-secrets.md; repos can override with E2E_API_URL.
       EXPO_PUBLIC_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
       EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY_PREVIEW }}
       PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}

--- a/apps/mobile/playwright.config.ts
+++ b/apps/mobile/playwright.config.ts
@@ -4,6 +4,7 @@ import { apiBaseUrl, appBaseUrl, runId } from './e2e-web/helpers/runtime';
 
 const e2eWebDir = path.join(process.cwd(), 'apps', 'mobile', 'e2e-web');
 const shouldStartLocalApi = process.env.PLAYWRIGHT_SKIP_LOCAL_API !== '1';
+const usesSharedStagingApi = process.env.PLAYWRIGHT_SKIP_LOCAL_API === '1';
 
 export default defineConfig({
   testDir: e2eWebDir,
@@ -11,7 +12,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 4 : undefined,
+  // Shared staging can edge-block parallel authenticated bursts; local API runs
+  // keep parallel workers because they do not traverse the staging gateway.
+  workers: process.env.CI ? (usesSharedStagingApi ? 1 : 4) : undefined,
   reporter: [
     ['line'],
     [

--- a/apps/mobile/src/components/change-password.test.tsx
+++ b/apps/mobile/src/components/change-password.test.tsx
@@ -28,13 +28,6 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ replace: mockReplace }),
 }));
 
-jest.mock('../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    muted: '#999',
-  }),
-}));
-
 // Stub useProfile so the centralized signOutWithCleanup has profileIds to
 // pass to SecureStore cleanup without needing a full ProfileProvider tree.
 // The real useProfile transitively pulls in SecureStore, api-client, and

--- a/apps/mobile/src/components/common/OfflineBanner.test.tsx
+++ b/apps/mobile/src/components/common/OfflineBanner.test.tsx
@@ -5,11 +5,6 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 44, bottom: 0, left: 0, right: 0 }),
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({ background: '#ffffff' }),
-}));
-
 describe('OfflineBanner', () => {
   it('renders the offline message', () => {
     const { getByText } = render(<OfflineBanner />);

--- a/apps/mobile/src/components/common/PasswordInput.test.tsx
+++ b/apps/mobile/src/components/common/PasswordInput.test.tsx
@@ -1,13 +1,6 @@
 import { render, fireEvent } from '@testing-library/react-native';
 import { PasswordInput } from './PasswordInput';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({ muted: '#888' }),
-  }),
-);
-
 describe('PasswordInput', () => {
   it('hides password by default', () => {
     const { getByTestId } = render(

--- a/apps/mobile/src/components/home/CoachBand.test.tsx
+++ b/apps/mobile/src/components/home/CoachBand.test.tsx
@@ -1,20 +1,6 @@
 import { render, fireEvent } from '@testing-library/react-native';
 import { CoachBand, type CoachBandProps } from './CoachBand';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      primarySoft: 'rgba(45,212,191,0.16)',
-      primary: '#2dd4bf',
-      secondary: '#a78bfa',
-      textTertiary: '#94a3b8',
-      textInverse: '#ffffff',
-      border: '#2a2a54',
-    }),
-  }),
-);
-
 describe('CoachBand', () => {
   const baseProps: CoachBandProps = {
     headline: 'Pick up where you stopped in Linear equations.',

--- a/apps/mobile/src/components/home/EarlyAdopterCard.test.tsx
+++ b/apps/mobile/src/components/home/EarlyAdopterCard.test.tsx
@@ -2,16 +2,6 @@ import { render, screen } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EarlyAdopterCard } from './EarlyAdopterCard';
 
-// External boundaries only
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    primary: '#007AFF',
-    textSecondary: '#666',
-    textMuted: '#999',
-  }),
-}));
-
 jest.mock('../../lib/profile', () => ({
   useProfile: () => ({ activeProfile: { id: 'profile-1' } }),
 }));

--- a/apps/mobile/src/components/home/LearnerScreen.test.tsx
+++ b/apps/mobile/src/components/home/LearnerScreen.test.tsx
@@ -41,6 +41,9 @@ const mockFetch = createRoutedMockFetch({
     pendingNotices: [],
     demoMode: false,
   },
+  '/learner-profile': {
+    profile: { accommodationMode: 'none' },
+  },
   '/subjects': { subjects: [] },
   '/usage': {
     usage: {
@@ -103,19 +106,12 @@ jest.mock('../common', () => ({
   BookPageFlipAnimation: () => null,
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    textPrimary: '#ffffff',
-    textSecondary: '#94a3b8',
-    textTertiary: '#94a3b8',
-    primary: '#00b4d8',
-    primarySoft: 'rgba(0,180,216,0.16)',
-    border: '#2a2a54',
-    muted: '#94a3b8',
+jest.mock(
+  '../feedback/FeedbackProvider' /* gc1-allow: native feedback modal/i18n subtree is outside LearnerScreen's contract */,
+  () => ({
+    useFeedbackContext: () => ({ openFeedback: jest.fn() }),
   }),
-  useTheme: () => ({ colorScheme: 'dark' }),
-}));
+);
 
 jest.mock('../../lib/greeting', () => ({
   getGreeting: (_name: string) => ({
@@ -220,6 +216,9 @@ describe('LearnerScreen', () => {
       children: [],
       pendingNotices: [],
       demoMode: false,
+    });
+    mockFetch.setRoute('/learner-profile', {
+      profile: { accommodationMode: 'none' },
     });
     mockFetch.setRoute('/subjects', { subjects: [] });
     mockFetch.setRoute('/usage', {

--- a/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
@@ -14,18 +14,6 @@ jest.mock(
 );
 
 jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook reads native ColorScheme — not available in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      textPrimary: '#ffffff',
-      textSecondary: '#94a3b8',
-      primary: '#00b4d8',
-    }),
-    useTheme: () => ({ colorScheme: 'light' }),
-  }),
-);
-
-jest.mock(
   'react-native-safe-area-context' /* gc1-allow: native module that requires device/simulator to resolve insets */,
   () => ({
     useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),

--- a/apps/mobile/src/components/library/CollapsibleChapter.test.tsx
+++ b/apps/mobile/src/components/library/CollapsibleChapter.test.tsx
@@ -1,15 +1,6 @@
 import { render, fireEvent } from '@testing-library/react-native';
 import { CollapsibleChapter } from './CollapsibleChapter';
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    success: '#22c55e',
-    textSecondary: '#6b7280',
-    primary: '#0088cc',
-  }),
-}));
-
 const onTopicPress = jest.fn();
 
 const topics = [

--- a/apps/mobile/src/components/library/InlineNoteCard.test.tsx
+++ b/apps/mobile/src/components/library/InlineNoteCard.test.tsx
@@ -1,15 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { InlineNoteCard } from './InlineNoteCard';
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    textPrimary: '#1a1a1a',
-    textSecondary: '#525252',
-    accent: '#a78bfa',
-  }),
-}));
-
 describe('InlineNoteCard', () => {
   const baseProps = {
     noteId: 'note-1',

--- a/apps/mobile/src/components/library/LibrarySearchBar.test.tsx
+++ b/apps/mobile/src/components/library/LibrarySearchBar.test.tsx
@@ -1,17 +1,26 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { ThemeContext } from '../../lib/theme';
 import { LibrarySearchBar } from './LibrarySearchBar';
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    textSecondary: '#525252',
-    muted: '#a3a3a3',
-  }),
-}));
+// renderWithTheme is only needed when a test asserts theme-derived style props.
+function renderWithTheme(ui: Parameters<typeof render>[0]) {
+  return render(
+    <ThemeContext.Provider
+      value={{
+        colorScheme: 'light',
+        setColorScheme: jest.fn(),
+        accentPresetId: null,
+        setAccentPresetId: jest.fn(),
+      }}
+    >
+      {ui}
+    </ThemeContext.Provider>,
+  );
+}
 
 describe('LibrarySearchBar', () => {
   it('renders with placeholder', () => {
-    render(
+    renderWithTheme(
       <LibrarySearchBar
         value=""
         onChangeText={jest.fn()}
@@ -24,7 +33,7 @@ describe('LibrarySearchBar', () => {
 
   it('calls onChangeText when typing', () => {
     const onChangeText = jest.fn();
-    render(
+    renderWithTheme(
       <LibrarySearchBar
         value=""
         onChangeText={onChangeText}
@@ -37,7 +46,7 @@ describe('LibrarySearchBar', () => {
 
   it('shows clear button when value is non-empty and clears on press', () => {
     const onChangeText = jest.fn();
-    render(
+    renderWithTheme(
       <LibrarySearchBar
         value="math"
         onChangeText={onChangeText}
@@ -50,7 +59,7 @@ describe('LibrarySearchBar', () => {
   });
 
   it('hides clear button when value is empty', () => {
-    render(
+    renderWithTheme(
       <LibrarySearchBar
         value=""
         onChangeText={jest.fn()}
@@ -63,7 +72,7 @@ describe('LibrarySearchBar', () => {
   // [a11y sweep] Break tests: the clear-search icon must be a11y-hidden —
   // the Pressable accessibilityLabel "Clear search" already conveys the action.
   it('marks the clear icon wrapper as accessibility-hidden [a11y sweep]', () => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithTheme(
       <LibrarySearchBar
         value="math"
         onChangeText={jest.fn()}
@@ -80,7 +89,7 @@ describe('LibrarySearchBar', () => {
   });
 
   it('clear icon is excluded from default visible-only queries [a11y sweep]', () => {
-    const { queryByTestId } = render(
+    const { queryByTestId } = renderWithTheme(
       <LibrarySearchBar
         value="math"
         onChangeText={jest.fn()}

--- a/apps/mobile/src/components/library/NoteDisplay.test.tsx
+++ b/apps/mobile/src/components/library/NoteDisplay.test.tsx
@@ -1,19 +1,6 @@
 import { render } from '@testing-library/react-native';
 import { NoteDisplay } from './NoteDisplay';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      textSecondary: '#999',
-      primary: '#00bcd4',
-      error: '#f44',
-      warning: '#ff9800',
-      success: '#4caf50',
-    }),
-  }),
-);
-
 describe('NoteDisplay', () => {
   it('shows note content', () => {
     const { getByText } = render(

--- a/apps/mobile/src/components/library/NoteInput.test.tsx
+++ b/apps/mobile/src/components/library/NoteInput.test.tsx
@@ -1,17 +1,6 @@
 import { render, fireEvent } from '@testing-library/react-native';
 import { NoteInput } from './NoteInput';
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    textSecondary: '#999',
-    primary: '#00bcd4',
-    error: '#f44',
-    warning: '#ff9800',
-    success: '#4caf50',
-  }),
-}));
-
 jest.mock('../../hooks/use-speech-recognition', () => ({
   useSpeechRecognition: () => ({
     status: 'idle',

--- a/apps/mobile/src/components/library/RetentionPill.test.tsx
+++ b/apps/mobile/src/components/library/RetentionPill.test.tsx
@@ -1,19 +1,6 @@
 import { render, screen } from '@testing-library/react-native';
 import { RetentionPill } from './RetentionPill';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      retentionStrong: '#22c55e',
-      retentionFading: '#eab308',
-      retentionWeak: '#f97316',
-      retentionForgotten: '#737373',
-      textSecondary: '#525252',
-    }),
-  }),
-);
-
 describe('RetentionPill', () => {
   it('renders still-remembered status with green dot and label', () => {
     render(<RetentionPill status="strong" />);

--- a/apps/mobile/src/components/library/ShelfRow.test.tsx
+++ b/apps/mobile/src/components/library/ShelfRow.test.tsx
@@ -5,27 +5,6 @@ import { ShelfRow } from './ShelfRow';
 // Mocks
 // ---------------------------------------------------------------------------
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    textPrimary: '#1a1a1a',
-    textSecondary: '#525252',
-    surfaceElevated: '#f3ede4',
-    warning: '#a16207',
-    muted: '#a3a3a3',
-    retentionStrong: '#15803d',
-    retentionFading: '#a16207',
-    retentionWeak: '#ea580c',
-    retentionForgotten: '#737373',
-    success: '#15803d',
-  }),
-  useSubjectTint: () => ({
-    name: 'teal',
-    solid: '#0f766e',
-    soft: 'rgba(15,118,110,0.14)',
-  }),
-}));
-
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/components/library/StudyCTA.test.tsx
+++ b/apps/mobile/src/components/library/StudyCTA.test.tsx
@@ -5,15 +5,6 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    primary: '#0d9488',
-    background: '#faf5ee',
-    border: '#e8e0d4',
-  }),
-}));
-
 describe('StudyCTA', () => {
   const onPress = jest.fn();
 

--- a/apps/mobile/src/components/library/TopicHeader.test.tsx
+++ b/apps/mobile/src/components/library/TopicHeader.test.tsx
@@ -1,20 +1,6 @@
 import { render, screen } from '@testing-library/react-native';
 import { TopicHeader } from './TopicHeader';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      textPrimary: '#1a1a1a',
-      textSecondary: '#525252',
-      retentionStrong: '#22c55e',
-      retentionFading: '#eab308',
-      retentionWeak: '#f97316',
-      retentionForgotten: '#737373',
-    }),
-  }),
-);
-
 describe('TopicHeader', () => {
   it('renders the topic name', () => {
     render(

--- a/apps/mobile/src/components/library/TopicPickerSheet.test.tsx
+++ b/apps/mobile/src/components/library/TopicPickerSheet.test.tsx
@@ -1,19 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { tokens } from '../../lib/design-tokens';
 import { TopicPickerSheet } from './TopicPickerSheet';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
-
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    primarySoft: '#d1fae5',
-    surface: '#f5f0e8',
-    textPrimary: '#1a1a1a',
-    textSecondary: '#525252',
-  }),
-}));
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -70,7 +61,7 @@ describe('TopicPickerSheet', () => {
     render(<TopicPickerSheet {...defaultProps} defaultTopicId="topic-2" />);
     const selectedRow = screen.getByTestId('topic-picker-topic-2');
     expect(selectedRow.props.style).toMatchObject({
-      backgroundColor: '#d1fae5',
+      backgroundColor: tokens.light.colors.primarySoft,
     });
   });
 
@@ -78,7 +69,7 @@ describe('TopicPickerSheet', () => {
     render(<TopicPickerSheet {...defaultProps} defaultTopicId="topic-2" />);
     const unselectedRow = screen.getByTestId('topic-picker-topic-1');
     expect(unselectedRow.props.style).toMatchObject({
-      backgroundColor: '#f5f0e8',
+      backgroundColor: tokens.light.colors.surface,
     });
   });
 

--- a/apps/mobile/src/components/library/TopicSessionRow.test.tsx
+++ b/apps/mobile/src/components/library/TopicSessionRow.test.tsx
@@ -5,19 +5,6 @@ jest.mock('@expo/vector-icons', () => ({
   Ionicons: () => null,
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    primary: '#0f9f8f',
-    textPrimary: '#1a1a1a',
-    textSecondary: '#525252',
-    border: '#e8e0d4',
-    background: '#ffffff',
-    surface: '#f8f5ef',
-    surfaceElevated: '#f0ebe2',
-  }),
-}));
-
 describe('TopicSessionRow', () => {
   const onPress = jest.fn();
 

--- a/apps/mobile/src/components/library/TopicStatusRow.test.tsx
+++ b/apps/mobile/src/components/library/TopicStatusRow.test.tsx
@@ -1,20 +1,6 @@
 import { fireEvent, render } from '@testing-library/react-native';
 import { TopicStatusRow } from './TopicStatusRow';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      primary: '#0088cc',
-      accent: '#d97706',
-      success: '#22c55e',
-      textSecondary: '#6b7280',
-      border: '#e5e7eb',
-      surface: '#ffffff',
-    }),
-  }),
-);
-
 describe('TopicStatusRow', () => {
   const onPress = jest.fn();
 

--- a/apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx
+++ b/apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx
@@ -27,17 +27,6 @@ jest.mock(
   }),
 );
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook reads native ColorScheme — not available in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      textPrimary: '#ffffff',
-      textSecondary: '#94a3b8',
-      primary: '#00b4d8',
-    }),
-  }),
-);
-
 const mockPlatformAlert = jest.fn();
 jest.mock(
   '../../lib/platform-alert' /* gc1-allow: wraps Alert.alert which is unavailable in JSDOM */,

--- a/apps/mobile/src/components/nudge/NudgeBanner.test.tsx
+++ b/apps/mobile/src/components/nudge/NudgeBanner.test.tsx
@@ -7,13 +7,6 @@ jest.mock(
   () => require('../../test-utils/mock-i18n').i18nMock,
 );
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook reads native ColorScheme — not available in JSDOM */,
-  () => ({
-    useThemeColors: () => ({ primary: '#00b4d8', textPrimary: '#ffffff' }),
-  }),
-);
-
 const mockMarkAllRead = jest.fn();
 
 jest.mock(

--- a/apps/mobile/src/components/session/ChatShell.test.tsx
+++ b/apps/mobile/src/components/session/ChatShell.test.tsx
@@ -29,16 +29,6 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useTheme: () => ({ colorScheme: 'dark' }),
-  useThemeColors: () => ({
-    muted: '#888',
-    primary: '#007AFF',
-    textInverse: '#fff',
-  }),
-}));
-
 jest.mock('../../lib/math-format', () => ({
   formatMathContent: (s: string) => s,
 }));

--- a/apps/mobile/src/components/session/LivingBook.test.tsx
+++ b/apps/mobile/src/components/session/LivingBook.test.tsx
@@ -1,17 +1,6 @@
 import { render, screen } from '@testing-library/react-native';
 import { LivingBook } from './LivingBook';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      primary: '#6366f1',
-      textSecondary: '#9ca3af',
-      warning: '#f59e0b',
-    }),
-  }),
-);
-
 describe('LivingBook', () => {
   it('renders with zero exchanges (no counter text)', () => {
     render(<LivingBook exchangeCount={0} isComplete={false} isExpressive />);

--- a/apps/mobile/src/components/session/SessionFooter.test.tsx
+++ b/apps/mobile/src/components/session/SessionFooter.test.tsx
@@ -67,6 +67,7 @@ function createProps(overrides: Record<string, unknown> = {}) {
 describe('SessionFooter', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    jest.clearAllMocks();
     // platformAlert delegates to Alert.alert on non-web platforms in Jest.
     jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
   });
@@ -139,10 +140,11 @@ describe('SessionFooter', () => {
   it('keeps the note editor open when note saving fails', () => {
     const setShowNoteInput = jest.fn();
     const createNote = {
-      mutate: jest.fn((...args: unknown[]) => {
-        const options = args[1] as { onError: (error: Error) => void };
-        options.onError(new Error('network down'));
-      }),
+      mutate: jest.fn(
+        (_vars: unknown, options?: { onError?: (error: Error) => void }) => {
+          options?.onError?.(new Error('network down'));
+        },
+      ),
       isPending: false,
     };
     const props = createProps({

--- a/apps/mobile/src/components/session/SessionFooter.test.tsx
+++ b/apps/mobile/src/components/session/SessionFooter.test.tsx
@@ -67,6 +67,7 @@ function createProps(overrides: Record<string, unknown> = {}) {
 describe('SessionFooter', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    // platformAlert delegates to Alert.alert on non-web platforms in Jest.
     jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
   });
 

--- a/apps/mobile/src/components/session/SessionFooter.test.tsx
+++ b/apps/mobile/src/components/session/SessionFooter.test.tsx
@@ -4,29 +4,22 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 import { SessionFooter } from './SessionFooter';
 
 jest.mock('../session', () => ({
+  // gc1-allow: footer tests isolate prompt/button behavior from sibling session components
   QuestionCounter: () => null,
   LibraryPrompt: () => null,
 }));
 
 jest.mock('../../lib/format-api-error', () => ({
+  // gc1-allow: error formatting is covered separately; this test asserts footer recovery behavior
   formatApiError: (e: unknown) => String(e),
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    primary: '#00b4d8',
-    textSecondary: '#999',
-    error: '#f44',
-    warning: '#ff9800',
-    success: '#4caf50',
-  }),
-}));
-
 jest.mock('../../hooks/use-speech-recognition', () => ({
+  // gc1-allow: native speech recognition is an external device boundary for NoteInput rendering
   useSpeechRecognition: () => ({
     status: 'idle',
     transcript: '',
@@ -73,7 +66,8 @@ function createProps(overrides: Record<string, unknown> = {}) {
 
 describe('SessionFooter', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
   });
 
   it('shows filing prompt with accept/dismiss for freeform sessions', () => {
@@ -138,6 +132,44 @@ describe('SessionFooter', () => {
         onSuccess: expect.any(Function),
         onError: expect.any(Function),
       }),
+    );
+  });
+
+  it('keeps the note editor open when note saving fails', () => {
+    const setShowNoteInput = jest.fn();
+    const createNote = {
+      mutate: jest.fn((...args: unknown[]) => {
+        const options = args[1] as { onError: (error: Error) => void };
+        options.onError(new Error('network down'));
+      }),
+      isPending: false,
+    };
+    const props = createProps({
+      showFilingPrompt: false,
+      notePromptOffered: true,
+      showNoteInput: true,
+      setShowNoteInput,
+      topicId: 'topic-1',
+      sessionId: 'session-1',
+      createNote,
+    });
+    render(<SessionFooter {...(props as any)} />);
+
+    fireEvent.changeText(
+      screen.getByTestId('note-text-input'),
+      'This took a while to write',
+    );
+    fireEvent.press(screen.getByText('Save'));
+
+    expect(setShowNoteInput).not.toHaveBeenCalled();
+    expect(screen.getByTestId('note-text-input').props.value).toBe(
+      'This took a while to write',
+    );
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Could not save note',
+      'Error: network down',
+      undefined,
+      undefined,
     );
   });
 });

--- a/apps/mobile/src/components/session/SessionInputModeToggle.test.tsx
+++ b/apps/mobile/src/components/session/SessionInputModeToggle.test.tsx
@@ -1,16 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { SessionInputModeToggle } from './SessionInputModeToggle';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      textInverse: '#fff',
-      textSecondary: '#888',
-    }),
-  }),
-);
-
 jest.mock('@expo/vector-icons', () => {
   const { Text } = require('react-native');
   return {

--- a/apps/mobile/src/components/session/VoicePlaybackBar.test.tsx
+++ b/apps/mobile/src/components/session/VoicePlaybackBar.test.tsx
@@ -1,16 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { VoicePlaybackBar } from './VoicePlaybackBar';
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      muted: '#888',
-      primary: '#007AFF',
-    }),
-  }),
-);
-
 jest.mock('@expo/vector-icons', () => {
   const { Text } = require('react-native');
   return {

--- a/apps/mobile/src/components/session/VoiceRecordButton.test.tsx
+++ b/apps/mobile/src/components/session/VoiceRecordButton.test.tsx
@@ -15,16 +15,6 @@ jest.mock('../../lib/haptics', () => ({
   hapticSuccess: () => mockHapticSuccess(),
 }));
 
-jest.mock('../../lib/theme', () => ({
-  // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
-  useThemeColors: () => ({
-    muted: '#888',
-    primary: '#007AFF',
-    textInverse: '#fff',
-    textSecondary: '#666',
-  }),
-}));
-
 jest.mock('@expo/vector-icons', () => {
   const { Text } = require('react-native');
   return {

--- a/apps/mobile/src/components/session/VoiceToggle.test.tsx
+++ b/apps/mobile/src/components/session/VoiceToggle.test.tsx
@@ -5,16 +5,6 @@ import { VoiceToggle } from './VoiceToggle';
 // Mocks — external boundaries only
 // ---------------------------------------------------------------------------
 
-jest.mock(
-  '../../lib/theme' /* gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM */,
-  () => ({
-    useThemeColors: () => ({
-      muted: '#888',
-      primary: '#007AFF',
-    }),
-  }),
-);
-
 jest.mock('@expo/vector-icons', () => {
   const { Text } = require('react-native');
   return {

--- a/apps/mobile/src/hooks/use-progress.test.ts
+++ b/apps/mobile/src/hooks/use-progress.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient } from '@tanstack/react-query';
-import { createQueryWrapper } from '../test-utils/app-hook-test-utils';
+import { setActiveProfileId } from '../lib/api-client';
+import { ForbiddenError } from '../lib/api-errors';
+import { createHookWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useSubjectProgress,
   useOverallProgress,
@@ -12,49 +14,30 @@ import {
 } from './use-progress';
 
 const mockFetch = jest.fn();
-jest.mock('../lib/api-client', () => ({
-  useApiClient: () => {
-    const { hc } = require('hono/client');
-    return hc('http://localhost', {
-      fetch: async (...args: unknown[]) => {
-        const res = await mockFetch(...(args as Parameters<typeof fetch>));
-        if (!res.ok) {
-          const text = await res
-            .clone()
-            .text()
-            .catch(() => res.statusText);
-          throw new Error(`API error ${res.status}: ${text}`);
-        }
-        return res;
-      },
-    });
-  },
-}));
-
-jest.mock('../lib/profile', () => ({
-  useProfile: () => ({
-    activeProfile: { id: 'test-profile-id' },
-  }),
-}));
+const originalFetch = globalThis.fetch;
 
 let queryClient: QueryClient;
 
 function createWrapper() {
-  const w = createQueryWrapper();
+  const w = createHookWrapper();
   queryClient = w.queryClient;
   return w.wrapper;
 }
 
+beforeEach(() => {
+  mockFetch.mockReset();
+  globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
+  setActiveProfileId('test-profile-id');
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  queryClient?.clear();
+  setActiveProfileId(undefined);
+  globalThis.fetch = originalFetch;
+});
+
 describe('useSubjectProgress', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches subject progress from API', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
@@ -87,9 +70,15 @@ describe('useSubjectProgress', () => {
     expect(result.current.data?.topicsTotal).toBe(10);
   });
 
-  it('handles API errors', async () => {
+  it('classifies forbidden API responses through the real client boundary', async () => {
     mockFetch.mockResolvedValueOnce(
-      new Response('Network error', { status: 500 }),
+      new Response(
+        JSON.stringify({
+          code: 'SUBJECT_INACTIVE',
+          message: 'This subject is archived',
+        }),
+        { status: 403 },
+      ),
     );
 
     const { result } = renderHook(() => useSubjectProgress('sub-1'), {
@@ -100,20 +89,15 @@ describe('useSubjectProgress', () => {
       expect(result.current.isError).toBe(true);
     });
 
-    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error).toBeInstanceOf(ForbiddenError);
+    expect(result.current.error).toMatchObject({
+      apiCode: 'SUBJECT_INACTIVE',
+      message: 'This subject is archived',
+    });
   });
 });
 
 describe('useOverallProgress', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches overall progress from API', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
@@ -151,15 +135,6 @@ describe('useOverallProgress', () => {
 });
 
 describe('useContinueSuggestion', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches continue suggestion from API', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
@@ -205,15 +180,6 @@ describe('useContinueSuggestion', () => {
 });
 
 describe('useLearningResumeTarget', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches resume target with optional scope', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
@@ -254,15 +220,6 @@ describe('useLearningResumeTarget', () => {
 });
 
 describe('useReviewSummary', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches review summary from API', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ totalOverdue: 6 }), { status: 200 }),
@@ -282,15 +239,6 @@ describe('useReviewSummary', () => {
 });
 
 describe('useOverdueTopics', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches overdue topics grouped by subject from API', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
@@ -330,15 +278,6 @@ describe('useOverdueTopics', () => {
 });
 
 describe('useTopicProgress', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    queryClient.clear();
-  });
-
   it('fetches topic progress from API', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(

--- a/apps/mobile/src/hooks/use-progress.test.ts
+++ b/apps/mobile/src/hooks/use-progress.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient } from '@tanstack/react-query';
 import { setActiveProfileId } from '../lib/api-client';
-import { ForbiddenError } from '../lib/api-errors';
+import { ForbiddenError, UpstreamError } from '../lib/api-errors';
 import { createHookWrapper } from '../test-utils/app-hook-test-utils';
 import {
   useSubjectProgress,
@@ -28,7 +28,6 @@ beforeEach(() => {
   mockFetch.mockReset();
   globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
   setActiveProfileId('test-profile-id');
-  jest.clearAllMocks();
 });
 
 afterEach(() => {
@@ -93,6 +92,33 @@ describe('useSubjectProgress', () => {
     expect(result.current.error).toMatchObject({
       apiCode: 'SUBJECT_INACTIVE',
       message: 'This subject is archived',
+    });
+  });
+
+  it('classifies server errors through the real client boundary', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: 'INTERNAL_ERROR',
+          message: 'Internal Server Error',
+        }),
+        { status: 500 },
+      ),
+    );
+
+    const { result } = renderHook(() => useSubjectProgress('sub-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeInstanceOf(UpstreamError);
+    expect(result.current.error).toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'Internal Server Error',
+      status: 500,
     });
   });
 });

--- a/docs/plans/2026-05-12-internal-mock-cleanup-inventory.csv
+++ b/docs/plans/2026-05-12-internal-mock-cleanup-inventory.csv
@@ -66,12 +66,13 @@ apps/api/src/inngest/functions/freeform-filing.test.ts,75,jest.mock,../../servic
 apps/api/src/inngest/functions/freeform-filing.test.ts,99,jest.mock,../../services/filing,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
 apps/api/src/inngest/functions/freeform-filing.test.ts,105,jest.mock,../../services/llm,API Inngest tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
 apps/api/src/inngest/functions/monthly-report-cron.test.ts,108,jest.mock,@eduagent/database,API Inngest tests,P1,critical-workflow: database mock can hide scoping or write behavior,Batch 2 - Inngest workflow harness,api-critical-workflow-target
-apps/api/src/inngest/functions/monthly-report-cron.test.ts,135,jest.mock,../../services/monthly-report,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
-apps/api/src/inngest/functions/monthly-report-cron.test.ts,144,jest.mock,../../services/snapshot-aggregation,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
-apps/api/src/inngest/functions/monthly-report-cron.test.ts,157,jest.mock,../../services/notifications,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
-apps/api/src/inngest/functions/monthly-report-cron.test.ts,169,jest.mock,../../services/settings,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
-apps/api/src/inngest/functions/monthly-report-cron.test.ts,176,jest.mock,../../services/sentry,API Inngest tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
-apps/api/src/inngest/functions/monthly-report-cron.test.ts,180,jest.mock,../helpers,API Inngest tests,P1,critical-workflow: API internal module mock,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,136,jest.mock,../../services/monthly-report,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,143,jest.mock,../../services/solo-progress-reports,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,153,jest.mock,../../services/snapshot-aggregation,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,166,jest.mock,../../services/notifications,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,178,jest.mock,../../services/settings,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,185,jest.mock,../../services/sentry,API Inngest tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/api/src/inngest/functions/monthly-report-cron.test.ts,189,jest.mock,../helpers,API Inngest tests,P1,critical-workflow: API internal module mock,Batch 2 - Inngest workflow harness,api-critical-workflow-target
 apps/api/src/inngest/functions/notification-suppressed-observe.test.ts,15,jest.mock,../../services/sentry,API Inngest tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/inngest/functions/notification-suppressed-observe.test.ts,21,jest.mock,../../services/logger,API Inngest tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/inngest/functions/notification-suppressed-observe.test.ts,30,jest.mock,../client,API Inngest tests,P3,transport-boundary: Inngest dispatch/client capture,Retain,inngest-transport-wrapper
@@ -157,6 +158,12 @@ apps/api/src/inngest/functions/trial-expiry.test.ts,91,jest.mock,../../services/
 apps/api/src/inngest/functions/weekly-progress-push.test.ts,13,jest.mock,../../services/sentry,API Inngest tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/inngest/functions/weekly-progress-push.test.ts,27,jest.mock,../helpers,API Inngest tests,P1,critical-workflow: API internal module mock,Batch 2 - Inngest workflow harness,api-critical-workflow-target
 apps/api/src/inngest/functions/weekly-progress-push.test.ts,30,jest.mock,../client,API Inngest tests,P3,transport-boundary: Inngest dispatch/client capture,Retain,inngest-transport-wrapper
+apps/api/src/inngest/functions/weekly-self-reports.test.ts,47,jest.mock,../../services/solo-progress-reports,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/weekly-self-reports.test.ts,57,jest.mock,../../services/snapshot-aggregation,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/weekly-self-reports.test.ts,65,jest.mock,../../services/weekly-report,API Inngest tests,P1,critical-workflow: sibling service behavior mocked,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/weekly-self-reports.test.ts,73,jest.mock,../../services/sentry,API Inngest tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/api/src/inngest/functions/weekly-self-reports.test.ts,77,jest.mock,../helpers,API Inngest tests,P1,critical-workflow: API internal module mock,Batch 2 - Inngest workflow harness,api-critical-workflow-target
+apps/api/src/inngest/functions/weekly-self-reports.test.ts,81,jest.mock,../client,API Inngest tests,P3,transport-boundary: Inngest dispatch/client capture,Retain,inngest-transport-wrapper
 apps/api/src/middleware/account.test.ts,5,jest.mock,../services/account,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Opportunistic API cleanup,api-critical-workflow-target
 apps/api/src/middleware/auth.test.ts,10,jest.mock,../services/sentry,API service/middleware unit tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/middleware/auth.test.ts,15,jest.mock,../services/logger,API service/middleware unit tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
@@ -335,7 +342,6 @@ apps/api/src/services/account.test.ts,49,jest.mock,./sentry,API service/middlewa
 apps/api/src/services/billing.test.ts,9,jest.mock,./sentry,API service/middleware unit tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/services/billing/family.test.ts,3,jest.mock,@eduagent/database,API service/middleware unit tests,P1,critical-workflow: database mock can hide scoping or write behavior,Batch 5 - billing/quota lifecycle,api-critical-workflow-target
 apps/api/src/services/book-generation.test.ts,1,jest.mock,./llm,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
-apps/api/src/services/book-suggestion-generation.integration.test.ts,14,jest.mock,./llm,API route + top-level integration tests,P0,temporary-internal: integration test mock reaches app behavior,Batch 1 - integration mock ratchet,integration-file-internal-target
 apps/api/src/services/book-suggestion-generation.test.ts,8,jest.mock,./llm,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
 apps/api/src/services/book-suggestion-generation.test.ts,13,jest.mock,./logger,API service/middleware unit tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/services/bookmarks.test.ts,11,jest.mock,@eduagent/database,API service/middleware unit tests,P1,critical-workflow: database mock can hide scoping or write behavior,Opportunistic API cleanup,api-critical-workflow-target
@@ -355,13 +361,12 @@ apps/api/src/services/interleaved.test.ts,26,jest.mock,@eduagent/database,API se
 apps/api/src/services/language-detect.test.ts,5,jest.mock,./llm,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
 apps/api/src/services/learner-input.test.ts,1,jest.mock,./llm,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
 apps/api/src/services/learner-input.test.ts,5,jest.mock,./learner-profile,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Opportunistic API cleanup,api-internal-target
-apps/api/src/services/learner-profile.test.ts,21,jest.mock,./llm/router,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
+apps/api/src/services/learner-profile.test.ts,25,jest.mock,./llm/router,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
 apps/api/src/services/memory.test.ts,6,jest.mock,./embeddings,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Batch 6 - LLM/provider fixture cleanup,api-internal-target
 apps/api/src/services/memory.test.ts,20,jest.mock,@eduagent/database,API service/middleware unit tests,P1,critical-workflow: database mock can hide scoping or write behavior,Opportunistic API cleanup,api-critical-workflow-target
 apps/api/src/services/monthly-report.test.ts,5,jest.mock,./llm,API service/middleware unit tests,P1,critical-workflow: LLM router/envelope path mocked,Batch 6 - LLM/provider fixture cleanup,api-critical-workflow-target
 apps/api/src/services/monthly-report.test.ts,9,jest.mock,./sentry,API service/middleware unit tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/api/src/services/notifications.test.ts,26,jest.mock,./settings,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Opportunistic API cleanup,api-critical-workflow-target
-apps/api/src/services/nudge.integration.test.ts,38,jest.mock,./notifications,API route + top-level integration tests,P0,temporary-internal: integration test mock reaches app behavior,Batch 1 - integration mock ratchet,integration-file-internal-target
 apps/api/src/services/nudge.test.ts,32,jest.mock,./family-access,API service/middleware unit tests,P1,"critical-workflow: guard, ownership, quota, or billing path mocked",Opportunistic API cleanup,api-internal-target
 apps/api/src/services/nudge.test.ts,40,jest.mock,./consent,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Opportunistic API cleanup,api-internal-target
 apps/api/src/services/nudge.test.ts,55,jest.mock,./notifications,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Opportunistic API cleanup,api-internal-target
@@ -411,19 +416,19 @@ apps/api/src/services/vocabulary-extract.test.ts,9,jest.mock,./sentry,API servic
 apps/api/src/services/xp.test.ts,10,jest.mock,@eduagent/database,API service/middleware unit tests,P1,critical-workflow: database mock can hide scoping or write behavior,Opportunistic API cleanup,api-critical-workflow-target
 apps/api/src/services/xp.test.ts,12,jest.mock,./settings,API service/middleware unit tests,P1,critical-workflow: sibling service behavior mocked,Opportunistic API cleanup,api-critical-workflow-target
 apps/mobile/src/app/(app)/_layout.test.tsx,20,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/_layout.test.tsx,41,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/_layout.test.tsx,51,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/_layout.test.tsx,55,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/_layout.test.tsx,59,jest.mock,@clerk/clerk-expo,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/app/(app)/_layout.test.tsx,69,jest.mock,expo-notifications,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/_layout.test.tsx,89,jest.mock,expo-speech-recognition,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/_layout.test.tsx,96,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/_layout.test.tsx,108,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/_layout.test.tsx,121,jest.mock,../../hooks/use-revenuecat,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/_layout.test.tsx,125,jest.mock,../../hooks/use-mentor-language-sync,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/_layout.test.tsx,129,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
-apps/mobile/src/app/(app)/_layout.test.tsx,137,jest.mock,../../lib/secure-storage,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/_layout.test.tsx,144,jest.mock,../../components/feedback/FeedbackProvider,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/_layout.test.tsx,50,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/_layout.test.tsx,60,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/_layout.test.tsx,64,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/_layout.test.tsx,68,jest.mock,@clerk/clerk-expo,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
+apps/mobile/src/app/(app)/_layout.test.tsx,78,jest.mock,expo-notifications,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/_layout.test.tsx,98,jest.mock,expo-speech-recognition,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/_layout.test.tsx,105,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/_layout.test.tsx,117,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/_layout.test.tsx,133,jest.mock,../../hooks/use-revenuecat,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/_layout.test.tsx,137,jest.mock,../../hooks/use-mentor-language-sync,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/_layout.test.tsx,141,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/mobile/src/app/(app)/_layout.test.tsx,149,jest.mock,../../lib/secure-storage,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/_layout.test.tsx,156,jest.mock,../../components/feedback/FeedbackProvider,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/child/[profileId]/_layout.test.tsx,18,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/child/[profileId]/_layout.test.tsx,30,jest.mock,../../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/child/[profileId]/index.test.tsx,3,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
@@ -487,9 +492,9 @@ apps/mobile/src/app/(app)/dictation/complete.test.tsx,42,jest.mock,../../../hook
 apps/mobile/src/app/(app)/dictation/complete.test.tsx,55,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/dictation/complete.test.tsx,60,jest.mock,../../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/dictation/complete.test.tsx,64,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/dictation/complete.test.tsx,74,jest.mock,expo-image-picker,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/dictation/complete.test.tsx,79,jest.mock,expo-file-system/legacy,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/dictation/complete.test.tsx,92,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/dictation/complete.test.tsx,75,jest.mock,expo-image-picker,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/dictation/complete.test.tsx,80,jest.mock,expo-file-system/legacy,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/dictation/complete.test.tsx,93,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/dictation/index.test.tsx,7,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/dictation/index.test.tsx,16,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/dictation/index.test.tsx,29,jest.mock,../../../hooks/use-dictation-api,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
@@ -497,8 +502,8 @@ apps/mobile/src/app/(app)/dictation/index.test.tsx,44,jest.mock,./_layout,Mobile
 apps/mobile/src/app/(app)/dictation/index.test.tsx,53,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/dictation/index.test.tsx,57,jest.mock,../../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/dictation/index.test.tsx,61,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/dictation/index.test.tsx,69,jest.mock,../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/dictation/index.test.tsx,74,jest.mock,../../../components/home/IntentCard,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/dictation/index.test.tsx,70,jest.mock,../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/dictation/index.test.tsx,75,jest.mock,../../../components/home/IntentCard,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/dictation/text-preview.test.tsx,7,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/dictation/text-preview.test.tsx,16,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/dictation/text-preview.test.tsx,30,jest.mock,../../../hooks/use-dictation-api,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
@@ -517,9 +522,9 @@ apps/mobile/src/app/(app)/homework/camera.test.tsx,54,jest.mock,expo-image-picke
 apps/mobile/src/app/(app)/homework/camera.test.tsx,61,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/homework/camera.test.tsx,75,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/homework/camera.test.tsx,82,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/homework/camera.test.tsx,93,jest.mock,../../../hooks/use-homework-ocr,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/homework/camera.test.tsx,105,jest.mock,../../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/homework/camera.test.tsx,162,jest.mock,../../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/homework/camera.test.tsx,94,jest.mock,../../../hooks/use-homework-ocr,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/homework/camera.test.tsx,106,jest.mock,../../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/homework/camera.test.tsx,163,jest.mock,../../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/library.test.tsx,16,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/(app)/library.test.tsx,28,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/library.test.tsx,32,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
@@ -530,12 +535,12 @@ apps/mobile/src/app/(app)/library.test.tsx,49,jest.mock,../../components/progres
 apps/mobile/src/app/(app)/library.test.tsx,56,jest.mock,../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/library.test.tsx,92,jest.mock,../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/library.test.tsx,96,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/library.test.tsx,112,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/library.test.tsx,125,jest.mock,../../hooks/use-library-search,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/library.test.tsx,129,jest.mock,../../components/common/ShimmerSkeleton,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/library.test.tsx,142,jest.mock,../../components/library/ShelfRow,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/library.test.tsx,169,jest.mock,../../components/library/LibrarySearchBar,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/library.test.tsx,193,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/library.test.tsx,113,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/library.test.tsx,126,jest.mock,../../hooks/use-library-search,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/library.test.tsx,130,jest.mock,../../components/common/ShimmerSkeleton,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/library.test.tsx,143,jest.mock,../../components/library/ShelfRow,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/library.test.tsx,170,jest.mock,../../components/library/LibrarySearchBar,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/library.test.tsx,194,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/mentor-memory.test.tsx,35,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/mentor-memory.test.tsx,47,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/mentor-memory.test.tsx,53,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
@@ -575,9 +580,9 @@ apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,79,jest.mock,expo-l
 apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,83,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,100,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,104,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,113,jest.mock,../../../hooks/use-subjects,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,120,jest.mock,../../../hooks/use-sessions,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,127,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,114,jest.mock,../../../hooks/use-subjects,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,121,jest.mock,../../../hooks/use-sessions,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/onboarding/language-setup.test.tsx,128,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/own-learning.test.tsx,16,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/own-learning.test.tsx,27,jest.mock,../../components/home,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/pick-book/_layout.test.tsx,12,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
@@ -587,22 +592,24 @@ apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx,45,jest.mock,react-nati
 apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx,49,jest.mock,../../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx,59,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/practice/index.test.tsx,3,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/app/(app)/practice/index.test.tsx,16,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/practice/index.test.tsx,27,jest.mock,../../../hooks/use-parent-proxy,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/practice/index.test.tsx,34,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/practice/index.test.tsx,38,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/practice/index.test.tsx,50,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/practice/index.test.tsx,56,jest.mock,../../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/practice/index.test.tsx,60,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/practice/index.test.tsx,64,jest.mock,../../../hooks/use-assessments,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/practice/index.test.tsx,17,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/practice/index.test.tsx,28,jest.mock,../../../hooks/use-parent-proxy,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/practice/index.test.tsx,35,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/practice/index.test.tsx,39,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/practice/index.test.tsx,54,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/practice/index.test.tsx,63,jest.mock,../../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/practice/index.test.tsx,67,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/practice/index.test.tsx,71,jest.mock,../../../hooks/use-subjects,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/practice/index.test.tsx,78,jest.mock,../../../hooks/use-assessments,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/progress.test.tsx,18,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/app/(app)/progress.test.tsx,130,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
-apps/mobile/src/app/(app)/progress.test.tsx,132,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
-apps/mobile/src/app/(app)/progress.test.tsx,135,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
-apps/mobile/src/app/(app)/progress.test.tsx,147,jest.mock,../../lib/analytics,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 7 - progress/report mobile screens,mobile-internal-target
-apps/mobile/src/app/(app)/progress.test.tsx,152,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 7 - progress/report mobile screens,mobile-internal-target
-apps/mobile/src/app/(app)/progress.test.tsx,155,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/progress.test.tsx,164,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/progress.test.tsx,134,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
+apps/mobile/src/app/(app)/progress.test.tsx,138,jest.mock,../../hooks/use-subjects,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
+apps/mobile/src/app/(app)/progress.test.tsx,145,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
+apps/mobile/src/app/(app)/progress.test.tsx,148,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
+apps/mobile/src/app/(app)/progress.test.tsx,160,jest.mock,../../lib/analytics,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 7 - progress/report mobile screens,mobile-internal-target
+apps/mobile/src/app/(app)/progress.test.tsx,165,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 7 - progress/report mobile screens,mobile-internal-target
+apps/mobile/src/app/(app)/progress.test.tsx,168,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/progress.test.tsx,177,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/progress/_layout.test.tsx,18,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/progress/_layout.test.tsx,30,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/progress/[subjectId]/index.test.tsx,12,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
@@ -652,6 +659,14 @@ apps/mobile/src/app/(app)/quiz/[roundId].test.tsx,7,jest.mock,react-i18next,Mobi
 apps/mobile/src/app/(app)/quiz/[roundId].test.tsx,37,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/[roundId].test.tsx,47,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/[roundId].test.tsx,52,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/history.test.tsx,9,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/quiz/history.test.tsx,14,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/quiz/history.test.tsx,21,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
+apps/mobile/src/app/(app)/quiz/history.test.tsx,32,jest.mock,../../../i18n,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/history.test.tsx,43,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/history.test.tsx,50,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/quiz/history.test.tsx,59,jest.mock,../../../lib/use-screen-top-inset,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/history.test.tsx,66,jest.mock,../../../lib/extract-vocabulary-language,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/quiz/index.test.tsx,17,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/(app)/quiz/index.test.tsx,73,jest.mock,../../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/quiz/index.test.tsx,79,jest.mock,../../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
@@ -659,28 +674,27 @@ apps/mobile/src/app/(app)/quiz/index.test.tsx,103,jest.mock,expo-router,Mobile t
 apps/mobile/src/app/(app)/quiz/index.test.tsx,113,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/index.test.tsx,117,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/index.test.tsx,137,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/quiz/index.test.tsx,144,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/index.test.tsx,145,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/quiz/launch.test.tsx,12,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/(app)/quiz/launch.test.tsx,46,jest.mock,../../../i18n,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,99,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,103,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,107,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,117,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,121,jest.mock,../../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,131,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/launch.test.tsx,135,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,107,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,112,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,116,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,129,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,136,jest.mock,../../../components/common/DeskLampAnimation,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,146,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/launch.test.tsx,150,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/quiz/play.test.tsx,18,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/play.test.tsx,22,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/play.test.tsx,26,jest.mock,expo-haptics,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/play.test.tsx,34,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/quiz/play.test.tsx,46,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/quiz/play.test.tsx,50,jest.mock,../../../components/quiz/GuessWhoQuestion,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/play.test.tsx,80,jest.mock,../../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/play.test.tsx,90,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/play.test.tsx,103,jest.mock,../../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/quiz/play.test.tsx,109,jest.mock,../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/quiz/play.test.tsx,114,jest.mock,../../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
-apps/mobile/src/app/(app)/quiz/play.test.tsx,138,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/play.test.tsx,46,jest.mock,../../../components/quiz/GuessWhoQuestion,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/play.test.tsx,76,jest.mock,../../../components/common/celebrations/PolarStar,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/play.test.tsx,86,jest.mock,../../../hooks/use-quiz,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/play.test.tsx,99,jest.mock,../../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/quiz/play.test.tsx,105,jest.mock,../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/quiz/play.test.tsx,110,jest.mock,../../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/mobile/src/app/(app)/quiz/play.test.tsx,135,jest.mock,./_layout,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/quiz/results.test.tsx,28,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/results.test.tsx,40,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/quiz/results.test.tsx,46,jest.mock,../../../components/common/BrandCelebration,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
@@ -714,8 +728,8 @@ apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,77,jest.mock,
 apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,87,jest.mock,../../../../../hooks/use-subjects,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,93,jest.mock,../../../../../hooks/use-move-topic,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,97,jest.mock,../../../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,109,jest.mock,../../../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,114,jest.mock,../../../../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,110,jest.mock,../../../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx,115,jest.mock,../../../../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,10,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,22,jest.mock,../../../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,31,jest.mock,../../../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
@@ -723,9 +737,9 @@ apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,53,jest.mock,react-na
 apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,57,jest.mock,../../../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,64,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,75,jest.mock,../../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,88,jest.mock,../../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,104,jest.mock,../../../../components/library/BookCard,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,121,jest.mock,../../../../components/library/SuggestionCard,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,89,jest.mock,../../../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,105,jest.mock,../../../../components/library/BookCard,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx,122,jest.mock,../../../../components/library/SuggestionCard,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/app/(app)/subject/_layout.test.tsx,12,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/subject/[subjectId].test.tsx,5,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/(app)/subject/[subjectId].test.tsx,13,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
@@ -737,21 +751,21 @@ apps/mobile/src/app/(app)/subscription.test.tsx,40,jest.mock,react-i18next,Mobil
 apps/mobile/src/app/(app)/subscription.test.tsx,45,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/subscription.test.tsx,54,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/subscription.test.tsx,58,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/subscription.test.tsx,73,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/subscription.test.tsx,77,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/subscription.test.tsx,83,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/subscription.test.tsx,90,jest.mock,../../lib/analytics,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/subscription.test.tsx,94,jest.mock,../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/(app)/subscription.test.tsx,111,jest.mock,../../hooks/use-revenuecat,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/subscription.test.tsx,133,jest.mock,react-native-purchases,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/subscription.test.tsx,74,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/subscription.test.tsx,78,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/subscription.test.tsx,84,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/subscription.test.tsx,91,jest.mock,../../lib/analytics,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/subscription.test.tsx,95,jest.mock,../../components/common,Mobile tests,P2,ui-harness-debt: component subtree mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/(app)/subscription.test.tsx,112,jest.mock,../../hooks/use-revenuecat,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/(app)/subscription.test.tsx,134,jest.mock,react-native-purchases,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/topic/_layout.test.tsx,16,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/topic/[topicId].test.tsx,17,jest.mock,../../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/(app)/topic/[topicId].test.tsx,26,jest.mock,../../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/(app)/topic/[topicId].test.tsx,56,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/topic/[topicId].test.tsx,66,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/topic/[topicId].test.tsx,70,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/app/(app)/topic/[topicId].test.tsx,74,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/(app)/topic/[topicId].test.tsx,94,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/topic/[topicId].test.tsx,64,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/topic/[topicId].test.tsx,74,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/topic/[topicId].test.tsx,78,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/app/(app)/topic/[topicId].test.tsx,82,jest.mock,../../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/(app)/topic/[topicId].test.tsx,103,jest.mock,../../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/app/(app)/topic/index.test.tsx,5,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/(app)/topic/recall-test.test.tsx,10,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/(app)/topic/recall-test.test.tsx,15,jest.mock,expo-localization,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
@@ -793,8 +807,8 @@ apps/mobile/src/app/create-subject.test.tsx,49,jest.mock,../lib/profile,Mobile t
 apps/mobile/src/app/create-subject.test.tsx,76,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/create-subject.test.tsx,86,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/create-subject.test.tsx,90,jest.mock,../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/create-subject.test.tsx,97,jest.mock,../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/create-subject.test.tsx,106,jest.mock,../hooks/use-keyboard-scroll,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/create-subject.test.tsx,100,jest.mock,../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/create-subject.test.tsx,109,jest.mock,../hooks/use-keyboard-scroll,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/delete-account.test.tsx,15,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/delete-account.test.tsx,17,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/delete-account.test.tsx,25,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
@@ -815,21 +829,21 @@ apps/mobile/src/app/session-summary/[sessionId].test.tsx,33,jest.mock,react-nati
 apps/mobile/src/app/session-summary/[sessionId].test.tsx,37,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/app/session-summary/[sessionId].test.tsx,42,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/session-summary/[sessionId].test.tsx,46,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,53,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,59,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,65,jest.mock,../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,70,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,106,jest.mock,../../hooks/use-parent-proxy,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,113,jest.mock,../../hooks/use-rating-prompt,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,123,jest.mock,../../hooks/use-depth-evaluation,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,131,jest.mock,../../lib/summary-draft,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/app/session-summary/[sessionId].test.tsx,241,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,54,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,60,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,66,jest.mock,../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,71,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,107,jest.mock,../../hooks/use-parent-proxy,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,114,jest.mock,../../hooks/use-rating-prompt,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,124,jest.mock,../../hooks/use-depth-evaluation,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,132,jest.mock,../../lib/summary-draft,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-summary/[sessionId].test.tsx,242,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/session-transcript/[sessionId].test.tsx,24,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/session-transcript/[sessionId].test.tsx,29,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/session-transcript/[sessionId].test.tsx,33,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/session-transcript/[sessionId].test.tsx,43,jest.mock,../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/app/session-transcript/[sessionId].test.tsx,47,jest.mock,../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/app/session-transcript/[sessionId].test.tsx,52,jest.mock,../../hooks/use-sessions,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/app/session-transcript/[sessionId].test.tsx,44,jest.mock,../../lib/navigation,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/app/session-transcript/[sessionId].test.tsx,48,jest.mock,../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/app/session-transcript/[sessionId].test.tsx,53,jest.mock,../../hooks/use-sessions,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/app/sso-callback.test.tsx,5,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/sso-callback.test.tsx,9,jest.mock,expo-web-browser,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/app/sso-callback.test.tsx,17,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
@@ -843,13 +857,10 @@ apps/mobile/src/components/account-security.test.tsx,14,jest.mock,expo-router,Mo
 apps/mobile/src/components/account-security.test.tsx,20,jest.mock,../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/components/change-password.test.tsx,16,jest.mock,@clerk/clerk-expo,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/components/change-password.test.tsx,27,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/change-password.test.tsx,31,jest.mock,../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/change-password.test.tsx,42,jest.mock,../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/change-password.test.tsx,36,jest.mock,../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/components/common/CelebrationAnimation.test.tsx,12,jest.mock,react-native-reanimated,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/common/celebrations/CelestialCelebration.test.tsx,16,jest.mock,react-native-reanimated,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/common/OfflineBanner.test.tsx,4,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/common/OfflineBanner.test.tsx,8,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/common/PasswordInput.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/durability/OutboxFailedBanner.test.tsx,15,jest.mock,../../lib/message-outbox,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/components/durability/OutboxFailedBanner.test.tsx,19,jest.mock,expo-clipboard,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/family/FamilyOrientationCue.test.tsx,14,jest.mock,../../lib/secure-storage,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
@@ -860,65 +871,48 @@ apps/mobile/src/components/family/WithdrawalCountdownBanner.test.tsx,20,jest.moc
 apps/mobile/src/components/family/WithdrawalCountdownBanner.test.tsx,26,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/home/ChildQuotaLine.test.tsx,7,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/components/home/ChildQuotaLine.test.tsx,12,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/CoachBand.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,6,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,14,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,18,jest.mock,../../lib/secure-storage,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,23,jest.mock,../feedback/FeedbackProvider,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,27,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/home/LearnerScreen.test.tsx,60,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/LearnerScreen.test.tsx,64,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/components/home/LearnerScreen.test.tsx,69,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/LearnerScreen.test.tsx,93,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/home/LearnerScreen.test.tsx,98,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/home/LearnerScreen.test.tsx,102,jest.mock,../common,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/home/LearnerScreen.test.tsx,106,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/home/LearnerScreen.test.tsx,119,jest.mock,../../lib/greeting,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/home/LearnerScreen.test.tsx,127,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/LearnerScreen.test.tsx,134,jest.mock,../../hooks/use-subscription,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/LearnerScreen.test.tsx,157,jest.mock,../../lib/session-recovery,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,7,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,11,jest.mock,../../lib/secure-storage,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,16,jest.mock,../feedback/FeedbackProvider,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/home/EarlyAdopterCard.test.tsx,20,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/home/LearnerScreen.test.tsx,63,jest.mock,../../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,67,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
+apps/mobile/src/components/home/LearnerScreen.test.tsx,72,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,96,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/home/LearnerScreen.test.tsx,101,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/home/LearnerScreen.test.tsx,105,jest.mock,../common,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,109,jest.mock,../feedback/FeedbackProvider,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,116,jest.mock,../../lib/greeting,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,124,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,131,jest.mock,../../hooks/use-subscription,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/LearnerScreen.test.tsx,154,jest.mock,../../lib/session-recovery,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/components/home/ParentHomeScreen.test.tsx,11,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,16,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,28,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,38,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,45,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,52,jest.mock,../../hooks/use-dashboard,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,59,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,66,jest.mock,../../hooks/use-subscription,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,77,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,85,jest.mock,../family/WithdrawalCountdownBanner,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,92,jest.mock,../../hooks/use-nudges,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,101,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,106,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
-apps/mobile/src/components/home/ParentHomeScreen.test.tsx,113,jest.mock,../../hooks/use-learner-profile,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,16,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,26,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,33,jest.mock,../../hooks/use-active-profile-role,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,40,jest.mock,../../hooks/use-dashboard,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,47,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,54,jest.mock,../../hooks/use-subscription,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,65,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,73,jest.mock,../family/WithdrawalCountdownBanner,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,80,jest.mock,../../hooks/use-nudges,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,89,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,94,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/mobile/src/components/home/ParentHomeScreen.test.tsx,101,jest.mock,../../hooks/use-learner-profile,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/components/home/ParentTransitionNotice.test.tsx,13,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/components/home/ParentTransitionNotice.test.tsx,21,jest.mock,../../lib/secure-storage,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/CollapsibleChapter.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/InlineNoteCard.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/LibrarySearchBar.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/library/LibrarySearchResults.test.tsx,10,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/components/library/NoteDisplay.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/NoteInput.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/NoteInput.test.tsx,14,jest.mock,../../hooks/use-speech-recognition,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/library/RetentionPill.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/ShelfRow.test.tsx,8,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/components/library/NoteInput.test.tsx,4,jest.mock,../../hooks/use-speech-recognition,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/components/library/StudyCTA.test.tsx,4,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/library/StudyCTA.test.tsx,8,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/TopicHeader.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/TopicPickerSheet.test.tsx,8,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/library/TopicSessionRow.test.tsx,4,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/library/TopicSessionRow.test.tsx,8,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/library/TopicStatusRow.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,16,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,23,jest.mock,../../hooks/use-nudges,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,30,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,42,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,48,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
+apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,31,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
+apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx,37,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/mobile/src/components/nudge/NudgeBanner.test.tsx,5,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/components/nudge/NudgeBanner.test.tsx,10,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/nudge/NudgeBanner.test.tsx,19,jest.mock,../../hooks/use-nudges,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/nudge/NudgeBanner.test.tsx,27,jest.mock,../../hooks/use-consent,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/nudge/NudgeBanner.test.tsx,34,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/nudge/NudgeBanner.test.tsx,12,jest.mock,../../hooks/use-nudges,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/nudge/NudgeBanner.test.tsx,20,jest.mock,../../hooks/use-consent,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/nudge/NudgeBanner.test.tsx,27,jest.mock,../../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/components/nudge/NudgeUnreadModal.test.tsx,5,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/components/progress/AccordionTopicList.test.tsx,8,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/progress/AccordionTopicList.test.tsx,13,jest.mock,../../hooks/use-dashboard,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
@@ -927,6 +921,7 @@ apps/mobile/src/components/progress/CurrentlyWorkingOnCard.test.tsx,4,jest.mock,
 apps/mobile/src/components/progress/MonthlyReportCard.test.tsx,5,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
 apps/mobile/src/components/progress/MonthlyReportCard.test.tsx,12,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
 apps/mobile/src/components/progress/ProgressPillRow.test.tsx,5,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
+apps/mobile/src/components/progress/RemediationCard.test.tsx,5,jest.mock,./RetentionSignal,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Batch 7 - progress/report mobile screens,mobile-internal-target
 apps/mobile/src/components/progress/ReportsListCard.test.tsx,10,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/progress/ReportsListCard.test.tsx,14,jest.mock,../../hooks/use-progress,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 7 - progress/report mobile screens,mobile-internal-target
 apps/mobile/src/components/progress/ReportsListCard.test.tsx,22,jest.mock,react-i18next,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
@@ -937,22 +932,18 @@ apps/mobile/src/components/session/BookmarkNudgeTooltip.test.tsx,10,jest.mock,..
 apps/mobile/src/components/session/ChatShell.test.tsx,11,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/session/ChatShell.test.tsx,24,jest.mock,@react-navigation/native,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/session/ChatShell.test.tsx,28,jest.mock,react-native-safe-area-context,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/session/ChatShell.test.tsx,32,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/ChatShell.test.tsx,41,jest.mock,../../lib/math-format,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/session/ChatShell.test.tsx,45,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/session/ChatShell.test.tsx,69,jest.mock,../../hooks/use-speech-recognition,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/session/ChatShell.test.tsx,86,jest.mock,../../hooks/use-text-to-speech,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/session/ChatShell.test.tsx,98,jest.mock,../common,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/session/ChatShell.test.tsx,32,jest.mock,../../lib/math-format,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/session/ChatShell.test.tsx,36,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/session/ChatShell.test.tsx,60,jest.mock,../../hooks/use-speech-recognition,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/session/ChatShell.test.tsx,77,jest.mock,../../hooks/use-text-to-speech,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/session/ChatShell.test.tsx,89,jest.mock,../common,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/components/session/FilingFailedBanner.test.tsx,7,jest.mock,../../lib/sentry,Mobile tests,P3,observability: logging or error-capture sink,Retain,observability-wrapper
 apps/mobile/src/components/session/FilingFailedBanner.test.tsx,13,jest.mock,../../hooks/use-retry-filing,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/session/LivingBook.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/session/QuotaExceededCard.test.tsx,4,jest.mock,expo-router,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/session/SessionFooter.test.tsx,9,jest.mock,../session,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/session/SessionFooter.test.tsx,14,jest.mock,../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/session/SessionFooter.test.tsx,18,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/SessionFooter.test.tsx,28,jest.mock,../../hooks/use-speech-recognition,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/components/session/SessionInputModeToggle.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/SessionInputModeToggle.test.tsx,11,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/session/SessionFooter.test.tsx,10,jest.mock,../session,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/session/SessionFooter.test.tsx,16,jest.mock,../../lib/format-api-error,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
+apps/mobile/src/components/session/SessionFooter.test.tsx,21,jest.mock,../../hooks/use-speech-recognition,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
+apps/mobile/src/components/session/SessionInputModeToggle.test.tsx,4,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/session/use-session-actions.test.ts,5,jest.mock,../../lib/platform-alert,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
 apps/mobile/src/components/session/use-session-actions.test.ts,9,jest.mock,../../lib/session-recovery,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/components/session/use-session-streaming.test.ts,9,jest.mock,../session,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
@@ -961,13 +952,10 @@ apps/mobile/src/components/session/use-session-streaming.test.ts,21,jest.mock,..
 apps/mobile/src/components/session/use-session-streaming.test.ts,27,jest.mock,../homework/problem-cards,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/components/session/use-session-streaming.test.ts,33,jest.mock,../../hooks/use-milestone-tracker,Mobile tests,P2,ui-harness-debt: query or state hook is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/components/session/use-subject-classification.test.ts,5,jest.mock,../session,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
-apps/mobile/src/components/session/VoicePlaybackBar.test.tsx,4,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/VoicePlaybackBar.test.tsx,11,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/session/VoicePlaybackBar.test.tsx,4,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/components/session/VoiceRecordButton.test.tsx,12,jest.mock,../../lib/haptics,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/VoiceRecordButton.test.tsx,18,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/VoiceRecordButton.test.tsx,27,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
-apps/mobile/src/components/session/VoiceToggle.test.tsx,8,jest.mock,../../lib/theme,Mobile tests,P3,native-boundary: approved mobile platform wrapper,Retain,mobile-platform-wrapper
-apps/mobile/src/components/session/VoiceToggle.test.tsx,15,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/session/VoiceRecordButton.test.tsx,18,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
+apps/mobile/src/components/session/VoiceToggle.test.tsx,8,jest.mock,@expo/vector-icons,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/hooks/use-account.test.ts,11,jest.mock,../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/hooks/use-active-profile-role.test.ts,6,jest.mock,../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/hooks/use-active-profile-role.test.ts,10,jest.mock,./use-parent-proxy,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
@@ -1012,8 +1000,6 @@ apps/mobile/src/hooks/use-post-session-notification-ask.test.ts,18,jest.mock,../
 apps/mobile/src/hooks/use-profiles.test.ts,7,jest.mock,../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/hooks/use-profiles.test.ts,26,jest.mock,../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/hooks/use-profiles.test.ts,29,jest.mock,@clerk/clerk-expo,Mobile tests,P3,external-boundary: third-party SDK or framework runtime,Retain,known-external-sdk
-apps/mobile/src/hooks/use-progress.test.ts,15,jest.mock,../lib/api-client,Mobile tests,P2,ui-harness-debt: API client mock hides query/error behavior,Batch 3 - mobile query/profile harness,mobile-internal-target
-apps/mobile/src/hooks/use-progress.test.ts,34,jest.mock,../lib/profile,Mobile tests,P2,ui-harness-debt: profile/auth provider is mocked,Batch 3 - mobile query/profile harness,mobile-internal-target
 apps/mobile/src/hooks/use-push-token-registration.test.ts,23,jest.mock,./use-settings,Mobile tests,P2,ui-harness-debt: internal mobile module mock,Opportunistic mobile cleanup,mobile-internal-target
 apps/mobile/src/hooks/use-push-token-registration.test.ts,27,jest.mock,expo-constants,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary
 apps/mobile/src/hooks/use-rating-prompt.test.ts,8,jest.mock,expo-store-review,Mobile tests,P3,native-boundary: platform or React Native module shim,Retain,known-native-boundary

--- a/docs/plans/2026-05-12-internal-mock-cleanup-inventory.md
+++ b/docs/plans/2026-05-12-internal-mock-cleanup-inventory.md
@@ -1,7 +1,7 @@
 # Internal Mock Cleanup Inventory
 
 **Date:** 2026-05-12  
-**Status:** Inventory + cleanup proposal  
+**Status:** Inventory + cleanup in progress; P0 and focused P1/P2 cleanup slices verified 2026-05-12  
 **Goal:** Reduce internal mocks that hide route/service/background-job contract drift while preserving true external boundary shims.
 
 ## Why
@@ -26,34 +26,36 @@ Raw rows are written to `docs/plans/2026-05-12-internal-mock-cleanup-inventory.c
 
 | Area | Internal-ish mocks | External mocks | Notes |
 | --- | ---: | ---: | --- |
-| Mobile tests | 302 | 351 | Mostly profile/API/query hooks and component subtree stubs; native/platform wrappers classify as retained boundaries. |
-| API Inngest tests | 112 | 45 | Highest concentration of service and database mocks around durable workflows; Inngest client dispatch shims classify as retained boundaries. |
-| API route + top-level integration tests | 110 | 44 | Route tests heavily mock services/database; top-level integration mocks are mostly boundary wrappers. |
+| Mobile tests | 308 | 326 | Mostly profile/API/query hooks and component subtree stubs; native/platform wrappers classify as retained boundaries. Focused component theme mocks and `use-progress.test.ts` API/profile mocks have been removed from the refreshed CSV. |
+| API Inngest tests | 117 | 47 | Highest concentration of service and database mocks around durable workflows; Inngest client dispatch shims classify as retained boundaries. |
+| API route + top-level integration tests | 108 | 44 | Route tests heavily mock services/database; top-level integration mocks are mostly boundary wrappers. P0 integration offenders are now drained. |
 | API service/middleware unit tests | 82 | 23 | Includes `@eduagent/database`, LLM router, sibling services, and Sentry/logging wrappers. |
 | API eval-llm tests | 0 | 1 | Eval harness LLM transport mock is classified as an external boundary. |
-| **Total** | **606** | **464** | **1,070 mock call rows across 293 test files, including 1,069 `jest.mock(...)` rows and 1 `jest.doMock(...)` row.** |
+| **Total** | **615** | **441** | **1,056 mock call rows across 281 test files, including 1,055 `jest.mock(...)` rows.** |
 
 Risk-class counts from the CSV:
 
 | Risk class | Count |
 | --- | ---: |
-| `P0` | 2 |
-| `P1` | 302 |
-| `P2` | 302 |
-| `P3` | 464 |
+| `P0` | 0 |
+| `P1` | 307 |
+| `P2` | 308 |
+| `P3` | 441 |
 
 Top internal-ish mocked targets:
 
 | Target | Count | Risk read |
 | --- | ---: | --- |
 | `@eduagent/database` | 54 | High when used above service-unit level; can hide scoped-repository and write-ownership regressions. |
-| `../lib/profile` | 27 | Medium; UI tests often bypass provider/state behavior. |
-| `../lib/api-client` | 24 | Medium-high in hooks/screens; can hide API error classification and query behavior. |
+| `../lib/profile` | 26 | Medium; UI tests often bypass provider/state behavior. |
+| `../lib/api-client` | 23 | Medium-high in hooks/screens; can hide API error classification and query behavior. |
 | `../services/account` | 23 | High in route/middleware tests; account/profile bootstrap bugs can disappear. |
-| `../helpers` | 21 | High in Inngest tests when step/runtime behavior is replaced. |
+| `../helpers` | 22 | High in Inngest tests when step/runtime behavior is replaced. |
 | `../services/profile` | 18 | High for profile scoping and parent/child access paths. |
-| `./llm` | 13 | High where integration/workflow behavior should use provider registration or HTTP-boundary interception. |
+| `./llm` | 12 | High where integration/workflow behavior should use provider registration or HTTP-boundary interception. |
+| `../../lib/profile` | 11 | Medium; UI tests often bypass provider/state behavior. |
 | `../../services/notifications` | 10 | High where notification formatting/business behavior is replaced, acceptable only for send transport. |
+| `../../../lib/profile` | 9 | Medium; UI tests often bypass provider/state behavior. |
 | `../../services/settings` | 9 | High where rate-limit, learning-mode, or notification settings behavior is replaced. |
 
 Top files by internal-ish mock count:
@@ -66,12 +68,12 @@ Top files by internal-ish mock count:
 | `apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx` | 11 | P2 UI screen harness debt. |
 | `apps/api/src/middleware/metering.test.ts` | 9 | P1 quota/billing correctness risk. |
 | `apps/mobile/src/app/(app)/child/[profileId]/index.test.tsx` | 9 | P2 UI screen harness debt. |
+| `apps/mobile/src/components/home/LearnerScreen.test.tsx` | 8 | P2 UI harness debt; real theme path restored, remaining mocks are API/profile/subtree follow-up debt. |
 | `apps/mobile/src/components/home/ParentHomeScreen.test.tsx` | 8 | P2 UI screen harness debt, already annotated with many `gc1-allow` reasons. |
+| `apps/api/src/inngest/functions/monthly-report-cron.test.ts` | 7 | P1 durable report workflow risk. |
 | `apps/api/src/inngest/functions/trial-expiry.test.ts` | 7 | P1 billing lifecycle risk. |
 | `apps/api/src/routes/filing.test.ts` | 7 | P1 LLM/session/filing contract risk. |
 | `apps/api/src/routes/sessions.test.ts` | 7 | P1 route-service-contract risk. |
-| `apps/api/src/services/session/session-cache.test.ts` | 7 | P1 service-contract risk. |
-| `apps/mobile/src/app/(app)/progress/[subjectId]/index.test.tsx` | 7 | P2 follow-up Batch 7 progress/report harness debt. |
 
 Mobile internal-ish groups:
 
@@ -104,6 +106,16 @@ Mobile internal-ish groups:
   - `tests/integration/learning-session.integration.test.ts`
   - `apps/api/src/inngest/functions/weekly-progress-push.integration.test.ts`
 - `gc1-allow` annotations exist, but they are inconsistent and currently mix external-boundary explanations with broad "unit test boundary" exceptions.
+
+## Cleanup Update - 2026-05-12
+
+Focused P1/P2 follow-up from this inventory is complete and reflected in the regenerated CSV:
+
+- Removed component-test `../../lib/theme` mocks from the touched component slice. Remaining component tests use real `useThemeColors()` defaults or an explicit real `ThemeContext` provider where needed.
+- Converted `apps/mobile/src/hooks/use-progress.test.ts` away from internal `../lib/api-client` and `../lib/profile` mocks. The suite now uses fake `globalThis.fetch`, the real API client boundary, a real profile-aware hook wrapper, and a 403 response that exercises `ForbiddenError` classification.
+- Migrated `tests/integration/subject-management.integration.test.ts` assertions onto shared response schemas and added a two-seeded-profile negative path proving a subject created under one profile is not visible through another profile.
+- Re-verified the integration mock guard with an empty offender allowlist; the only remaining integration Inngest client mock is the documented transport-boundary capture in `tests/integration/review-session-calibration.integration.test.ts`.
+- Regenerated `docs/plans/2026-05-12-internal-mock-cleanup-inventory.csv` after the cleanup. The refreshed inventory has 1,056 rows across 281 files, with `P0 = 0`.
 
 ## First 3 Cleanup Batches
 
@@ -184,6 +196,11 @@ These are the first concrete checks. This table should grow as each shared utili
 | DB-backed LLM integration fixture conversion | `pnpm exec jest -c tests/integration/jest.config.cjs learning-session.integration.test.ts --runInBand --no-coverage` | **Blocked by environment** | `tests/integration/learning-session.integration.test.ts` now uses the shared fixture, but local execution stops in integration setup because `DATABASE_URL` is unset. Step 4 should make this proof runnable locally. |
 | Integration mock ratchet guard | `pnpm exec jest -c apps/api/jest.config.cjs apps/api/src/services/llm/integration-mock-guard.test.ts --runInBand --no-coverage` | **Passed**: 1 suite, 4 tests | The guard now enumerates `apps/api` and `tests/integration`, rejects non-allowlisted internal `jest.mock()` calls, allows only documented Sentry/Stripe/Inngest transport boundaries, keeps an empty shrinking offender allowlist, and includes a detector self-check for internal vs external mock specifiers. |
 | P0 integration mock cleanup | `pnpm exec jest -c apps/api/jest.integration.config.cjs --runTestsByPath apps/api/src/services/book-suggestion-generation.integration.test.ts apps/api/src/services/nudge.integration.test.ts --runInBand --no-coverage` | **Passed**: 2 suites, 10 tests | Converted `book-suggestion-generation.integration.test.ts` from `jest.mock('./llm')` to the shared LLM provider fixture, and converted `nudge.integration.test.ts` from `jest.mock('./notifications')` to the shared Expo Push fetch interceptor. Jest emitted the existing open-handle warning after success. |
+| Component real-theme cleanup | `pnpm exec jest -c apps/mobile/jest.config.cjs --runTestsByPath apps/mobile/src/components/change-password.test.tsx apps/mobile/src/components/common/OfflineBanner.test.tsx apps/mobile/src/components/common/PasswordInput.test.tsx apps/mobile/src/components/home/CoachBand.test.tsx apps/mobile/src/components/home/EarlyAdopterCard.test.tsx apps/mobile/src/components/home/ParentHomeScreen.test.tsx apps/mobile/src/components/library/CollapsibleChapter.test.tsx apps/mobile/src/components/library/InlineNoteCard.test.tsx apps/mobile/src/components/library/LibrarySearchBar.test.tsx apps/mobile/src/components/library/NoteDisplay.test.tsx apps/mobile/src/components/library/NoteInput.test.tsx apps/mobile/src/components/library/RetentionPill.test.tsx apps/mobile/src/components/library/ShelfRow.test.tsx apps/mobile/src/components/library/StudyCTA.test.tsx apps/mobile/src/components/library/TopicHeader.test.tsx apps/mobile/src/components/library/TopicPickerSheet.test.tsx apps/mobile/src/components/library/TopicSessionRow.test.tsx apps/mobile/src/components/library/TopicStatusRow.test.tsx apps/mobile/src/components/nudge/NudgeActionSheet.test.tsx apps/mobile/src/components/nudge/NudgeBanner.test.tsx apps/mobile/src/components/session/ChatShell.test.tsx apps/mobile/src/components/session/LivingBook.test.tsx apps/mobile/src/components/session/SessionFooter.test.tsx apps/mobile/src/components/session/SessionInputModeToggle.test.tsx apps/mobile/src/components/session/VoicePlaybackBar.test.tsx apps/mobile/src/components/session/VoiceRecordButton.test.tsx apps/mobile/src/components/session/VoiceToggle.test.tsx --runInBand --no-coverage` | **Passed**: 27 suites, 299 tests | Removes the touched component-test theme mocks. `LibrarySearchBar.test.tsx` now uses a real `ThemeContext`; `TopicPickerSheet.test.tsx` asserts real token values. Existing warnings remain from Expo native module setup and `ParentTransitionNotice` async state updates. |
+| Learner home real-theme assertion pass | `pnpm exec jest -c apps/mobile/jest.config.cjs --runTestsByPath apps/mobile/src/components/home/LearnerScreen.test.tsx --runInBand --no-coverage --forceExit` | **Passed**: 1 suite, 28 tests | `LearnerScreen.test.tsx` no longer mocks `../../lib/theme`. The suite still needs `--forceExit` because the mobile home harness leaves async work open after assertions pass. |
+| Progress hooks HTTP-boundary cleanup | `pnpm exec jest -c apps/mobile/jest.config.cjs apps/mobile/src/hooks/use-progress.test.ts --runInBand --no-coverage` | **Passed**: 1 suite, 9 tests | Converts progress hooks from internal API/profile mocks to fake HTTP responses through the real client boundary, including a 403 classification test that would fail if production error classification regressed. |
+| Subject route real-service cleanup | `pnpm exec jest -c tests/integration/jest.config.cjs subject-management.integration.test.ts --runInBand --no-coverage` | **Passed**: 1 suite, 10 tests | Route tests parse shared response schemas and include a two-profile negative path. The suite emits the existing integration-test open-handle warning after success. |
+| Refreshed inventory CSV | `pnpm exec tsx scripts/generate-internal-mock-cleanup-inventory.ts` | **Generated**: 1,056 rows across 281 files | Regenerated the companion CSV after cleanup. The refreshed classification has `P0 = 0`, `P1 = 307`, `P2 = 308`, and `P3 = 441`. |
 | Mobile profile/provider wrapper | `pnpm exec jest -c apps/mobile/jest.config.cjs apps/mobile/src/hooks/use-push-token-registration.test.ts --runInBand --no-coverage` | **Passed**: 9 tests | Proves controlled profile fixture/provider pattern works for hook tests. Warnings remain from Expo native module setup and React act noise. |
 | Mobile routed API fetch | `pnpm exec jest -c apps/mobile/jest.config.cjs --runTestsByPath "apps/mobile/src/app/(app)/home.test.tsx" --runInBand --no-coverage` | **Assertions passed, process timed out** | Proves route-shaped mock fetch can drive screen behavior, but the screen harness left async work/open handles. Batch 3 should include teardown/query-cache cleanup in the shared render helper. |
 | API app typecheck after shared API fixtures | `pnpm exec tsc -p apps/api/tsconfig.app.json --noEmit --pretty false` | **Passed** | Confirms the API app build graph accepts the shared Inngest and LLM test utilities. Broad spec typecheck is still noisy from pre-existing test errors and was not used as the completion gate. |

--- a/tests/integration/subject-management.integration.test.ts
+++ b/tests/integration/subject-management.integration.test.ts
@@ -19,21 +19,31 @@
 
 import { buildIntegrationEnv, cleanupAccounts } from './helpers';
 import { buildAuthHeaders, createProfileViaRoute } from './route-fixtures';
+import {
+  createSubjectWithStructureResponseSchema,
+  subjectListResponseSchema,
+  subjectResponseSchema,
+} from '@eduagent/schemas';
 
 import { app } from '../../apps/api/src/index';
 
 const TEST_ENV = buildIntegrationEnv();
 const SUBJECT_AUTH_USER_ID = 'integration-subject-user';
 const SUBJECT_AUTH_EMAIL = 'integration-subjects@integration.test';
+const OTHER_SUBJECT_AUTH_USER_ID = 'integration-subject-other-user';
+const OTHER_SUBJECT_AUTH_EMAIL = 'integration-subjects-other@integration.test';
 
 const SUBJECT_ID = '00000000-0000-4000-8000-000000000040';
 
-async function createOwnerProfile(): Promise<string> {
+async function createOwnerProfile(
+  user = { userId: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
+  displayName = 'Integration Learner',
+): Promise<string> {
   const profile = await createProfileViaRoute({
     app,
     env: TEST_ENV,
-    user: { userId: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-    displayName: 'Integration Learner',
+    user,
+    displayName,
     birthYear: 2000,
   });
   return profile.id;
@@ -41,7 +51,8 @@ async function createOwnerProfile(): Promise<string> {
 
 async function createSubject(
   profileId: string,
-  name: string
+  name: string,
+  user = { userId: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
 ): Promise<{
   id: string;
   name: string;
@@ -51,16 +62,16 @@ async function createSubject(
     {
       method: 'POST',
       headers: buildAuthHeaders(
-        { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-        profileId
+        { sub: user.userId, email: user.email },
+        profileId,
       ),
       body: JSON.stringify({ name }),
     },
-    TEST_ENV
+    TEST_ENV,
   );
 
   expect(res.status).toBe(201);
-  const body = await res.json();
+  const body = createSubjectWithStructureResponseSchema.parse(await res.json());
   expect(body.subject).toMatchObject({ id: expect.any(String), name });
   return body.subject as { id: string; name: string };
 }
@@ -68,15 +79,15 @@ async function createSubject(
 beforeEach(async () => {
   jest.clearAllMocks();
   await cleanupAccounts({
-    emails: [SUBJECT_AUTH_EMAIL],
-    clerkUserIds: [SUBJECT_AUTH_USER_ID],
+    emails: [SUBJECT_AUTH_EMAIL, OTHER_SUBJECT_AUTH_EMAIL],
+    clerkUserIds: [SUBJECT_AUTH_USER_ID, OTHER_SUBJECT_AUTH_USER_ID],
   });
 });
 
 afterAll(async () => {
   await cleanupAccounts({
-    emails: [SUBJECT_AUTH_EMAIL],
-    clerkUserIds: [SUBJECT_AUTH_USER_ID],
+    emails: [SUBJECT_AUTH_EMAIL, OTHER_SUBJECT_AUTH_EMAIL],
+    clerkUserIds: [SUBJECT_AUTH_USER_ID, OTHER_SUBJECT_AUTH_USER_ID],
   });
 });
 
@@ -95,14 +106,14 @@ describe('Integration: GET /v1/subjects', () => {
         method: 'GET',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = subjectListResponseSchema.parse(await res.json());
     expect(body.subjects).toHaveLength(1);
     expect(body.subjects[0].id).toBe(subject.id);
     expect(body.subjects[0].name).toBe('Mathematics');
@@ -119,11 +130,11 @@ describe('Integration: GET /v1/subjects', () => {
         method: 'PATCH',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
         body: JSON.stringify({ status: 'archived' }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
     expect(archiveRes.status).toBe(200);
 
@@ -133,17 +144,17 @@ describe('Integration: GET /v1/subjects', () => {
         method: 'GET',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = subjectListResponseSchema.parse(await res.json());
     expect(body.subjects).toHaveLength(2);
     expect(body.subjects.map((row: { id: string }) => row.id)).toEqual(
-      expect.arrayContaining([active.id, archived.id])
+      expect.arrayContaining([active.id, archived.id]),
     );
   });
 
@@ -168,15 +179,17 @@ describe('Integration: POST /v1/subjects', () => {
         method: 'POST',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
         body: JSON.stringify({ name: 'Mathematics' }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(201);
-    const body = await res.json();
+    const body = createSubjectWithStructureResponseSchema.parse(
+      await res.json(),
+    );
     expect(body.subject).toMatchObject({
       id: expect.any(String),
       name: 'Mathematics',
@@ -193,11 +206,11 @@ describe('Integration: POST /v1/subjects', () => {
         method: 'POST',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
         body: JSON.stringify({ name: '' }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(400);
@@ -219,15 +232,56 @@ describe('Integration: GET /v1/subjects/:id', () => {
         method: 'GET',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = subjectResponseSchema.parse(await res.json());
     expect(body.subject).toMatchObject({ id: subject.id, name: 'Mathematics' });
+  });
+
+  it('does not expose a subject across two seeded profiles', async () => {
+    const ownerProfileId = await createOwnerProfile();
+    const otherProfileId = await createOwnerProfile(
+      {
+        userId: OTHER_SUBJECT_AUTH_USER_ID,
+        email: OTHER_SUBJECT_AUTH_EMAIL,
+      },
+      'Other Integration Learner',
+    );
+    const subject = await createSubject(ownerProfileId, 'Private Mathematics');
+    const otherHeaders = buildAuthHeaders(
+      {
+        sub: OTHER_SUBJECT_AUTH_USER_ID,
+        email: OTHER_SUBJECT_AUTH_EMAIL,
+      },
+      otherProfileId,
+    );
+
+    const detailRes = await app.request(
+      `/v1/subjects/${subject.id}`,
+      {
+        method: 'GET',
+        headers: otherHeaders,
+      },
+      TEST_ENV,
+    );
+    expect(detailRes.status).toBe(404);
+
+    const listRes = await app.request(
+      '/v1/subjects?includeInactive=true',
+      {
+        method: 'GET',
+        headers: otherHeaders,
+      },
+      TEST_ENV,
+    );
+    expect(listRes.status).toBe(200);
+    const listBody = subjectListResponseSchema.parse(await listRes.json());
+    expect(listBody.subjects).toEqual([]);
   });
 
   it('returns 404 when not found', async () => {
@@ -239,10 +293,10 @@ describe('Integration: GET /v1/subjects/:id', () => {
         method: 'GET',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(404);
@@ -266,15 +320,15 @@ describe('Integration: PATCH /v1/subjects/:id', () => {
         method: 'PATCH',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
         body: JSON.stringify({ name: 'Advanced Mathematics' }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = subjectResponseSchema.parse(await res.json());
     expect(body.subject).toMatchObject({
       id: subject.id,
       name: 'Advanced Mathematics',
@@ -290,11 +344,11 @@ describe('Integration: PATCH /v1/subjects/:id', () => {
         method: 'PATCH',
         headers: buildAuthHeaders(
           { sub: SUBJECT_AUTH_USER_ID, email: SUBJECT_AUTH_EMAIL },
-          profileId
+          profileId,
         ),
         body: JSON.stringify({ name: 'Updated Name' }),
       },
-      TEST_ENV
+      TEST_ENV,
     );
 
     expect(res.status).toBe(404);

--- a/tests/integration/subject-management.integration.test.ts
+++ b/tests/integration/subject-management.integration.test.ts
@@ -11,9 +11,9 @@
  * 3. POST /v1/subjects — 201 creates subject
  * 4. POST /v1/subjects — 400 with invalid body
  * 5. GET /v1/subjects/:id — 200 returns subject
- * 6. GET /v1/subjects/:id — 404 when not found
+ * 6. GET /v1/subjects/:id — 404 when not found/cross-profile
  * 7. PATCH /v1/subjects/:id — 200 updates subject
- * 8. PATCH /v1/subjects/:id — 404 when not found
+ * 8. PATCH /v1/subjects/:id — 404 when not found/cross-profile
  * 9. GET /v1/subjects — 401 without auth
  */
 
@@ -270,6 +270,17 @@ describe('Integration: GET /v1/subjects/:id', () => {
       TEST_ENV,
     );
     expect(detailRes.status).toBe(404);
+
+    const patchRes = await app.request(
+      `/v1/subjects/${subject.id}`,
+      {
+        method: 'PATCH',
+        headers: otherHeaders,
+        body: JSON.stringify({ name: 'Hijacked Mathematics' }),
+      },
+      TEST_ENV,
+    );
+    expect(patchRes.status).toBe(404);
 
     const listRes = await app.request(
       '/v1/subjects?includeInactive=true',


### PR DESCRIPTION
## Summary
- removed real-theme internal mocks from touched component tests and updated the inventory doc/CSV
- converted progress hooks to fake HTTP-boundary tests that exercise the real client classification path
- moved subject management integration assertions toward schema parsing and added a two-profile scoping negative path

## Tests
- pnpm exec jest -c apps/mobile/jest.config.cjs --runTestsByPath <component suites> --runInBand --no-coverage
- pnpm exec jest -c apps/mobile/jest.config.cjs apps/mobile/src/hooks/use-progress.test.ts --runInBand --no-coverage
- pnpm exec jest -c tests/integration/jest.config.cjs subject-management.integration.test.ts --runInBand --no-coverage
- pnpm exec jest -c apps/api/jest.config.cjs apps/api/src/services/llm/integration-mock-guard.test.ts --runInBand --no-coverage
- pnpm exec tsx scripts/generate-internal-mock-cleanup-inventory.ts --check
- pre-commit: tsc --build plus related mobile tests, 29 suites / 336 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched many mobile component tests to use the real theme and consolidated test harnesses; added API-bound progress hook error coverage and multi-profile integration checks.

* **Bug Fixes**
  * Improved handling and messaging when saving notes fails (keeps editor open and surfaces formatted error).

* **Chores**
  * Updated mock-cleanup docs, CI workflows, E2E staging URLs, and Playwright worker settings for shared staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->