### PR TITLE
fix(mobile): cover delayed child progress links

### DIFF
--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -603,6 +603,52 @@ describe('ProgressScreen — progressive disclosure', () => {
     });
   });
 
+  it('opens a valid requested child profile after child links load', async () => {
+    const childProfile: Profile = {
+      id: 'child-1',
+      accountId: 'account-1',
+      displayName: 'Emma',
+      isOwner: false,
+      hasPremiumLlm: false,
+      consentStatus: null,
+      linkCreatedAt: null,
+      conversationLanguage: 'en',
+      pronouns: null,
+      birthYear: 2015,
+      avatarUrl: null,
+      location: null,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    mockSearchParams = { profileId: 'child-1' };
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 2 },
+        subjects: [fullSubject],
+      },
+      childInventory: {
+        global: { ...baseGlobal, totalSessions: 6, topicsMastered: 2 },
+        subjects: [fullSubject],
+      },
+    });
+
+    const view = render(<ProgressScreen />);
+
+    expect(useChildInventory).toHaveBeenLastCalledWith(undefined, {
+      enabled: false,
+    });
+
+    mockLinkedChildren = [childProfile];
+    view.rerender(<ProgressScreen />);
+
+    await waitFor(() => {
+      expect(useChildInventory).toHaveBeenLastCalledWith('child-1', {
+        enabled: true,
+      });
+    });
+    screen.getByText('6 sessions');
+  });
+
   it('ignores an unknown requested child profile when no child link is known', () => {
     mockSearchParams = { profileId: 'foreign-child' };
     mockHooks({

--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -236,6 +236,23 @@ const fullSubject = {
   sessionsCount: 5,
 };
 
+const childProgressProfile: Profile = {
+  id: 'child-1',
+  accountId: 'account-1',
+  displayName: 'Emma',
+  isOwner: false,
+  hasPremiumLlm: false,
+  consentStatus: null,
+  linkCreatedAt: null,
+  conversationLanguage: 'en',
+  pronouns: null,
+  birthYear: 2015,
+  avatarUrl: null,
+  location: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
 function mockHooks(
   overrides: {
     inventory?:
@@ -565,24 +582,7 @@ describe('ProgressScreen — progressive disclosure', () => {
   });
 
   it('opens the requested child progress profile from route params', () => {
-    mockLinkedChildren = [
-      {
-        id: 'child-1',
-        accountId: 'account-1',
-        displayName: 'Emma',
-        isOwner: false,
-        hasPremiumLlm: false,
-        consentStatus: null,
-        linkCreatedAt: null,
-        conversationLanguage: 'en',
-        pronouns: null,
-        birthYear: 2015,
-        avatarUrl: null,
-        location: null,
-        createdAt: '2026-01-01T00:00:00Z',
-        updatedAt: '2026-01-01T00:00:00Z',
-      },
-    ];
+    mockLinkedChildren = [childProgressProfile];
     mockSearchParams = { profileId: 'child-1' };
     mockHooks({
       inventory: {
@@ -604,22 +604,6 @@ describe('ProgressScreen — progressive disclosure', () => {
   });
 
   it('opens a valid requested child profile after child links load', async () => {
-    const childProfile: Profile = {
-      id: 'child-1',
-      accountId: 'account-1',
-      displayName: 'Emma',
-      isOwner: false,
-      hasPremiumLlm: false,
-      consentStatus: null,
-      linkCreatedAt: null,
-      conversationLanguage: 'en',
-      pronouns: null,
-      birthYear: 2015,
-      avatarUrl: null,
-      location: null,
-      createdAt: '2026-01-01T00:00:00Z',
-      updatedAt: '2026-01-01T00:00:00Z',
-    };
     mockSearchParams = { profileId: 'child-1' };
     mockHooks({
       inventory: {
@@ -638,15 +622,16 @@ describe('ProgressScreen — progressive disclosure', () => {
       enabled: false,
     });
 
-    mockLinkedChildren = [childProfile];
+    mockLinkedChildren = [childProgressProfile];
     view.rerender(<ProgressScreen />);
 
     await waitFor(() => {
       expect(useChildInventory).toHaveBeenLastCalledWith('child-1', {
         enabled: true,
       });
+      screen.getByTestId('progress-pill-child-1');
+      screen.getByText('6 sessions');
     });
-    screen.getByText('6 sessions');
   });
 
   it('ignores an unknown requested child profile when no child link is known', () => {


### PR DESCRIPTION
## Summary
- add regression coverage for opening `/progress?profileId=<child>` when the child link data loads after the screen first mounts

## Validation
- `pnpm exec jest --config apps/mobile/jest.config.cjs --testMatch "**/progress.test.tsx" --runInBand --no-coverage`
- `pnpm exec nx run @eduagent/mobile:typecheck`
- `pnpm exec nx run @eduagent/mobile:lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added reusable test fixtures for child profile testing. Introduced additional test cases for the progress screen verifying correct behavior when child profiles are referenced but not yet available. Tests validate component initialization states, transitions between disabled and enabled modes, and accurate rendering of child profile information and corresponding session metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/245)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->