### PR TITLE
fix(tests): align progress mock response headers

### DIFF
--- a/apps/mobile/src/hooks/use-progress.test.ts
+++ b/apps/mobile/src/hooks/use-progress.test.ts
@@ -411,6 +411,7 @@ describe('useProfileWeeklyReports', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ reports: [{ id: 'not-a-uuid' }] }), {
         status: 200,
+        headers: { 'Content-Type': 'application/json' },
       }),
     );
 


### PR DESCRIPTION
## Summary
- add the missing JSON content-type header to the invalid weekly-report progress hook response fixture
- follows up PR #236 after it merged before GitHub picked up the final branch commit

## Validation
- pnpm exec jest --config apps/mobile/jest.config.cjs --testMatch "**/apps/mobile/src/hooks/use-progress.test.ts" --runInBand --no-coverage --forceExit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring mocked HTTP responses properly include the `Content-Type` header during schema validation testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->