### PR TITLE
fix(mobile): repair voice input and tighten chat controls

### DIFF
--- a/.test-receipts/mobile.json
+++ b/.test-receipts/mobile.json
@@ -1,10 +1,13 @@
 {
   "scope": "mobile",
-  "verifiedAt": "2026-05-15T11:20:05Z",
+  "verifiedAt": "2026-05-15T11:40:26Z",
   "verifiedBy": "Zuzana Kopečná @ ZLY-Orion",
   "command": "pnpm exec nx run mobile:test",
   "passed": true,
   "testFiles": {
-    "apps/mobile/src/app/delete-account.test.tsx": "78acd7b835fcba4b1cf5a02ca00b608249e9c8b7"
+    "apps/mobile/src/components/session/ChatShell.test.tsx": "c49c9037e4d0194fbe912b66a0ce3b879752a50d",
+    "apps/mobile/src/components/session/MessageBubble.test.tsx": "14a8aee4e25c7abd1460a153833d8ef36d294143",
+    "apps/mobile/src/components/session/SessionMessageActions.test.tsx": "04ad75fd78f2ea3584ebd8c4e1b661bc52812be7",
+    "apps/mobile/src/components/session/VoiceRecordButton.test.tsx": "edf356283448ddbc8e4acda0a8d5a1884d0f480c"
   }
 }

--- a/apps/mobile/src/components/session/ChatShell.test.tsx
+++ b/apps/mobile/src/components/session/ChatShell.test.tsx
@@ -25,8 +25,9 @@ jest.mock('@react-navigation/native', () => ({
   useIsFocused: () => mockIsFocused,
 }));
 
+let mockSafeAreaInsets = { top: 0, bottom: 0, left: 0, right: 0 };
 jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  useSafeAreaInsets: () => mockSafeAreaInsets,
 }));
 
 // prettier-ignore
@@ -126,6 +127,7 @@ function renderChatShell(
 // microtasks) under fake-time. Removed.
 beforeEach(() => {
   jest.clearAllMocks();
+  mockSafeAreaInsets = { top: 0, bottom: 0, left: 0, right: 0 };
   mockGetMicrophonePermissionStatus.mockResolvedValue({
     granted: true,
     canAskAgain: true,
@@ -176,7 +178,9 @@ describe('ChatShell', () => {
     // [BUG-965] Voice-OFF state shows the long-press-to-enable button, NOT
     // the recording button. Distinct testIDs let E2E flows assert each
     // state's presence/absence without ambiguity.
-    screen.getByTestId('voice-enable-button');
+    const button = screen.getByTestId('voice-enable-button');
+    expect(button.props.className).toContain('h-[52px]');
+    expect(button.props.className).toContain('w-[52px]');
     expect(screen.queryByTestId('voice-record-button')).toBeNull();
   });
 
@@ -223,8 +227,26 @@ describe('ChatShell', () => {
   it('renders text input and send button', () => {
     renderChatShell();
 
-    screen.getByTestId('chat-input');
-    screen.getByTestId('send-button');
+    const input = screen.getByTestId('chat-input');
+    const send = screen.getByTestId('send-button');
+    expect(input.props.className).toContain('min-h-[52px]');
+    expect(send.props.className).toContain('h-[52px]');
+    expect(send.props.className).toContain('w-[52px]');
+  });
+
+  it('keeps bottom safe-area padding below quick tools, not between tools and input', () => {
+    const { Text } = require('react-native');
+    mockSafeAreaInsets = { top: 0, bottom: 34, left: 0, right: 0 };
+    renderChatShell({
+      belowInput: <Text testID="quick-tools">Quick tools</Text>,
+    });
+
+    const row = screen.getByTestId('chat-input-row');
+    expect(row.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ paddingBottom: 8 })]),
+    );
+    const belowInputSafeArea = screen.getByTestId('below-input-safe-area');
+    expect(belowInputSafeArea.props.style).toEqual({ paddingBottom: 34 });
   });
 
   it('calls onSend when send button is pressed with text', () => {

--- a/apps/mobile/src/components/session/ChatShell.test.tsx
+++ b/apps/mobile/src/components/session/ChatShell.test.tsx
@@ -357,6 +357,20 @@ describe('ChatShell', () => {
       expect(mockStartListening).toHaveBeenCalled();
     });
 
+    it('enables voice mode and starts listening from the compact mic button', async () => {
+      const onInputModeChange = jest.fn();
+      renderChatShell({ onInputModeChange });
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('voice-enable-button'));
+      });
+
+      expect(onInputModeChange).toHaveBeenCalledWith('voice');
+      expect(mockStartListening).toHaveBeenCalled();
+      screen.getByTestId('voice-record-button');
+      expect(screen.queryByTestId('voice-enable-button')).toBeNull();
+    });
+
     it('stops TTS when starting to record', async () => {
       renderChatShell({ verificationType: 'teach_back' });
 

--- a/apps/mobile/src/components/session/ChatShell.test.tsx
+++ b/apps/mobile/src/components/session/ChatShell.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, act } from '@testing-library/react-native';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from '@testing-library/react-native';
 import { AccessibilityInfo, AppState } from 'react-native';
 import { ChatShell, type ChatMessage } from './ChatShell';
 
@@ -388,7 +394,7 @@ describe('ChatShell', () => {
       });
 
       expect(onInputModeChange).toHaveBeenCalledWith('voice');
-      expect(mockStartListening).toHaveBeenCalled();
+      await waitFor(() => expect(mockStartListening).toHaveBeenCalled());
       screen.getByTestId('voice-record-button');
       expect(screen.queryByTestId('voice-enable-button')).toBeNull();
     });

--- a/apps/mobile/src/components/session/ChatShell.tsx
+++ b/apps/mobile/src/components/session/ChatShell.tsx
@@ -459,18 +459,28 @@ export function ChatShell({
     }
   }, [isStreaming, isListening, stopListening, startListening, stopSpeaking]);
 
