### PR TITLE
fix(api): narrow final app-help review guards

### DIFF
--- a/apps/api/src/services/app-help-map.test.ts
+++ b/apps/api/src/services/app-help-map.test.ts
@@ -148,9 +148,10 @@ describe('isAppHelpQuery', () => {
     'what is challenge mode',
     'where can I see what you remember',
     'how do I delete my account',
-    'Where can I see my progress?',
+    'Where can I find the progress tab?',
+    'How do I get to the progress screen?',
     'Where do I find the app settings?',
-    'Where can I see help?',
+    'Where is the Help & feedback section?',
   ])('classifies "%s" as app-help', (msg) => {
     expect(isAppHelpQuery(msg)).toBe(true);
   });
@@ -188,6 +189,9 @@ describe('isAppHelpQuery', () => {
     'Can you help me find the answer?',
     'How to use the formula',
     'What is the Explorer age of discovery?',
+    'Where can I see progress on this topic?',
+    'Where can I see my progress in the textbook?',
+    'Where can I find help with this calculus problem?',
   ])('does NOT classify "%s" as app-help', (msg) => {
     expect(isAppHelpQuery(msg)).toBe(false);
   });

--- a/apps/api/src/services/app-help-map.ts
+++ b/apps/api/src/services/app-help-map.ts
@@ -37,9 +37,9 @@ export function buildAppHelpPromptBlock(): string {
 // Specific multi-word phrases that are unambiguously about app navigation,
 // plus possessive/navigational frames that anchor common nouns to app-help.
 const APP_HELP_SPECIFIC =
-  /\b(explorer mode|challenge mode|change mode|learning preferences|help section|mentor memory|delete.*account|export.*data|notification settings)\b/i;
+  /\b(explorer mode|challenge mode|change mode|learning preferences|help section|help (&|and) feedback|progress (tab|page|screen|section)|mentor memory|delete.*account|export.*data|notification settings)\b/i;
 const APP_HELP_FRAMED =
-  /\b(where (do i|are my|can i|is the) (find|see|change|access|get to) (my |the )?(notes|saved|settings|preferences|bookmarks?|notifications?|profile|account|mode|app|help|progress)\b|how do i (find|change|see|access|get to) (my |the )?(notes|saved|settings|preferences|bookmarks?|notifications?|profile|account|mode|progress)|my (notes|saved|settings|preferences|bookmarks?|notifications?|profile|account|progress)\b|(where are|where is|where can i find) (my )?(notes|saved|settings|preferences|bookmarks?|notifications?|profile|help|mentor memory|progress)|where can i see what you remember|what you remember about me)/i;
+  /\b(where (do i|are my|can i|is the) (find|see|change|access|get to) (my |the )?(notes|saved|settings|preferences|bookmarks?|notifications?|profile|account|mode|app)\b|how do i (find|change|see|access|get to) (my |the )?(notes|saved|settings|preferences|bookmarks?|notifications?|profile|account|mode)|my (notes|saved|settings|preferences|bookmarks?|notifications?|profile|account)\b|(where are|where is|where can i find) (my )?(notes|saved|settings|preferences|bookmarks?|notifications?|profile|mentor memory)|where can i see what you remember|what you remember about me)/i;
 
 export function isAppHelpQuery(userMessage: string): boolean {
   if (!userMessage || userMessage.length < 5) return false;

--- a/apps/api/src/services/dedupe-key.ts
+++ b/apps/api/src/services/dedupe-key.ts
@@ -24,11 +24,14 @@ export function buildEmailIdempotencyKey(
   return segments.map((s) => encodeOptionalDedupeSegment(s)).join(':');
 }
 
-// LEGACY FORMAT ONLY — preserves the pre-PR-243 Resend idempotency key format
-// (weekly|monthly)-{parentId}-{date}. Do not use for new email types; use
-// buildEmailIdempotencyKey() instead.
+/**
+ * @deprecated LEGACY FORMAT ONLY — preserves the pre-PR-243 Resend
+ * idempotency key format `(weekly|monthly)-{parentId}-{date}`. Segments are
+ * NOT URI-encoded; keys are opaque to Resend and are never parsed back. Do not
+ * use for new email types; use buildEmailIdempotencyKey() instead.
+ */
 export function buildLegacyEmailIdempotencyKey(
-  prefix: string,
+  prefix: 'weekly' | 'monthly',
   ...segments: string[]
 ): string {
   return joinDedupeKey([prefix, ...segments], '-');


### PR DESCRIPTION
## Summary
- narrow app-help classification so learning questions about help/progress stay with the tutor
- keep explicit navigation phrases for help feedback and progress tab/page/screen/section
- mark legacy weekly/monthly email idempotency helper as deprecated and type-restricted

## Validation
- pnpm exec jest --runTestsByPath src/services/app-help-map.test.ts src/services/dedupe-key.test.ts --no-coverage --runInBand
- pnpm exec nx run api:typecheck --output-style=static
- pre-commit hook: tsc --build and 43 related Jest suites passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced help query recognition to better understand requests related to feedback and progress navigation across the application

* **Chores**
  * Deprecated legacy email idempotency key function for future removal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/248)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->