### PR TITLE
fix(mobile): cover unknown delayed child progress link

### DIFF
--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -662,6 +662,10 @@ describe('ProgressScreen — progressive disclosure', () => {
 
     const view = render(<ProgressScreen />);
 
+    expect(useChildInventory).toHaveBeenLastCalledWith(undefined, {
+      enabled: false,
+    });
+
     mockLinkedChildren = [childProgressProfile];
     view.rerender(<ProgressScreen />);
 

--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -651,6 +651,28 @@ describe('ProgressScreen — progressive disclosure', () => {
     screen.getByText('2 sessions completed');
   });
 
+  it('ignores an unknown requested child profile after child links load', async () => {
+    mockSearchParams = { profileId: 'foreign-child' };
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 2 },
+        subjects: [fullSubject],
+      },
+    });
+
+    const view = render(<ProgressScreen />);
+
+    mockLinkedChildren = [childProgressProfile];
+    view.rerender(<ProgressScreen />);
+
+    await waitFor(() => {
+      expect(useChildInventory).toHaveBeenLastCalledWith(undefined, {
+        enabled: false,
+      });
+      screen.getByText('2 sessions completed');
+    });
+  });
+
   it('shows full view when totalSessions is 1 with subjects', () => {
     mockHooks({
       inventory: {


### PR DESCRIPTION
## Summary
- add delayed-load coverage for rejecting an unknown requested child progress profile
- keeps the parent progress screen on the owner profile when child links load but do not match the route param

## Verified by
- pnpm exec jest --clearCache --config apps/mobile/jest.config.cjs
- pnpm exec jest --config apps/mobile/jest.config.cjs --testMatch "**/progress.test.tsx" --runInBand --no-coverage
- pnpm exec nx run @eduagent/mobile:lint
- pnpm exec nx run @eduagent/mobile:typecheck