### PR TITLE
fix(e2e): address PR review follow-ups

### DIFF
--- a/apps/mobile/e2e-web/flows/journeys/j10-practice-quiz-cycle.spec.ts
+++ b/apps/mobile/e2e-web/flows/journeys/j10-practice-quiz-cycle.spec.ts
@@ -103,7 +103,9 @@ test('J-10 learner → Practice → Quiz → launch → play → results → hom
       continue;
     }
 
-    await pressableClick(quizScreen);
+    throw new Error(
+      'None of quiz-results-screen, quiz-final-see-results, or quiz-next-question were visible after answer feedback.',
+    );
   }
 
   // Results screen

--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -603,6 +603,23 @@ describe('ProgressScreen — progressive disclosure', () => {
     });
   });
 
+  it('ignores an unknown requested child profile when no child link is known', () => {
+    mockSearchParams = { profileId: 'foreign-child' };
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 2 },
+        subjects: [fullSubject],
+      },
+    });
+
+    render(<ProgressScreen />);
+
+    expect(useChildInventory).toHaveBeenCalledWith(undefined, {
+      enabled: false,
+    });
+    screen.getByText('2 sessions completed');
+  });
+
   it('shows full view when totalSessions is 1 with subjects', () => {
     mockHooks({
       inventory: {

--- a/apps/mobile/src/app/(app)/progress/index.tsx
+++ b/apps/mobile/src/app/(app)/progress/index.tsx
@@ -177,19 +177,21 @@ export default function ProgressScreen(): React.ReactElement {
     ? rawRequestedProfileId[0]
     : rawRequestedProfileId;
 
-  const [selectedProfileId, setSelectedProfileId] = useState<string>(
-    () =>
-      requestedProfileId ??
-      (hasLinked ? linkedChildren[0]?.id : activeProfile?.id) ??
-      '',
-  );
+  const [selectedProfileId, setSelectedProfileId] = useState<string>(() => {
+    const knownRequestedProfileId =
+      requestedProfileId &&
+      (requestedProfileId === activeProfile?.id ||
+        linkedChildren.some((child) => child.id === requestedProfileId));
+    if (knownRequestedProfileId) return requestedProfileId;
+    return (hasLinked ? linkedChildren[0]?.id : activeProfile?.id) ?? '';
+  });
 
   useEffect(() => {
     if (!requestedProfileId) return;
     const knownTarget =
       requestedProfileId === activeProfile?.id ||
       linkedChildren.some((child) => child.id === requestedProfileId);
-    if (knownTarget || linkedChildren.length === 0) {
+    if (knownTarget) {
       setSelectedProfileId(requestedProfileId);
     }
   }, [requestedProfileId, activeProfile?.id, linkedChildren]);

--- a/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
@@ -272,6 +272,12 @@ describe('ParentHomeScreen', () => {
     screen.getByTestId('parent-home-tonight-section');
     screen.getByText('Ask Emma: what made Fractions click today?');
     screen.getByText('Fractions · 18 min this week');
+
+    fireEvent.press(screen.getByTestId('parent-home-tonight-child-a-primary'));
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '/(app)/progress',
+      params: { profileId: 'child-a' },
+    });
   });
 
   it('ranks multi-child tonight prompts by sessions — most active child appears first', async () => {

--- a/apps/mobile/src/components/home/ParentHomeScreen.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.tsx
@@ -408,7 +408,7 @@ export function ParentHomeScreen({
     router.push({
       pathname: '/create-profile',
       params: { for: 'child' },
-    } as never);
+    } as Href);
   }, [router]);
 
   const handleAddChild = useCallback(() => {
@@ -460,14 +460,9 @@ export function ParentHomeScreen({
     hasNoLinkedChildren,
     subscription,
     familyData,
-    router,
     t,
     navigateToCreateChildProfile,
   ]);
-
-  function pushChildDetail(childProfileId: string): void {
-    router.push(`/(app)/child/${childProfileId}` as Href);
-  }
 
   function pushChildProgress(childProfileId: string): void {
     router.push({
@@ -538,7 +533,7 @@ export function ParentHomeScreen({
                 (prompt) => (
                   <Pressable
                     key={`tonight-${prompt.key}`}
-                    onPress={() => pushChildDetail(prompt.childId)}
+                    onPress={() => pushChildProgress(prompt.childId)}
                     className="flex-row items-center py-2.5"
                     style={
                       Platform.OS === 'web' ? { cursor: 'pointer' } : undefined

--- a/apps/mobile/src/components/home/ParentHomeScreen.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.tsx
@@ -411,6 +411,10 @@ export function ParentHomeScreen({
     } as Href);
   }, [router]);
 
+  const navigateToSubscription = useCallback(() => {
+    router.push('/(app)/subscription' as Href);
+  }, [router]);
+
   const handleAddChild = useCallback(() => {
     if (hasNoLinkedChildren) {
       navigateToCreateChildProfile();
@@ -429,7 +433,7 @@ export function ParentHomeScreen({
         [
           {
             text: t('more.family.viewPlans'),
-            onPress: () => router.push('/(app)/subscription'),
+            onPress: navigateToSubscription,
           },
           { text: t('common.cancel'), style: 'cancel' },
         ],
@@ -447,7 +451,7 @@ export function ParentHomeScreen({
           ? [
               {
                 text: t('more.family.viewPlans'),
-                onPress: () => router.push('/(app)/subscription'),
+                onPress: navigateToSubscription,
               },
               { text: t('common.cancel'), style: 'cancel' },
             ]
@@ -462,18 +466,25 @@ export function ParentHomeScreen({
     familyData,
     t,
     navigateToCreateChildProfile,
+    navigateToSubscription,
   ]);
 
-  function pushChildProgress(childProfileId: string): void {
-    router.push({
-      pathname: '/(app)/progress',
-      params: { profileId: childProfileId },
-    } as Href);
-  }
+  const pushChildProgress = useCallback(
+    (childProfileId: string): void => {
+      router.push({
+        pathname: '/(app)/progress',
+        params: { profileId: childProfileId },
+      } as Href);
+    },
+    [router],
+  );
 
-  function pushChildReports(childProfileId: string): void {
-    router.push(`/(app)/child/${childProfileId}/reports` as Href);
-  }
+  const pushChildReports = useCallback(
+    (childProfileId: string): void => {
+      router.push(`/(app)/child/${childProfileId}/reports` as Href);
+    },
+    [router],
+  );
 
   const parentInitial = initialOf(activeProfile?.displayName ?? firstName);
 

--- a/tests/integration/quiz-routes.integration.test.ts
+++ b/tests/integration/quiz-routes.integration.test.ts
@@ -5,6 +5,7 @@ import { app } from '../../apps/api/src/index';
 import { QUIZ_CONFIG } from '../../apps/api/src/services/quiz/config';
 import {
   _resetCircuits,
+  CircuitOpenError,
   createMockProvider,
   registerProvider,
 } from '../../apps/api/src/services/llm';
@@ -183,6 +184,42 @@ describe('Integration: POST /v1/quiz/rounds', () => {
     const llmFixture = registerLlmProviderFixture({
       id: 'gemini',
       chatError: abortError,
+    });
+
+    try {
+      const res = await app.request(
+        '/v1/quiz/rounds',
+        {
+          method: 'POST',
+          headers: buildAuthHeaders(
+            { sub: QUIZ_AUTH_USER_ID, email: QUIZ_AUTH_EMAIL },
+            profileId,
+          ),
+          body: JSON.stringify({
+            activityType: 'vocabulary',
+            subjectId,
+          }),
+        },
+        TEST_ENV,
+      );
+
+      expect(res.status).toBe(502);
+      expect(await res.json()).toMatchObject({
+        code: ERROR_CODES.UPSTREAM_ERROR,
+      });
+      expect(llmFixture.chatCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      llmFixture.dispose();
+      restoreDefaultLlmProvider();
+    }
+  });
+
+  it('returns 502 UPSTREAM_ERROR when an LLM-backed quiz circuit is open [BUG-990]', async () => {
+    const profileId = await createQuizProfile();
+    const subjectId = await seedLanguageSubject(profileId);
+    const llmFixture = registerLlmProviderFixture({
+      id: 'gemini',
+      chatError: new CircuitOpenError('gemini'),
     });
 
     try {


### PR DESCRIPTION
## Summary
- close the post-review edge case where `/progress?profileId=` could select an unknown child when no child links were loaded
- route parent Home tonight prompts to the real child progress screen and remove the stale child-detail route helper
- make the J10 Playwright flow fail loudly when quiz feedback does not expose an expected next/results action
- add integration coverage for quiz circuit-open failures returning `UPSTREAM_ERROR`

## Validation
- `pnpm exec jest --config apps/mobile/jest.config.cjs --testMatch "**/progress.test.tsx" --runInBand --no-coverage`
- `pnpm exec jest --config apps/mobile/jest.config.cjs --testMatch "**/ParentHomeScreen.test.tsx" --runInBand --no-coverage`
- `pnpm exec jest --config tests/integration/jest.config.cjs --testMatch "**/quiz-routes.integration.test.ts" --runInBand --no-coverage`
- `pnpm exec nx run @eduagent/mobile:typecheck`
- `pnpm exec nx run @eduagent/mobile:lint`
- `pnpm exec nx run api:typecheck`
- `pnpm exec nx run api:lint`
- `C:/Tools/doppler/doppler.exe run -c stg -- pnpm exec playwright test -c apps/mobile/playwright.config.ts --reporter=line apps/mobile/e2e-web/flows/journeys/j10-practice-quiz-cycle.spec.ts`