### PR TITLE
ci: unify GC1 ratchet on the same detector as pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,29 +151,16 @@ jobs:
         run: bash scripts/check-prompt-markers.sh
 
       # GC1 ratchet (Tier 1): block PRs that add NEW relative-path jest.mock()
-      # calls in test files. Existing legacy sites are grandfathered. To allow
-      # a legitimate new internal mock, add `// gc1-allow: <reason>` on the
-      # same line as the jest.mock(...) call. See CLAUDE.md → "Code Quality
-      # Guards" → "No new internal jest.mock()".
+      # calls in test files unless the factory uses Pattern A (spreads
+      # jest.requireActual of the same specifier) or the line carries a
+      # `// gc1-allow: <reason>` sticker. Same TypeScript detector the
+      # pre-commit hook in `.husky/pre-commit` uses, so rules can't drift.
+      # See CLAUDE.md → "Code Quality Guards" → "No new internal jest.mock()".
       - name: GC1 — no new internal jest.mock
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          # Exclude the GC1 detector's own test file — its fixtures are
-          # literal "jest.mock(...)" strings used to test the detector, not
-          # real jest.mock calls.
-          violations=$(git diff "origin/${BASE_REF}...HEAD" -- '*.test.ts' '*.test.tsx' ':!scripts/check-gc1-pattern-a.test.ts' \
-            | grep -E '^\+[^+]' \
-            | grep -E "jest\.mock\(['\"\`]\.\.?/" \
-            | grep -iv 'gc1-allow' \
-            || true)
-          if [ -n "$violations" ]; then
-            echo "::error::New internal jest.mock() call(s) detected. Use jest.requireActual() with targeted overrides, or add '// gc1-allow: <reason>' on the same line if external-boundary justified. See CLAUDE.md → 'No new internal jest.mock()'."
-            echo "$violations"
-            exit 1
-          fi
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: pnpm exec tsx scripts/check-gc1-pattern-a.ts
 
       # Structural-regression guards under scripts/ (BUG-979 / BUG-974). Nx
       # does not pick these up — they live outside any project — so we run

--- a/scripts/check-gc1-pattern-a.ts
+++ b/scripts/check-gc1-pattern-a.ts
@@ -16,11 +16,14 @@
 //   apps/api/src/services/billing/family.test.ts:3   (named-local spread)
 //   apps/api/src/routes/quiz.test.ts:66   (gc1-allow external boundary)
 //
-// CLI usage (from .husky/pre-commit):
-//   pnpm exec tsx scripts/check-gc1-pattern-a.ts
+// CLI usage:
+//   Pre-commit (default): scans the staged index.
+//     pnpm exec tsx scripts/check-gc1-pattern-a.ts
+//   CI (PR mode):         scans HEAD vs. origin/<base>. Triggered by setting
+//     GITHUB_BASE_REF. Reads files from HEAD (not the index).
 // Exit codes: 0 clean, 1 violations.
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 export type Violation = {
   file: string;
@@ -136,14 +139,48 @@ export function checkFile(
   return violations;
 }
 
+type DiffSource = {
+  // git-diff range args: e.g. `['--cached']` for the index or
+  // `['origin/main...HEAD']` for a CI base-vs-HEAD comparison.
+  rangeArgs: string[];
+  // `git show <ref>:<file>` ref: `:` reads the index, `HEAD` reads the tip.
+  showRef: string;
+  // Human label for error messages.
+  mode: 'pre-commit' | 'ci';
+};
+
+function resolveDiffSource(): DiffSource {
+  const baseRef = process.env.GITHUB_BASE_REF;
+  if (baseRef && baseRef.trim().length > 0) {
+    return {
+      rangeArgs: [`origin/${baseRef}...HEAD`],
+      showRef: 'HEAD',
+      mode: 'ci',
+    };
+  }
+  return { rangeArgs: ['--cached'], showRef: ':', mode: 'pre-commit' };
+}
+
 function runCli(): void {
-  const stagedFiles = execSync(
-    "git diff --cached --name-only --diff-filter=d -- '*.test.ts' '*.test.tsx'",
+  const src = resolveDiffSource();
+
+  const nameOnly = spawnSync(
+    'git',
+    [
+      'diff',
+      ...src.rangeArgs,
+      '--name-only',
+      '--diff-filter=d',
+      '--',
+      '*.test.ts',
+      '*.test.tsx',
+    ],
     { encoding: 'utf8' },
-  )
-    .trim()
-    .split('\n')
-    .filter(Boolean);
+  );
+  if (nameOnly.status !== 0) {
+    process.exit(0);
+  }
+  const stagedFiles = nameOnly.stdout.trim().split('\n').filter(Boolean);
 
   if (stagedFiles.length === 0) {
     process.exit(0);
@@ -156,12 +193,12 @@ function runCli(): void {
     try {
       const diffResult = spawnSync(
         'git',
-        ['diff', '--cached', '--unified=0', '--', f],
+        ['diff', ...src.rangeArgs, '--unified=0', '--', f],
         {
           encoding: 'utf8',
         },
       );
-      const stagedResult = spawnSync('git', ['show', `:${f}`], {
+      const stagedResult = spawnSync('git', ['show', `${src.showRef}:${f}`], {
         encoding: 'utf8',
       });
       if (diffResult.status !== 0 || stagedResult.status !== 0) {
@@ -181,7 +218,7 @@ function runCli(): void {
 
   console.error('');
   console.error(
-    'pre-commit: GC1 — new internal jest.mock() must be Pattern A or carry gc1-allow.',
+    `${src.mode === 'ci' ? 'CI' : 'pre-commit'}: GC1 — new internal jest.mock() must be Pattern A or carry gc1-allow.`,
   );
   console.error('');
   console.error('Offending added lines:');


### PR DESCRIPTION
## Why

The CI workflow ran a textual grep that fired false positives on multi-line `jest.mock(...)` factories using `...jest.requireActual` (the regex only inspected the opening line of the call). Result: properly-converted mocks required `// gc1-allow` annotations purely to defeat the dumb check — the annotation lost its meaning as an audit-trail of true escape hatches.

The smart structural detector at `scripts/check-gc1-pattern-a.ts` already exists and is used by `.husky/pre-commit`. It validates the actual Pattern A structure (factory body spreads `jest.requireActual(<same path>)`). This PR wires the CI workflow to that same script so CI and pre-commit can't drift.

## Changes

- **`scripts/check-gc1-pattern-a.ts`** — adds CI mode via `GITHUB_BASE_REF` env var. When set, the script scans `origin/<base>...HEAD` (and reads files from `HEAD:`) instead of the staged index. Pre-commit behaviour unchanged.
- **`.github/workflows/ci.yml`** — replaces the inline grep with `pnpm exec tsx scripts/check-gc1-pattern-a.ts`.

## Verification

- 14/14 unit tests in `scripts/check-gc1-pattern-a.test.ts` pass.
- Script exits 0 in both pre-commit mode (no env) and CI mode (`GITHUB_BASE_REF=main`) on a branch with no test-file changes.
- This PR's own diff is non-test files, so the GC1 step is a no-op for this PR's CI; the real exercise will come on the next PR that touches a test file.

## Follow-up (separate PR)

Most of the 24 `// gc1-allow: requireActual + targeted overrides` annotations added in #258 become noise once this lands — the smart detector accepts Pattern A directly. A cleanup PR can sweep them later. Leaving them in place doesn't break anything.