### PR TITLE
refactor: Cleanup PR-24 — Per-package READMEs

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -10,7 +10,7 @@ Hono REST API running on Cloudflare Workers. Provides all backend endpoints for 
 | Runtime | Cloudflare Workers |
 | Database | Neon (PostgreSQL) via `@eduagent/database` |
 | Auth | Clerk JWKS verification |
-| Background jobs | Inngest v3 (45 functions) |
+| Background jobs | Inngest v3 |
 | LLM | Multi-provider via `services/llm/router.ts` |
 
 ## Structure

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,69 @@
+# @eduagent/api
+
+Hono REST API running on Cloudflare Workers. Provides all backend endpoints for the MentoMate mobile app.
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Framework | Hono 4.11 |
+| Runtime | Cloudflare Workers |
+| Database | Neon (PostgreSQL) via `@eduagent/database` |
+| Auth | Clerk JWKS verification |
+| Background jobs | Inngest v3 (45 functions) |
+| LLM | Multi-provider via `services/llm/router.ts` |
+
+## Structure
+
+```
+src/
+  config.ts           Typed environment config (use this; never raw process.env)
+  index.ts            Hono app entry + route mounting
+  routes/             One file per route group — handlers only, no business logic
+  services/           Business logic, LLM prompts, billing, session management
+  inngest/            Inngest client, function registry, background function files
+  middleware/         Auth (Clerk JWT), error handling, env validation
+  data/               Static seed data
+```
+
+## Key Patterns
+
+- All routes are prefixed `/v1/`. App Store binaries cannot be force-updated.
+- Route handlers are inline for Hono RPC type inference. Logic lives in `services/`.
+- Route files must not import ORM primitives — call a service function instead.
+- Services must not import from `hono` — they receive typed args, return typed results.
+- Use the typed `config` object from `config.ts`. Raw `process.env` reads are banned by eslint G4.
+- Error responses use `ApiErrorSchema` from `@eduagent/schemas`. Never ad-hoc JSON.
+- Durable background work goes through Inngest. No fire-and-forget from route handlers.
+- LLM structured responses use `llmResponseEnvelopeSchema` + `parseEnvelope()`.
+
+## Development
+
+```bash
+# Local dev server (Wrangler)
+pnpm exec nx dev api
+
+# Lint
+pnpm exec nx run api:lint
+
+# Type check
+pnpm exec nx run api:typecheck
+
+# Tests
+pnpm exec nx run api:test
+
+# LLM eval harness (snapshot — no LLM call)
+pnpm eval:llm
+
+# LLM eval harness (live — real LLM call)
+pnpm eval:llm --live
+```
+
+## Deploy
+
+```bash
+# Deploy to Cloudflare Workers
+pnpm exec nx deploy api
+```
+
+Secrets are managed via Doppler. Never use `wrangler secret put` directly.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,80 @@
+# @eduagent/mobile
+
+Expo (React Native) mobile app for MentoMate — the AI-powered tutoring platform.
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Framework | Expo SDK 54, React Native |
+| Styling | NativeWind 4.2.1 (Tailwind CSS 3.4.19) |
+| Navigation | Expo Router (file-system based) |
+| Auth | Clerk (`@clerk/clerk-expo`) |
+| Server state | TanStack Query v5 |
+| API client | Hono RPC (`import type { AppType } from '@eduagent/api'`) |
+
+## Structure
+
+```
+src/
+  app/              Expo Router pages
+    (auth)/         Unauthenticated screens (sign-in, sign-up)
+    (app)/          Authenticated app screens
+  components/       Shared UI components (persona-unaware)
+  hooks/            Custom React hooks
+  lib/              Utilities: api-client, secure-storage, design-tokens, error classes
+  providers/        React context providers (auth, active profile)
+  i18n/             Internationalization (7 locales: en, es, nb, pt, pl, de, ja)
+  test-utils/       Mobile-specific test helpers
+```
+
+## Tab Shapes
+
+Two tab shapes exist — selected by `resolveTabShape()`:
+
+| Shape | Who | Tabs |
+|-------|-----|------|
+| **guardian** | Owner with linked children | Home, Own Learning, Library, Progress, More |
+| **learner** | Everyone else | Home, Library, Progress, More |
+
+Use `isOwner` / `role` for content gating inside screens. Never use `personaFromBirthYear()` for feature gating (theming only).
+
+## Key Rules
+
+- Shared components are persona-unaware. Use NativeWind semantic classes (`bg-surface`, `text-primary`), not hardcoded hex colors or persona checks.
+- No direct `expo-secure-store` imports — use `src/lib/secure-storage.ts`. Keys must use only letters, digits, `.`, `-`, `_`.
+- Default exports only for Expo Router page components under `src/app/**`.
+- No global `crypto` (Hermes doesn't have it) — use `Crypto.randomUUID()` from `expo-crypto`.
+- Every `.mutateAsync()` call needs visible error handling.
+- Cross-tab `router.push` must push the full ancestor chain, not just the leaf.
+
+## Development
+
+```bash
+# iOS
+pnpm exec nx run mobile:ios
+
+# Android
+pnpm exec nx run mobile:android
+
+# Tests
+cd apps/mobile && pnpm exec jest --findRelatedTests src/path/to/file.tsx --no-coverage
+
+# Type check
+cd apps/mobile && pnpm exec tsc --noEmit
+
+# Lint
+pnpm exec nx lint mobile
+```
+
+## OTA Updates
+
+```bash
+# Preview channel
+pnpm run ota:preview
+
+# Production channel
+pnpm run ota:production
+```
+
+Both commands use Doppler for environment injection (`-c stg` / `-c prd`).

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -1,0 +1,86 @@
+# @eduagent/database
+
+Drizzle ORM schema, migrations, and scoped repository for Neon (PostgreSQL) + pgvector.
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| ORM | Drizzle ORM |
+| Database | Neon (PostgreSQL) with pgvector extension |
+| Driver | `@neondatabase/serverless` |
+| Auth isolation | Profile-scoped repository pattern + RLS |
+
+## Structure
+
+```
+src/
+  schema/           Drizzle table definitions (one file per domain)
+  client.ts         Neon database client factory
+  repository.ts     createScopedRepository — profile-isolated read helper
+  account-repository.ts  Account-level (cross-profile) queries
+  rls.ts            Row-level security helpers
+  queries/          Embeddings and other complex queries
+  utils/            UUID helpers
+  streaks-rules.ts  Streak calculation logic
+```
+
+## Key Patterns
+
+### Reading data
+
+Always use `createScopedRepository(profileId)` for queries on a single scoped table:
+
+```typescript
+const repo = createScopedRepository(db, profileId);
+const row = await repo.assessments.findFirst(eq(assessments.id, id));
+```
+
+For multi-table joins through a parent chain, use `db.select()` directly and enforce `profileId` via the closest ancestor:
+
+```typescript
+// Correct: profile enforced via subjects.profileId (parent chain)
+await db.select()
+  .from(learningSession)
+  .innerJoin(curriculumTopics, eq(learningSession.topicId, curriculumTopics.id))
+  .innerJoin(subjects, eq(curriculumTopics.subjectId, subjects.id))
+  .where(eq(subjects.profileId, profileId));
+```
+
+### Writing data
+
+Include explicit `profileId` protection in every write:
+
+```typescript
+await db.update(subjects)
+  .set({ ... })
+  .where(and(eq(subjects.id, id), eq(subjects.profileId, profileId)));
+```
+
+## Schema Migration
+
+```bash
+# Dev: push schema directly (never use against staging/production)
+pnpm run db:push:dev
+
+# Generate migration SQL
+pnpm run db:generate:dev
+
+# Apply migration
+pnpm run db:migrate:dev
+
+# Open Drizzle Studio
+pnpm run db:studio:dev
+```
+
+**Never run `drizzle-kit push` against staging or production.** Use committed migration SQL + `drizzle-kit migrate`.
+
+Any migration that drops columns, tables, or types must include a `## Rollback` section specifying reversibility and data loss.
+
+## Testing
+
+Integration tests run against a real Neon database. Never mock the database in integration tests.
+
+```bash
+pnpm exec nx run database:test
+```

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -41,8 +41,8 @@ For multi-table joins through a parent chain, use `db.select()` directly and enf
 ```typescript
 // Correct: profile enforced via subjects.profileId (parent chain)
 await db.select()
-  .from(learningSession)
-  .innerJoin(curriculumTopics, eq(learningSession.topicId, curriculumTopics.id))
+  .from(learningSessions)
+  .innerJoin(curriculumTopics, eq(learningSessions.topicId, curriculumTopics.id))
   .innerJoin(subjects, eq(curriculumTopics.subjectId, subjects.id))
   .where(eq(subjects.profileId, profileId));
 ```

--- a/packages/retention/README.md
+++ b/packages/retention/README.md
@@ -1,0 +1,56 @@
+# @eduagent/retention
+
+Pure TypeScript implementation of the SM-2 spaced repetition algorithm.
+
+## Overview
+
+Zero dependencies. Deterministic output. Used by `apps/api` to schedule review intervals after each learning session assessment.
+
+Reference: [SuperMemo SM-2 algorithm](https://www.supermemo.com/en/archives1990-2015/english/ol/sm2)
+
+## Usage
+
+```typescript
+import { sm2, type RetentionCard, type SM2Input } from '@eduagent/retention';
+
+// New card (first review)
+const result = sm2({ quality: 4 });
+
+// Existing card
+const result = sm2({ quality: 3, card: existingCard });
+
+// result.card     — updated RetentionCard (persist this)
+// result.wasSuccessful — quality >= 3
+```
+
+### `RetentionCard`
+
+```typescript
+interface RetentionCard {
+  easeFactor: number;      // >= 1.3; default 2.5 for new cards
+  interval: number;        // days until next review
+  repetitions: number;     // consecutive correct recalls
+  lastReviewedAt: string;  // ISO 8601 UTC
+  nextReviewAt: string;    // ISO 8601 UTC
+}
+```
+
+### Quality scale
+
+| Value | Meaning |
+|-------|---------|
+| 0 | Total blackout |
+| 1 | Incorrect, but recognized on recall |
+| 2 | Incorrect, but easy to remember the correct answer |
+| 3 | Correct with significant difficulty |
+| 4 | Correct after hesitation |
+| 5 | Perfect recall |
+
+Responses with `quality < 3` reset the repetition counter. The ease factor floor is 1.3.
+
+## Development
+
+```bash
+pnpm exec nx run retention:typecheck
+pnpm exec nx run retention:test
+```

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -1,0 +1,50 @@
+# @eduagent/schemas
+
+Shared Zod schemas and inferred TypeScript types. The single source of truth for the API contract between `apps/api` and `apps/mobile`.
+
+## Overview
+
+All API-facing types live here. Neither `apps/api` nor `apps/mobile` should redefine types that cross the API boundary — import from `@eduagent/schemas` instead.
+
+## What's in Here
+
+| File | Domain |
+|------|--------|
+| `common.ts` | Shared primitives and utilities |
+| `errors.ts` | `QuotaExceededError`, `ResourceGoneError`, `ForbiddenError` |
+| `profiles.ts` | User profile shapes, tab shape resolution |
+| `sessions.ts` | Learning session schemas |
+| `subjects.ts` | Curriculum subject schemas |
+| `assessments.ts` | Quick-check request/response schemas |
+| `billing.ts` | Subscription and billing schemas |
+| `inngest-events.ts` | Inngest event payload schemas |
+| `llm-envelope.ts` | `llmResponseEnvelopeSchema` — structured LLM output contract |
+| `filing.ts` | Conversation-first filing flow schemas |
+| `retention-status.ts` | SM-2 retention status shapes |
+| `progress.ts` | Progress and dashboard schemas |
+| `quiz.ts` / `quiz-utils.ts` | Quiz activity schemas |
+| `learning-profiles.ts` | Adaptive memory profiles |
+| `stream-fallback.ts` | SSE stream frame schemas |
+| *(and more)* | |
+
+## Usage
+
+```typescript
+import { sessionEventSchema, ApiErrorSchema } from '@eduagent/schemas';
+```
+
+Always import from the package barrel (`@eduagent/schemas`), not from individual files.
+
+## Key Constraints
+
+- `@eduagent/schemas` has no workspace dependencies — it is the leaf package.
+- Use `.nullable()` for response schemas, `.optional()` for request schemas. Never `.nullable().optional()`.
+- The `llmResponseEnvelopeSchema` is mandatory for LLM flows that drive state-machine decisions. Parse with `parseEnvelope()` from `apps/api/src/services/llm/envelope.ts`.
+- Error response shapes use `ApiErrorSchema`: `{ code, message, details? }`.
+
+## Development
+
+```bash
+pnpm exec nx run schemas:typecheck
+pnpm exec nx run schemas:test
+```

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -42,7 +42,10 @@ Loads `DATABASE_URL` and related vars from `.env.test` for integration tests:
 
 ```typescript
 import { loadDatabaseEnv } from '@eduagent/test-utils';
-loadDatabaseEnv();
+import { resolve } from 'path';
+
+// Pass the monorepo root so .env.test.local / .env.development.local resolve correctly.
+loadDatabaseEnv(resolve(__dirname, '../..'));
 ```
 
 ## Rules

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,0 +1,51 @@
+# @eduagent/test-utils
+
+Shared test utilities for all workspace packages. Provides fixture IDs, JWT signing helpers, a database mock, and environment loading.
+
+## Exports
+
+### Fixture IDs (`lib/fixture-ids.ts`)
+
+Canonical RFC 9562 v4 UUIDs for use in tests. Import instead of hardcoding UUIDs:
+
+```typescript
+import { TEST_PROFILE_ID, TEST_SUBJECT_ID, TEST_SESSION_ID } from '@eduagent/test-utils';
+```
+
+Available: `TEST_PROFILE_ID`, `TEST_PROFILE_ID_2`, `TEST_PROFILE_ID_3`, `TEST_ACCOUNT_ID`, `TEST_SESSION_ID`, `TEST_SESSION_ID_2`, `TEST_SUBJECT_ID`, `TEST_SUBJECT_ID_2`, `TEST_TOPIC_ID`, `TEST_TOPIC_ID_2`, `TEST_TOPIC_ID_3`, `TEST_BOOK_ID`, `TEST_SHELF_ID`, `TEST_VOCABULARY_ID`, `TEST_NONEXISTENT_ID`.
+
+### JWT Signing (`auth/test-jwt.ts`)
+
+Real-crypto JWT signing utilities for route and unit tests (Clerk JWKS simulation):
+
+```typescript
+import { signTestJwt, TEST_JWKS, TEST_KID } from '@eduagent/test-utils';
+
+const token = await signTestJwt({ sub: 'user_123', profileId: TEST_PROFILE_ID });
+```
+
+### Database Mock (`lib/neon-mock.ts`)
+
+Drizzle-compatible mock for unit tests:
+
+```typescript
+import { createMockDb } from '@eduagent/test-utils';
+
+const db = createMockDb();
+```
+
+Use for unit tests only. Integration tests must use a real Neon database — never mock the database in integration tests.
+
+### Environment Loading (`lib/load-database-env.ts`)
+
+Loads `DATABASE_URL` and related vars from `.env.test` for integration tests:
+
+```typescript
+import { loadDatabaseEnv } from '@eduagent/test-utils';
+loadDatabaseEnv();
+```
+
+## Rules
+
+- This package is a `devDependency` — never import it from production code.
+- GC1 ratchet: do not add new `jest.mock('./...')` or `jest.mock('../...')` relative imports in test files. Use `jest.requireActual()` with targeted overrides instead.


### PR DESCRIPTION
## Summary

Cleanup PR-24: Per-package READMEs

**Cluster**: C8 — Track C archeology
**Phases**: P7
**Source**: `docs/audit/cleanup-plan.md`

## Changes

- **P7**: AUDIT-EXTREFS-3 — Per-package READMEs (commit `fc04f1da`)

## Verification

| Check | Result | Details |
| TypeCheck | PASS | All 6 projects — cache hit, 0 errors |
| Lint | PASS | 310 warnings (pre-existing grandfathered jest.mock), 0 errors |
| Tests | N/A | Changed files are README.md only — no test files to scan |
| Phase verifications | PASS | `pnpm exec nx run-many -t typecheck` passes (phase P7 verification command) |
| GC1 ratchet | PASS | No new internal jest.mock() calls in test diffs |

## Review Summary

**Verdict**: APPROVE
**Findings**: 0C / 0H / 3M / 1L

---
Generated by Archon workflow `execute-cleanup-pr`
