### PR TITLE
fix(account-billing): address final review notes

### DIFF
--- a/.test-receipts/mobile.json
+++ b/.test-receipts/mobile.json
@@ -1,12 +1,12 @@
 {
   "scope": "mobile",
-  "verifiedAt": "2026-05-15T10:02:17Z",
+  "verifiedAt": "2026-05-15T11:04:43Z",
   "verifiedBy": "Zuzana Kopečná @ ZLY-Orion",
-  "command": "pnpm exec nx run mobile:test",
+  "command": "pnpm exec jest --config apps/mobile/jest.config.cjs --cacheDirectory=.tmp/jest-cache-receipt-parallel --no-coverage --forceExit",
   "passed": true,
   "testFiles": {
     "apps/mobile/src/app/(app)/subscription.test.tsx": "4483793cbec48cae6b06749424409e31815b5810",
-    "apps/mobile/src/app/delete-account.test.tsx": "7c2bb205f22073d480bd4f1a43e8b40e12bb16bf",
+    "apps/mobile/src/app/delete-account.test.tsx": "78acd7b835fcba4b1cf5a02ca00b608249e9c8b7",
     "apps/mobile/src/hooks/use-account.test.ts": "f55b2a8d4a8faba67d10a45a74609cfa02fe5915"
   }
 }

--- a/apps/api/src/services/deletion.ts
+++ b/apps/api/src/services/deletion.ts
@@ -104,6 +104,8 @@ export async function getDeletionStatus(
 
   const scheduledAt = row.deletionScheduledAt ?? null;
   const cancelledAt = row.deletionCancelledAt ?? null;
+  // Deletion stays active when no later cancellation supersedes the schedule.
+  // Equal timestamps are treated as scheduled, mirroring isDeletionCancelled().
   const scheduled =
     scheduledAt !== null &&
     (cancelledAt === null || cancelledAt <= scheduledAt);

--- a/apps/mobile/src/app/delete-account.test.tsx
+++ b/apps/mobile/src/app/delete-account.test.tsx
@@ -51,20 +51,18 @@ let mockDeletionStatus: MockDeletionStatus = {
   refetch: mockDeletionStatusRefetch,
 };
 
-jest.mock(
-  '../hooks/use-account',
-  /* gc1-allow: screen tests mock account hooks to avoid full QueryClient/provider setup around the Expo Router page */ () => ({
-    useDeleteAccount: () => ({
-      mutateAsync: mockDeleteMutateAsync,
-      isPending: mockDeleteIsPending,
-    }),
-    useCancelDeletion: () => ({
-      mutateAsync: mockCancelMutateAsync,
-      isPending: false,
-    }),
-    useDeletionStatus: () => mockDeletionStatus,
+// prettier-ignore
+jest.mock('../hooks/use-account', /* gc1-allow: screen tests mock account hooks to avoid full QueryClient/provider setup around the Expo Router page */ () => ({
+  useDeleteAccount: () => ({
+    mutateAsync: mockDeleteMutateAsync,
+    isPending: mockDeleteIsPending,
   }),
-);
+  useCancelDeletion: () => ({
+    mutateAsync: mockCancelMutateAsync,
+    isPending: false,
+  }),
+  useDeletionStatus: () => mockDeletionStatus,
+}));
 
 // prettier-ignore
 jest.mock('../lib/theme', /* gc1-allow: nativewind vars() does not resolve 'react' in jest; stub theme hooks so screen tests don't blow up on import */ () => ({

--- a/apps/mobile/src/app/delete-account.tsx
+++ b/apps/mobile/src/app/delete-account.tsx
@@ -52,23 +52,31 @@ export default function DeleteAccountScreen() {
   // synchronously around the mutation closes that race.
   const submittingRef = useRef(false);
   const locallyScheduledRef = useRef(false);
+  const stageRef = useRef<Stage>('initial');
+  const setScreenStage = useCallback((nextStage: Stage) => {
+    stageRef.current = nextStage;
+    setStage(nextStage);
+  }, []);
 
   useEffect(() => {
+    const currentStage = stageRef.current;
     if (deletionStatus.data?.scheduled === true) {
-      if (stage === 'confirming') return;
+      if (currentStage === 'confirming') return;
       setGracePeriodEnds(deletionStatus.data.gracePeriodEnds);
-      setStage('scheduled');
+      if (currentStage !== 'scheduled') {
+        setScreenStage('scheduled');
+      }
     } else if (
       deletionStatus.data?.scheduled === false &&
-      stage === 'scheduled'
+      currentStage === 'scheduled'
     ) {
       if (locallyScheduledRef.current) {
         return;
       }
       setGracePeriodEnds(null);
-      setStage('initial');
+      setScreenStage('initial');
     }
-  }, [deletionStatus.data, stage]);
+  }, [deletionStatus.data, setScreenStage]);
 
   const handleClose = useCallback(() => {
     goBackOrReplace(router, '/(app)/more');
@@ -78,8 +86,8 @@ export default function DeleteAccountScreen() {
   const onBeginConfirm = useCallback(() => {
     setError('');
     setConfirmText('');
-    setStage('confirming');
-  }, []);
+    setScreenStage('confirming');
+  }, [setScreenStage]);
 
   // Step 2: user has typed DELETE and taps the destructive button — fire
   // the mutation. The button is only enabled when the typed phrase
@@ -93,19 +101,19 @@ export default function DeleteAccountScreen() {
       const result = await deleteAccount.mutateAsync();
       locallyScheduledRef.current = true;
       setGracePeriodEnds(result.gracePeriodEnds);
-      setStage('scheduled');
+      setScreenStage('scheduled');
     } catch (err: unknown) {
       setError(formatApiError(err));
     } finally {
       submittingRef.current = false;
     }
-  }, [deleteAccount, confirmText]);
+  }, [deleteAccount, confirmText, setScreenStage]);
 
   const onBackToWarning = useCallback(() => {
     setConfirmText('');
     setError('');
-    setStage('initial');
-  }, []);
+    setScreenStage('initial');
+  }, [setScreenStage]);
 
   const onCancelDeletion = useCallback(async () => {
     setError('');


### PR DESCRIPTION
Follow-up to PR #271 after it was merged.

Addresses the remaining review notes that had been fixed locally but were not pushed before merge:

- documents the deletion cancellation/schedule timestamp invariant
- removes the delete-account stage effect dependency loop by using a stage ref setter
- keeps the gc1-allow annotation on the same jest.mock line

Validation:

- pnpm exec jest --config apps/api/jest.config.cjs --runInBand --testMatch "**/apps/api/src/services/deletion.test.ts"
- pnpm exec jest --config apps/mobile/jest.config.cjs --runInBand --forceExit --runTestsByPath "apps/mobile/src/app/delete-account.test.tsx"
- pnpm exec jest --config apps/mobile/jest.config.cjs --cacheDirectory=.tmp/jest-cache-receipt-parallel --no-coverage --forceExit