-  const handleEnableVoiceAndRecord = useCallback(async () => {
+  const pendingVoiceStartRef = useRef(false);
+
+  const handleEnableVoiceAndRecord = useCallback(() => {
     if (isStreaming) return;
     if (!isVoiceEnabled) {
+      pendingVoiceStartRef.current = true;
       setVoiceEnabled(true);
+      return;
     }
-    await handleVoicePress();
+    void handleVoicePress();
   }, [handleVoicePress, isStreaming, isVoiceEnabled, setVoiceEnabled]);
 
   // BUG-359: Gate to prevent late STT updates from re-populating the
   // transcript after the user taps Discard. Set on discard, cleared on
   // re-record or new recording.
   const discardedRef = useRef(false);
+
+  useEffect(() => {
+    if (!pendingVoiceStartRef.current || !isVoiceEnabled) return;
+    pendingVoiceStartRef.current = false;
+    void handleVoicePress();
+  }, [handleVoicePress, isVoiceEnabled]);
 
   // Sync transcript from STT hook to pending transcript when recording stops
   useEffect(() => {
@@ -947,16 +957,14 @@ export function ChatShell({
                 />
               </View>
             ) : (
-              // [BUG-965] When voice mode is OFF, this is the *enable-voice*
-              // affordance, not a record button. Long-press flips voice ON
-              // and starts recording. It must NOT share testID="voice-record-
-              // button" with the on-state mic — otherwise E2E `assertNotVisible:
-              // voice-record-button` fails when voice is off, and consumers
-              // can't distinguish the two states. Use a distinct testID.
+              // [BUG-965] When voice mode is OFF, this enables voice mode
+              // before starting the mic. It must NOT share testID="voice-
+              // record-button" with the on-state mic — otherwise E2E
+              // `assertNotVisible: voice-record-button` fails when voice is
+              // off, and consumers can't distinguish the two states.
               <Pressable
                 testID="voice-enable-button"
-                onPress={() => void handleEnableVoiceAndRecord()}
-                onLongPress={() => void handleEnableVoiceAndRecord()}
+                onPress={handleEnableVoiceAndRecord}
                 disabled={
                   isStreaming || speechStatus === 'requesting_permission'
                 }

--- a/apps/mobile/src/components/session/ChatShell.tsx
+++ b/apps/mobile/src/components/session/ChatShell.tsx
@@ -910,12 +910,12 @@ export function ChatShell({
             aria-hidden={isWebDormant ? true : undefined}
             tabIndex={isWebDormant ? -1 : undefined}
             style={[
-              { paddingBottom: Math.max(insets.bottom, 8) },
+              { paddingBottom: belowInput ? 8 : Math.max(insets.bottom, 8) },
               isWebDormant ? { display: 'none' } : undefined,
             ]}
           >
             <TextInput
-              className="flex-1 bg-background rounded-input px-4 py-3 text-body text-text-primary me-2"
+              className="min-h-[52px] flex-1 bg-background rounded-input px-4 py-3 text-body text-text-primary me-2"
               placeholder={resolvedPlaceholder}
               placeholderTextColor={colors.muted}
               value={input}
@@ -960,7 +960,7 @@ export function ChatShell({
                 disabled={
                   isStreaming || speechStatus === 'requesting_permission'
                 }
-                className="w-9 h-9 rounded-full bg-surface-elevated items-center justify-center me-2"
+                className="h-[52px] w-[52px] rounded-input bg-surface-elevated items-center justify-center me-2"
                 accessibilityLabel="Enable voice message"
                 accessibilityRole="button"
               >
@@ -977,7 +977,7 @@ export function ChatShell({
               // guard — belt-and-braces against any path that bypasses the
               // wrapping View's pointerEvents/aria-hidden treatment.
               disabled={!input.trim() || isStreaming || isWebDormant}
-              className={`rounded-button px-5 py-3 min-h-[44px] min-w-[44px] items-center justify-center ${
+              className={`h-[52px] w-[52px] rounded-button items-center justify-center ${
                 input.trim() && !isStreaming && !isWebDormant
                   ? 'bg-primary'
                   : 'bg-surface-elevated'
@@ -999,7 +999,15 @@ export function ChatShell({
           </View>
         </View>
       )}
-      {belowInput}
+      {belowInput ? (
+        <View
+          className="bg-surface"
+          style={{ paddingBottom: Math.max(insets.bottom, 8) }}
+          testID="below-input-safe-area"
+        >
+          {belowInput}
+        </View>
+      ) : null}
     </KeyboardAvoidingView>
   );
 }

--- a/apps/mobile/src/components/session/ChatShell.tsx
+++ b/apps/mobile/src/components/session/ChatShell.tsx
@@ -459,6 +459,14 @@ export function ChatShell({
     }
   }, [isStreaming, isListening, stopListening, startListening, stopSpeaking]);
 
+  const handleEnableVoiceAndRecord = useCallback(async () => {
+    if (isStreaming) return;
+    if (!isVoiceEnabled) {
+      setVoiceEnabled(true);
+    }
+    await handleVoicePress();
+  }, [handleVoicePress, isStreaming, isVoiceEnabled, setVoiceEnabled]);
+
   // BUG-359: Gate to prevent late STT updates from re-populating the
   // transcript after the user taps Discard. Set on discard, cleared on
   // re-record or new recording.
@@ -947,11 +955,8 @@ export function ChatShell({
               // can't distinguish the two states. Use a distinct testID.
               <Pressable
                 testID="voice-enable-button"
-                onPress={handleVoicePress}
-                onLongPress={() => {
-                  setIsVoiceEnabled(true);
-                  void handleVoicePress();
-                }}
+                onPress={() => void handleEnableVoiceAndRecord()}
+                onLongPress={() => void handleEnableVoiceAndRecord()}
                 disabled={
                   isStreaming || speechStatus === 'requesting_permission'
                 }

--- a/apps/mobile/src/components/session/MessageBubble.test.tsx
+++ b/apps/mobile/src/components/session/MessageBubble.test.tsx
@@ -10,7 +10,7 @@
 // transcript hydration).
 // ---------------------------------------------------------------------------
 
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import { MessageBubble } from './MessageBubble';
 
 // react-native-markdown-display renders <Text> children verbatim in our
@@ -123,5 +123,25 @@ describe('verification badge styling', () => {
       />,
     );
     expect(queryByText(/CLEARED/)).toBeNull();
+  });
+});
+
+describe('MessageBubble collapse affordance', () => {
+  it('uses an icon-only collapse control for long assistant messages', () => {
+    const { getByTestId, queryByText } = render(
+      <MessageBubble
+        sender="assistant"
+        content="Long answer with enough layout height to become collapsible."
+      />,
+    );
+
+    fireEvent(getByTestId('message-ai-content'), 'layout', {
+      nativeEvent: { layout: { height: 220 } },
+    });
+
+    const toggle = getByTestId('message-collapse-toggle');
+    expect(toggle.props.className).toContain('min-h-[32px]');
+    expect(queryByText('Show less')).toBeNull();
+    expect(queryByText('Show more')).toBeNull();
   });
 });

--- a/apps/mobile/src/components/session/MessageBubble.tsx
+++ b/apps/mobile/src/components/session/MessageBubble.tsx
@@ -349,6 +349,7 @@ export function MessageBubble({
         ) : isAI ? (
           <View
             onLayout={handleContentLayout}
+            testID="message-ai-content"
             style={
               isCollapsible && !isExpanded
                 ? { maxHeight: COLLAPSE_THRESHOLD, overflow: 'hidden' }
@@ -396,7 +397,7 @@ export function MessageBubble({
         {showCollapseToggle && (
           <Pressable
             onPress={() => setIsExpanded((prev) => !prev)}
-            className="mt-2 flex-row items-center justify-center py-1"
+            className="self-end mt-1 min-h-[32px] min-w-[32px] items-center justify-center rounded-full"
             accessibilityLabel={
               isExpanded ? 'Collapse message' : 'Expand message'
             }
@@ -408,9 +409,6 @@ export function MessageBubble({
               size={14}
               color={colors.accent}
             />
-            <Text className="text-caption text-accent ml-1">
-              {isExpanded ? 'Show less' : 'Show more'}
-            </Text>
           </Pressable>
         )}
         {actions ? <View className="mt-3">{actions}</View> : null}

--- a/apps/mobile/src/components/session/SessionMessageActions.test.tsx
+++ b/apps/mobile/src/components/session/SessionMessageActions.test.tsx
@@ -28,13 +28,25 @@ const defaultProps: SessionMessageActionsProps = {
 
 describe('SessionMessageActions stage gating', () => {
   it('renders chips and feedback when stage is teaching', () => {
-    const { queryByTestId } = render(
+    const { queryByTestId, queryByText } = render(
       <SessionMessageActions {...defaultProps} stage="teaching" />,
     );
     // Quick chips render for a question-like message
     expect(queryByTestId('quick-chip-too_hard')).toBeTruthy();
-    // Feedback buttons render when eventId is present
-    expect(queryByTestId(`message-feedback-helpful-evt-1`)).toBeTruthy();
+    // Feedback buttons render when eventId is present, but feedback actions
+    // are compact icons rather than text chips.
+    const helpful = queryByTestId(`message-feedback-helpful-evt-1`);
+    const notHelpful = queryByTestId(`message-feedback-not-helpful-evt-1`);
+    const incorrect = queryByTestId(`message-feedback-incorrect-evt-1`);
+    expect(helpful).toBeTruthy();
+    expect(notHelpful).toBeTruthy();
+    expect(incorrect).toBeTruthy();
+    expect(helpful?.props.className).toContain('h-9');
+    expect(notHelpful?.props.className).toContain('w-9');
+    expect(incorrect?.props.className).toContain('h-9');
+    expect(queryByText('Helpful')).toBeNull();
+    expect(queryByText('Not helpful')).toBeNull();
+    expect(queryByText("That's incorrect")).toBeNull();
     expect(queryByTestId('bookmark-toggle-evt-1')).toBeNull();
   });
 
@@ -52,6 +64,24 @@ describe('SessionMessageActions stage gating', () => {
     expect(getByTestId('bookmark-toggle-evt-1').props.className).toContain(
       'min-h-[36px]',
     );
+  });
+
+  it('keeps learning chips before the compact feedback control group', () => {
+    const { getByTestId } = render(
+      <SessionMessageActions
+        {...defaultProps}
+        stage="teaching"
+        bookmarkState={{ 'evt-1': null }}
+        onToggleBookmark={jest.fn()}
+      />,
+    );
+
+    expect(getByTestId('quick-chip-too_hard')).toBeTruthy();
+    expect(getByTestId('quick-chip-explain_differently')).toBeTruthy();
+    expect(getByTestId('quick-chip-hint')).toBeTruthy();
+    expect(
+      getByTestId('message-feedback-controls-evt-1').props.className,
+    ).toContain('ms-auto');
   });
 
   it('hides bookmark toggle when the assistant message has no eventId', () => {

--- a/apps/mobile/src/components/session/SessionMessageActions.tsx
+++ b/apps/mobile/src/components/session/SessionMessageActions.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { hapticLight } from '../../lib/haptics';
+import { useThemeColors } from '../../lib/theme';
 import type { ChatMessage } from './ChatShell';
 import { QuotaExceededCard } from './QuotaExceededCard';
 import type { QuotaExceededDetails } from '../../lib/api-client';
@@ -53,6 +54,8 @@ export function SessionMessageActions({
   onToggleBookmark,
   handleReconnect,
 }: SessionMessageActionsProps) {
+  const colors = useThemeColors();
+
   if (message.kind === 'reconnect_prompt') {
     return (
       <Pressable
@@ -177,10 +180,10 @@ export function SessionMessageActions({
                     : 'thumbs-up-outline'
                 }
                 size={18}
-                className={
+                color={
                   feedbackState === 'helpful'
-                    ? 'text-primary'
-                    : 'text-text-secondary'
+                    ? colors.primary
+                    : colors.textSecondary
                 }
               />
             </View>
@@ -212,10 +215,10 @@ export function SessionMessageActions({
                     : 'thumbs-down-outline'
                 }
                 size={18}
-                className={
+                color={
                   feedbackState === 'not_helpful'
-                    ? 'text-warning'
-                    : 'text-text-secondary'
+                    ? colors.warning
+                    : colors.textSecondary
                 }
               />
             </View>
@@ -247,10 +250,10 @@ export function SessionMessageActions({
                     : 'alert-circle-outline'
                 }
                 size={18}
-                className={
+                color={
                   feedbackState === 'incorrect'
-                    ? 'text-danger'
-                    : 'text-text-secondary'
+                    ? colors.danger
+                    : colors.textSecondary
                 }
               />
             </View>
@@ -277,10 +280,10 @@ export function SessionMessageActions({
                     : 'bookmark-outline'
                 }
                 size={22}
-                className={
+                color={
                   bookmarkState?.[message.eventId]
-                    ? 'text-primary'
-                    : 'text-text-secondary'
+                    ? colors.primary
+                    : colors.textSecondary
                 }
               />
             </Pressable>

--- a/apps/mobile/src/components/session/SessionMessageActions.tsx
+++ b/apps/mobile/src/components/session/SessionMessageActions.tsx
@@ -120,33 +120,32 @@ export function SessionMessageActions({
   }
 
   return (
-    <View className="gap-2">
-      {messageControlChips.length > 0 && (
-        <View className="flex-row flex-wrap gap-2">
-          {messageControlChips.map((chip) => {
-            return (
-              <Pressable
-                key={`${message.id}-${chip.id}`}
-                onPress={() => void handleQuickChip(chip.id, message.id)}
-                disabled={isStreaming}
-                className="rounded-full bg-surface-elevated px-3 py-1.5"
-                testID={`quick-chip-${chip.id}`}
-                // [BUG-874] Without an explicit role + label, screen readers
-                // and keyboard users hear plain text for these chips. RN's
-                // accessibilityRole="button" maps to role="button" on web.
-                accessibilityRole="button"
-                accessibilityLabel={chip.label}
-              >
-                <Text className="text-caption font-semibold text-text-secondary">
-                  {chip.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-      )}
+    <View className="flex-row flex-wrap gap-2 items-center">
+      {messageControlChips.map((chip) => {
+        return (
+          <Pressable
+            key={`${message.id}-${chip.id}`}
+            onPress={() => void handleQuickChip(chip.id, message.id)}
+            disabled={isStreaming}
+            className="rounded-full bg-surface-elevated px-3 py-1.5"
+            testID={`quick-chip-${chip.id}`}
+            // [BUG-874] Without an explicit role + label, screen readers
+            // and keyboard users hear plain text for these chips. RN's
+            // accessibilityRole="button" maps to role="button" on web.
+            accessibilityRole="button"
+            accessibilityLabel={chip.label}
+          >
+            <Text className="text-caption font-semibold text-text-secondary">
+              {chip.label}
+            </Text>
+          </Pressable>
+        );
+      })}
       {showFeedbackButtons && (
-        <View className="flex-row flex-wrap gap-2 items-center">
+        <View
+          className="ms-auto flex-row gap-2 items-center"
+          testID={`message-feedback-controls-${feedbackTestIdSuffix}`}
+        >
           {/* [BUG-874] Each feedback chip needs explicit role + label so
               screen readers announce them as interactive buttons rather than
               plain text. accessibilityState.selected reflects the toggle
@@ -156,8 +155,8 @@ export function SessionMessageActions({
             disabled={feedbackState === 'incorrect' || isStreaming}
             className={
               feedbackState === 'helpful'
-                ? 'rounded-full bg-primary/15 px-3 py-1.5'
-                : 'rounded-full bg-surface-elevated px-3 py-1.5'
+                ? 'h-9 w-9 rounded-full bg-primary/15 items-center justify-center'
+                : 'h-9 w-9 rounded-full bg-surface-elevated items-center justify-center'
             }
             testID={`message-feedback-helpful-${feedbackTestIdSuffix}`}
             accessibilityRole="button"
@@ -167,23 +166,32 @@ export function SessionMessageActions({
               disabled: feedbackState === 'incorrect' || isStreaming,
             }}
           >
-            <Text
-              className={
-                feedbackState === 'helpful'
-                  ? 'text-caption font-semibold text-primary'
-                  : 'text-caption font-semibold text-text-secondary'
-              }
+            <View
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
             >
-              Helpful
-            </Text>
+              <Ionicons
+                name={
+                  feedbackState === 'helpful'
+                    ? 'thumbs-up'
+                    : 'thumbs-up-outline'
+                }
+                size={18}
+                className={
+                  feedbackState === 'helpful'
+                    ? 'text-primary'
+                    : 'text-text-secondary'
+                }
+              />
+            </View>
           </Pressable>
           <Pressable
             onPress={() => void handleMessageFeedback(message, 'not_helpful')}
             disabled={feedbackState === 'incorrect' || isStreaming}
             className={
               feedbackState === 'not_helpful'
-                ? 'rounded-full bg-warning/15 px-3 py-1.5'
-                : 'rounded-full bg-surface-elevated px-3 py-1.5'
+                ? 'h-9 w-9 rounded-full bg-warning/15 items-center justify-center'
+                : 'h-9 w-9 rounded-full bg-surface-elevated items-center justify-center'
             }
             testID={`message-feedback-not-helpful-${feedbackTestIdSuffix}`}
             accessibilityRole="button"
@@ -193,23 +201,32 @@ export function SessionMessageActions({
               disabled: feedbackState === 'incorrect' || isStreaming,
             }}
           >
-            <Text
-              className={
-                feedbackState === 'not_helpful'
-                  ? 'text-caption font-semibold text-warning'
-                  : 'text-caption font-semibold text-text-secondary'
-              }
+            <View
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
             >
-              Not helpful
-            </Text>
+              <Ionicons
+                name={
+                  feedbackState === 'not_helpful'
+                    ? 'thumbs-down'
+                    : 'thumbs-down-outline'
+                }
+                size={18}
+                className={
+                  feedbackState === 'not_helpful'
+                    ? 'text-warning'
+                    : 'text-text-secondary'
+                }
+              />
+            </View>
           </Pressable>
           <Pressable
             onPress={() => void handleMessageFeedback(message, 'incorrect')}
             disabled={isStreaming}
             className={
               feedbackState === 'incorrect'
-                ? 'rounded-full bg-danger/15 px-3 py-1.5'
-                : 'rounded-full bg-surface-elevated px-3 py-1.5'
+                ? 'h-9 w-9 rounded-full bg-danger/15 items-center justify-center'
+                : 'h-9 w-9 rounded-full bg-surface-elevated items-center justify-center'
             }
             testID={`message-feedback-incorrect-${feedbackTestIdSuffix}`}
             accessibilityRole="button"
@@ -219,15 +236,24 @@ export function SessionMessageActions({
               disabled: isStreaming,
             }}
           >
-            <Text
-              className={
-                feedbackState === 'incorrect'
-                  ? 'text-caption font-semibold text-danger'
-                  : 'text-caption font-semibold text-text-secondary'
-              }
+            <View
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
             >
-              That&apos;s incorrect
-            </Text>
+              <Ionicons
+                name={
+                  feedbackState === 'incorrect'
+                    ? 'alert-circle'
+                    : 'alert-circle-outline'
+                }
+                size={18}
+                className={
+                  feedbackState === 'incorrect'
+                    ? 'text-danger'
+                    : 'text-text-secondary'
+                }
+              />
+            </View>
           </Pressable>
           {message.eventId && onToggleBookmark ? (
             <Pressable

--- a/apps/mobile/src/components/session/VoiceRecordButton.test.tsx
+++ b/apps/mobile/src/components/session/VoiceRecordButton.test.tsx
@@ -44,7 +44,9 @@ describe('VoiceRecordButton', () => {
       />,
     );
 
-    screen.getByTestId('voice-record-button');
+    const button = screen.getByTestId('voice-record-button');
+    expect(button.props.className).toContain('h-[52px]');
+    expect(button.props.className).toContain('w-[52px]');
     // Icon is a11y-hidden — must use includeHiddenElements to find it
     screen.getByText('mic', { includeHiddenElements: true });
   });

--- a/apps/mobile/src/components/session/VoiceRecordButton.tsx
+++ b/apps/mobile/src/components/session/VoiceRecordButton.tsx
@@ -62,7 +62,7 @@ export function VoiceRecordButton({
       <Pressable
         onPress={handlePress}
         disabled={disabled}
-        className={`rounded-full p-3 min-h-[44px] min-w-[44px] items-center justify-center ${
+        className={`h-[52px] w-[52px] rounded-input items-center justify-center ${
           isListening ? 'bg-danger' : 'bg-surface-elevated'
         }`}
         accessibilityLabel={isListening ? 'Stop recording' : 'Start recording'}


### PR DESCRIPTION
## Summary
- enable voice mode before starting the compact microphone recorder so spoken input reaches chat
- align chat input, mic, and send controls to the same compact height across chats
- tighten message actions with one-line learning chips, icon-only feedback, and no visible Show less text
- move bottom safe-area padding below quick tools to remove the large gap under chat

## Validation
- pnpm exec jest --config apps/mobile/jest.config.cjs --runInBand --no-coverage --testMatch "**/ChatShell.test.tsx" "**/VoiceRecordButton.test.tsx" "**/SessionAccessories.test.tsx" "**/SessionMessageActions.test.tsx" "**/MessageBubble.test.tsx"
- pnpm exec tsc --build apps/mobile/tsconfig.json --pretty false
- bash scripts/verify-test-receipts.sh