### PR TITLE
Align subject shelf UI

### DIFF
--- a/.test-receipts/mobile.json
+++ b/.test-receipts/mobile.json
@@ -1,13 +1,14 @@
 {
   "scope": "mobile",
-  "verifiedAt": "2026-05-15T11:40:26Z",
+  "verifiedAt": "2026-05-15T12:25:09Z",
   "verifiedBy": "Zuzana Kopečná @ ZLY-Orion",
   "command": "pnpm exec nx run mobile:test",
   "passed": true,
   "testFiles": {
-    "apps/mobile/src/components/session/ChatShell.test.tsx": "c49c9037e4d0194fbe912b66a0ce3b879752a50d",
-    "apps/mobile/src/components/session/MessageBubble.test.tsx": "14a8aee4e25c7abd1460a153833d8ef36d294143",
-    "apps/mobile/src/components/session/SessionMessageActions.test.tsx": "04ad75fd78f2ea3584ebd8c4e1b661bc52812be7",
-    "apps/mobile/src/components/session/VoiceRecordButton.test.tsx": "edf356283448ddbc8e4acda0a8d5a1884d0f480c"
+    "apps/mobile/src/app/(app)/library.test.tsx": "3694463dd920dcd11433463370fce84a075a296e",
+    "apps/mobile/src/app/(app)/progress.test.tsx": "205001bf5dbcae8c7889e4ba278d1a0ae78bff91",
+    "apps/mobile/src/components/home/SubjectTile.test.tsx": "8c424034399124cea0a5c7f7c13234a9b59521c4",
+    "apps/mobile/src/hooks/use-homework-ocr.test.ts": "50a460ee0ad42bac4f073d19e90dc151389e0655",
+    "apps/mobile/src/lib/subject-tints.test.ts": "27cd5e6ecfee942e5d854432f06bf2d99e93098e"
   }
 }

--- a/apps/mobile/src/app/(app)/library.test.tsx
+++ b/apps/mobile/src/app/(app)/library.test.tsx
@@ -64,6 +64,7 @@ jest.mock('../../components/common', () => ({
 
 jest.mock('../../lib/theme', () => ({
   // gc1-allow: theme hook requires native ColorScheme unavailable in JSDOM
+  useTheme: () => ({ colorScheme: 'light' }),
   useThemeColors: () => ({
     accent: '#2563eb',
     border: '#e5e7eb',

--- a/apps/mobile/src/app/(app)/library.tsx
+++ b/apps/mobile/src/app/(app)/library.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../components/common';
 import { goBackOrReplace } from '../../lib/navigation';
 import { useAllBooks } from '../../hooks/use-all-books';
-import { useThemeColors } from '../../lib/theme';
+import { useTheme, useThemeColors } from '../../lib/theme';
 import { useSubjects, useUpdateSubject } from '../../hooks/use-subjects';
 import { useOverallProgress } from '../../hooks/use-progress';
 import {
@@ -41,7 +41,7 @@ import {
 } from '../../components/library/LibrarySearchResults';
 import { useLibrarySearch } from '../../hooks/use-library-search';
 import { ShimmerSkeleton } from '../../components/common/ShimmerSkeleton';
-import { getLearningSubjectTint } from '../../lib/learning-subject-tints';
+import { getSubjectTintMap } from '../../lib/subject-tints';
 
 // ---------------------------------------------------------------------------
 // Local types
@@ -75,6 +75,12 @@ const SUBJECT_STATUS_ORDER: Record<Subject['status'], number> = {
   paused: 1,
   archived: 2,
 };
+
+const SUBJECT_STATUS_GROUPS: Subject['status'][] = [
+  'active',
+  'paused',
+  'archived',
+];
 
 function sortSubjectsByStatus<T extends { status: Subject['status'] }>(
   input: readonly T[],
@@ -133,6 +139,7 @@ export default function LibraryScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const themeColors = useThemeColors();
+  const { colorScheme } = useTheme();
   const { activeProfile, profiles } = useProfile();
   const isGuardian = isGuardianProfile(activeProfile, profiles);
 
@@ -172,13 +179,11 @@ export default function LibraryScreen() {
   );
   const subjectTintsById = useMemo(
     () =>
-      new Map(
-        sortedSubjects.map((subject, index) => [
-          subject.id,
-          getLearningSubjectTint(index, themeColors),
-        ]),
+      getSubjectTintMap(
+        sortedSubjects.map((subject) => subject.id),
+        colorScheme,
       ),
-    [sortedSubjects, themeColors],
+    [sortedSubjects, colorScheme],
   );
 
   const progressQuery = useOverallProgress();
@@ -549,6 +554,11 @@ export default function LibraryScreen() {
     const isSearching = debouncedQuery.trim().length > 0;
     const showingStaleCachedData =
       (subjectsQuery.isError || progressQuery.isError) && subjects.length > 0;
+    const shelfGroups = SUBJECT_STATUS_GROUPS.map((status) => ({
+      status,
+      subjects: visibleSubjects.filter((subject) => subject.status === status),
+    })).filter((group) => group.subjects.length > 0);
+    const showShelfGroupLabels = shelfGroups.length > 1;
 
     return (
       <>
@@ -671,33 +681,42 @@ export default function LibraryScreen() {
                 </Text>
               </Pressable>
             ) : null}
-            {visibleSubjects.map((subject) => {
-              const retData = retentionDataBySubjectId.get(subject.id);
-              const books = booksBySubjectId.get(subject.id) ?? [];
-              const bookCount = books.length;
-              const progress = progressBySubjectId.get(subject.id);
-              const topicsTotal = progress?.topicsTotal ?? 0;
-              const topicsCompleted = progress?.topicsCompleted ?? 0;
-              const topicProgress = `${topicsCompleted}/${topicsTotal}`;
-              const isFinished =
-                topicsTotal > 0 &&
-                (progress?.topicsVerified ?? 0) >= topicsTotal;
+            {shelfGroups.map((group) => (
+              <View key={group.status}>
+                {showShelfGroupLabels ? (
+                  <Text className="text-caption font-bold text-text-secondary mt-1 mb-2">
+                    {t(`library.sections.${group.status}`)}
+                  </Text>
+                ) : null}
+                {group.subjects.map((subject) => {
+                  const retData = retentionDataBySubjectId.get(subject.id);
+                  const books = booksBySubjectId.get(subject.id) ?? [];
+                  const bookCount = books.length;
+                  const progress = progressBySubjectId.get(subject.id);
+                  const topicsTotal = progress?.topicsTotal ?? 0;
+                  const topicsCompleted = progress?.topicsCompleted ?? 0;
+                  const topicProgress = `${topicsCompleted}/${topicsTotal}`;
+                  const isFinished =
+                    topicsTotal > 0 &&
+                    (progress?.topicsVerified ?? 0) >= topicsTotal;
 
-              return (
-                <ShelfRow
-                  key={subject.id}
-                  subjectId={subject.id}
-                  name={subject.name}
-                  bookCount={bookCount}
-                  topicProgress={topicProgress}
-                  reviewDueCount={retData?.reviewDueCount ?? 0}
-                  isFinished={isFinished}
-                  status={subject.status}
-                  tint={subjectTintsById.get(subject.id)}
-                  onPress={handleShelfPress}
-                />
-              );
-            })}
+                  return (
+                    <ShelfRow
+                      key={subject.id}
+                      subjectId={subject.id}
+                      name={subject.name}
+                      bookCount={bookCount}
+                      topicProgress={topicProgress}
+                      reviewDueCount={retData?.reviewDueCount ?? 0}
+                      isFinished={isFinished}
+                      status={subject.status}
+                      tint={subjectTintsById.get(subject.id)}
+                      onPress={handleShelfPress}
+                    />
+                  );
+                })}
+              </View>
+            ))}
           </View>
         )}
       </>

--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -851,6 +851,42 @@ describe('ProgressScreen — progressive disclosure', () => {
     screen.getByText('5 sessions · 30 min');
   });
 
+  it('uses compact subject breakdown cards when a child has many subjects', () => {
+    const manySubjects = Array.from({ length: 7 }, (_, index) => ({
+      ...fullSubject,
+      subjectId: `s${index + 1}`,
+      subjectName: `Subject ${index + 1}`,
+      lastSessionAt: '2026-05-01T10:00:00Z',
+    }));
+
+    mockLinkedChildren = [makeLinkedChild()];
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 5, topicsMastered: 3 },
+        subjects: [fullSubject],
+      },
+    });
+    (useChildInventory as jest.Mock).mockReturnValue({
+      data: {
+        global: { ...baseGlobal, totalSessions: 5, topicsMastered: 3 },
+        subjects: manySubjects,
+        currentlyWorkingOn: [],
+      },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+      refetch: jest.fn(),
+    });
+
+    render(<ProgressScreen />);
+
+    screen.getByTestId('progress-subject-card-s1');
+    screen.getByTestId('progress-subject-card-s7');
+    screen.getByText('Subject 7');
+    screen.getAllByText('3/10 topics mastered');
+    expect(screen.queryByText(/Last studied/)).toBeNull();
+  });
+
   it('does not render report cards for parent viewing child', () => {
     mockLinkedChildren = [makeLinkedChild()];
     mockHooks({

--- a/apps/mobile/src/app/(app)/progress/index.tsx
+++ b/apps/mobile/src/app/(app)/progress/index.tsx
@@ -50,16 +50,14 @@ import {
   useRefreshProgressSnapshot,
 } from '../../../hooks/use-progress';
 import { useSubjects } from '../../../hooks/use-subjects';
-import {
-  getLearningSubjectTint,
-  type LearningSubjectTint,
-} from '../../../lib/learning-subject-tints';
+import type { LearningSubjectTint } from '../../../lib/learning-subject-tints';
 import { pushLearningResumeTarget } from '../../../lib/navigation';
 import { copyRegisterFor, type CopyRegister } from '../../../lib/copy-register';
 import { useLinkedChildren, useProfile } from '../../../lib/profile';
 import { buildGrowthData, isProfileStale } from '../../../lib/progress';
 import { bucketAccountAge, hashProfileId, track } from '../../../lib/analytics';
-import { useThemeColors } from '../../../lib/theme';
+import { useTheme } from '../../../lib/theme';
+import { getSubjectTint, getSubjectTintMap } from '../../../lib/subject-tints';
 
 function heroCopy(
   input: {
@@ -175,15 +173,31 @@ function LoadingBlock(): React.ReactElement {
 function SubjectBreakdownCard({
   subject,
   tint,
+  compact = false,
 }: {
   subject: SubjectInventory;
   tint: LearningSubjectTint;
+  compact?: boolean;
 }): React.ReactElement {
   const { t } = useTranslation();
+  const timeLabel = formatMinutes(
+    subject.wallClockMinutes ?? subject.activeMinutes,
+  );
+  const sessionsLabel = t('progress.guardian.sessionCount', {
+    count: subject.sessionsCount,
+  });
+  const topicsLabel =
+    subject.topics.total != null
+      ? t('progress.guardian.topicsMastered', {
+          mastered: subject.topics.mastered,
+          total: subject.topics.total,
+        })
+      : null;
+
   return (
     <View
       testID={`progress-subject-card-${subject.subjectId}`}
-      className="rounded-card p-4 mt-3"
+      className={`rounded-card ${compact ? 'p-3 mt-2' : 'p-4 mt-3'}`}
       style={{
         backgroundColor: tint.soft,
         borderColor: tint.solid + '33',
@@ -202,26 +216,25 @@ function SubjectBreakdownCard({
             {subject.subjectName}
           </Text>
           <Text className="text-body-sm text-text-secondary mt-1">
-            {t('progress.guardian.sessionCount', {
-              count: subject.sessionsCount,
-            })}{' '}
-            · {formatMinutes(subject.wallClockMinutes ?? subject.activeMinutes)}
+            {sessionsLabel} · {timeLabel}
           </Text>
+          {compact && topicsLabel ? (
+            <Text className="text-caption text-text-secondary mt-1">
+              {topicsLabel}
+            </Text>
+          ) : null}
         </View>
       </View>
-      {subject.lastSessionAt ? (
+      {!compact && subject.lastSessionAt ? (
         <Text className="text-caption text-text-secondary mt-1">
           {t('progress.guardian.lastStudied', {
             date: formatRelativeDate(subject.lastSessionAt),
           })}
         </Text>
       ) : null}
-      {subject.topics.total != null ? (
+      {!compact && topicsLabel ? (
         <Text className="text-caption text-text-secondary mt-1">
-          {t('progress.guardian.topicsMastered', {
-            mastered: subject.topics.mastered,
-            total: subject.topics.total,
-          })}
+          {topicsLabel}
         </Text>
       ) : null}
     </View>
@@ -282,7 +295,7 @@ export default function ProgressScreen(): React.ReactElement {
     profileId?: string;
   }>();
   const insets = useSafeAreaInsets();
-  const themeColors = useThemeColors();
+  const { colorScheme } = useTheme();
   const { activeProfile } = useProfile();
   const linkedChildren = useLinkedChildren();
   const hasLinked = linkedChildren.length > 0;
@@ -508,6 +521,14 @@ export default function ProgressScreen(): React.ReactElement {
     (child) => child.id === selectedProfileId,
   );
   const selectedChildName = selectedChild?.displayName;
+  const progressSubjectTintsById = useMemo(
+    () =>
+      getSubjectTintMap(
+        inventory?.subjects.map((subject) => subject.subjectId) ?? [],
+        colorScheme,
+      ),
+    [inventory?.subjects, colorScheme],
+  );
 
   const handleEmptyProgressAction = () => {
     if (activeProfile) {
@@ -784,17 +805,6 @@ export default function ProgressScreen(): React.ReactElement {
                     </Text>
                   </Pressable>
                 ) : null}
-                {inventory?.subjects?.length ? (
-                  <View testID="progress-subject-breakdown" className="mt-3">
-                    {inventory.subjects.map((subject, index) => (
-                      <SubjectBreakdownCard
-                        key={subject.subjectId}
-                        subject={subject}
-                        tint={getLearningSubjectTint(index, themeColors)}
-                      />
-                    ))}
-                  </View>
-                ) : null}
                 {selectedProfileId ? (
                   <Pressable
                     testID="progress-view-all-reports"
@@ -811,6 +821,27 @@ export default function ProgressScreen(): React.ReactElement {
                       {t('progress.guardian.viewAllReports')}
                     </Text>
                   </Pressable>
+                ) : null}
+                {inventory?.subjects?.length ? (
+                  <View testID="progress-subject-breakdown" className="mt-5">
+                    <Text className="text-caption font-bold text-text-secondary mb-2">
+                      {t('progress.guardian.subjectsTitle')}
+                    </Text>
+                    {inventory.subjects.map((subject) => {
+                      const compact = inventory.subjects.length >= 7;
+                      return (
+                        <SubjectBreakdownCard
+                          key={subject.subjectId}
+                          subject={subject}
+                          tint={
+                            progressSubjectTintsById.get(subject.subjectId) ??
+                            getSubjectTint(subject.subjectId, colorScheme)
+                          }
+                          compact={compact}
+                        />
+                      );
+                    })}
+                  </View>
                 ) : null}
               </>
             ) : null}

--- a/apps/mobile/src/components/home/LearnerScreen.tsx
+++ b/apps/mobile/src/components/home/LearnerScreen.tsx
@@ -34,7 +34,7 @@ import {
   type SessionRecoveryMarker,
 } from '../../lib/session-recovery';
 import { FEATURE_FLAGS } from '../../lib/feature-flags';
-import { getSubjectTint } from '../../lib/subject-tints';
+import { getSubjectTint, getSubjectTintMap } from '../../lib/subject-tints';
 import { useTheme } from '../../lib/theme';
 import { useThemeColors } from '../../lib/theme';
 import {
@@ -232,47 +232,51 @@ export function LearnerScreen({
 
   const subjectCards = useMemo(() => {
     if (!subjects?.length) return [];
+    const activeSubjects = subjects.filter((s) => s.status === 'active');
+    const subjectTintsById = getSubjectTintMap(
+      activeSubjects.map((s) => s.id),
+      colorScheme,
+    );
     const progressBySubject = new Map(
       (overallProgress?.subjects ?? []).map((p) => [p.subjectId, p]),
     );
-    return subjects
-      .filter((s) => s.status === 'active')
-      .map((s) => {
-        const progress = progressBySubject.get(s.id);
-        const tint = getSubjectTint(s.id, colorScheme);
-        const total = progress?.topicsTotal ?? 0;
-        const completed = progress?.topicsCompleted ?? 0;
+    return activeSubjects.map((s) => {
+      const progress = progressBySubject.get(s.id);
+      const tint =
+        subjectTintsById.get(s.id) ?? getSubjectTint(s.id, colorScheme);
+      const total = progress?.topicsTotal ?? 0;
+      const completed = progress?.topicsCompleted ?? 0;
 
-        const isPreparing = s.curriculumStatus === 'preparing';
-        let hint = isPreparing ? `Setting up ${s.name}...` : 'Open';
-        if (
-          !isPreparing &&
-          resumeTarget?.subjectId === s.id &&
-          ['active_session', 'paused_session'].includes(resumeTarget.resumeKind)
-        ) {
-          hint = `Continue ${resumeTarget.topicTitle ?? s.name}`;
-        } else if (
-          !isPreparing &&
-          reviewSummary?.nextReviewTopic?.subjectId === s.id
-        ) {
-          hint = `Quiz: ${reviewSummary.nextReviewTopic.topicTitle}`;
-        } else if (!isPreparing && completed > 0) {
-          hint = `Practice: ${s.name}`;
-        }
+      const isPreparing = s.curriculumStatus === 'preparing';
+      let hint = isPreparing ? `Setting up ${s.name}...` : 'Open';
+      if (
+        !isPreparing &&
+        resumeTarget?.subjectId === s.id &&
+        ['active_session', 'paused_session'].includes(resumeTarget.resumeKind)
+      ) {
+        hint = `Continue ${resumeTarget.topicTitle ?? s.name}`;
+      } else if (
+        !isPreparing &&
+        reviewSummary?.nextReviewTopic?.subjectId === s.id
+      ) {
+        hint = `Quiz: ${reviewSummary.nextReviewTopic.topicTitle}`;
+      } else if (!isPreparing && completed > 0) {
+        hint = `Practice: ${s.name}`;
+      }
 
-        return {
-          subjectId: s.id,
-          name: s.name,
-          hint,
-          isPreparing,
-          progress: total > 0 ? completed / total : 0,
-          topicsCompleted: completed,
-          topicsTotal: total,
-          tintSolid: tint.solid,
-          tintSoft: tint.soft,
-          icon: DEFAULT_SUBJECT_ICON,
-        };
-      });
+      return {
+        subjectId: s.id,
+        name: s.name,
+        hint,
+        isPreparing,
+        progress: total > 0 ? completed / total : 0,
+        topicsCompleted: completed,
+        topicsTotal: total,
+        tintSolid: tint.solid,
+        tintSoft: tint.soft,
+        icon: DEFAULT_SUBJECT_ICON,
+      };
+    });
   }, [subjects, overallProgress, resumeTarget, reviewSummary, colorScheme]);
 
   const coachBand = useMemo(() => {
@@ -367,6 +371,8 @@ export function LearnerScreen({
     quizDiscovery,
     recoveryMarker,
     resumeTarget,
+    returnParams,
+    returnToTab,
     reviewSummary,
   ]);
 
@@ -527,7 +533,7 @@ export function LearnerScreen({
             <Text className="text-h3 font-bold text-text-primary px-5 mb-2">
               {t('home.learner.intentHeading')}
             </Text>
-            <View className="px-5" style={{ gap: 10 }}>
+            <View className="px-5" style={{ gap: 8 }}>
               {HOME_INTENT_ACTIONS.map((action) => {
                 const title = t(action.titleKey);
                 const subtitle = t(action.subtitleKey);
@@ -537,19 +543,19 @@ export function LearnerScreen({
                     key={action.testID}
                     testID={action.testID}
                     onPress={() => openIntentAction(action.route)}
-                    className={`rounded-2xl border px-4 py-4 flex-row items-center ${
+                    className={`rounded-2xl border px-4 py-3 flex-row items-center ${
                       action.highlight
                         ? 'bg-primary-soft border-primary/40'
                         : 'bg-surface border-border'
                     }`}
-                    style={{ gap: 12 }}
+                    style={{ gap: 10 }}
                     accessibilityRole="button"
                     accessibilityLabel={`${title}. ${subtitle}`}
                   >
-                    <View className="w-11 h-11 rounded-2xl bg-surface-elevated items-center justify-center">
+                    <View className="w-10 h-10 rounded-2xl bg-surface-elevated items-center justify-center">
                       <Ionicons
                         name={action.icon}
-                        size={22}
+                        size={21}
                         color={colors.primary}
                       />
                     </View>
@@ -557,7 +563,10 @@ export function LearnerScreen({
                       <Text className="text-body font-bold text-text-primary">
                         {title}
                       </Text>
-                      <Text className="text-body-sm text-text-secondary mt-1">
+                      <Text
+                        className="text-body-sm text-text-secondary mt-0.5"
+                        numberOfLines={2}
+                      >
                         {subtitle}
                       </Text>
                     </View>

--- a/apps/mobile/src/components/home/SubjectTile.test.tsx
+++ b/apps/mobile/src/components/home/SubjectTile.test.tsx
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { SubjectTile, type SubjectTileProps } from './SubjectTile';
 
 const baseProps: SubjectTileProps = {
@@ -38,5 +39,14 @@ describe('SubjectTile', () => {
   it('renders the icon tile', () => {
     const { getByTestId } = render(<SubjectTile {...baseProps} />);
     expect(getByTestId('home-subject-card-abc-123-icon')).toBeTruthy();
+  });
+
+  it('uses the subject shelf tint for the card background and border', () => {
+    const { getByTestId } = render(<SubjectTile {...baseProps} />);
+    const tile = getByTestId('home-subject-card-abc-123');
+    const style = StyleSheet.flatten(tile.props.style);
+
+    expect(style.backgroundColor).toBe(baseProps.tintSoft);
+    expect(style.borderColor).toBe(`${baseProps.tintSolid}33`);
   });
 });

--- a/apps/mobile/src/components/home/SubjectTile.tsx
+++ b/apps/mobile/src/components/home/SubjectTile.tsx
@@ -41,7 +41,14 @@ export function SubjectTile({
       }
       accessibilityRole="button"
       className="w-[142px] rounded-2xl bg-surface border border-border p-3.5 pb-4"
-      style={[{ gap: 10 }, isPreparing && { opacity: 0.7 }]}
+      style={[
+        {
+          backgroundColor: tintSoft,
+          borderColor: `${tintSolid}33`,
+          gap: 10,
+        },
+        isPreparing && { opacity: 0.7 },
+      ]}
     >
       <View testID={`${testID}-icon`} className="items-start">
         <SubjectBookshelfMotif

--- a/apps/mobile/src/components/library/ShelfRow.tsx
+++ b/apps/mobile/src/components/library/ShelfRow.tsx
@@ -76,8 +76,7 @@ export function ShelfRow({
   const showFinished = isFinished && !needsReview;
 
   return (
-    <View style={{ opacity: isInactive ? 0.65 : 1 }}>
-      {/* Header row */}
+    <View style={{ marginBottom: 12, opacity: isInactive ? 0.65 : 1 }}>
       <Pressable
         testID={testID ?? `shelf-row-header-${subjectId}`}
         onPress={() => onPress(subjectId)}
@@ -93,25 +92,29 @@ export function ShelfRow({
               : '',
           action: t('library.row.shelfActionOpen'),
         })}
-        style={{
+        style={({ pressed }) => ({
+          backgroundColor: tint.soft,
+          borderColor: tint.solid + '33',
+          borderRadius: 16,
+          borderWidth: 1,
           flexDirection: 'row',
-          alignItems: 'center',
-          paddingVertical: 12,
+          alignItems: 'flex-start',
+          minHeight: 108,
           paddingHorizontal: 16,
-          gap: 12,
-        }}
+          paddingVertical: 18,
+          opacity: pressed ? 0.76 : 1,
+        })}
       >
         <SubjectBookshelfMotif
           testID={`shelf-row-bookshelf-${subjectId}`}
           tint={tint}
         />
 
-        {/* Name + subtitle */}
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, marginLeft: 14, minWidth: 0 }}>
           <Text
             style={{
-              fontSize: 15,
-              fontWeight: 'bold',
+              fontSize: 19,
+              fontWeight: '700',
               color: colors.textPrimary,
             }}
             numberOfLines={1}
@@ -120,104 +123,113 @@ export function ShelfRow({
           </Text>
           <Text
             style={{
-              fontSize: 12,
+              fontSize: 15,
               color: isUnstarted ? tint.solid : colors.textSecondary,
-              fontWeight: isUnstarted ? '500' : 'normal',
-              marginTop: 1,
+              fontWeight: isUnstarted ? '600' : '400',
+              marginTop: 4,
             }}
             numberOfLines={1}
           >
             {subtitle}
           </Text>
+
+          <View
+            style={{
+              alignItems: 'center',
+              flexDirection: 'row',
+              flexWrap: 'wrap',
+              gap: 8,
+              marginTop: 10,
+            }}
+          >
+            {statusChip ? (
+              <View
+                testID={statusChip.testID}
+                style={{
+                  paddingHorizontal: 10,
+                  paddingVertical: 4,
+                  borderRadius: 999,
+                  backgroundColor: statusChip.backgroundColor,
+                }}
+              >
+                <Text
+                  style={{
+                    fontSize: 12,
+                    fontWeight: '700',
+                    color: statusChip.color,
+                  }}
+                >
+                  {statusChip.label}
+                </Text>
+              </View>
+            ) : null}
+
+            {needsReview ? (
+              <View
+                testID={`shelf-row-review-${subjectId}`}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 4,
+                  paddingHorizontal: 10,
+                  paddingVertical: 4,
+                  borderRadius: 999,
+                  backgroundColor: colors.retentionWeak + '22',
+                }}
+              >
+                <Ionicons
+                  name="refresh-circle"
+                  size={13}
+                  color={colors.retentionWeak}
+                />
+                <Text
+                  style={{
+                    fontSize: 12,
+                    fontWeight: '700',
+                    color: colors.retentionWeak,
+                  }}
+                >
+                  {t('library.row.review')}
+                </Text>
+              </View>
+            ) : null}
+
+            {showFinished ? (
+              <View
+                testID={`shelf-row-finished-${subjectId}`}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 4,
+                  paddingHorizontal: 10,
+                  paddingVertical: 4,
+                  borderRadius: 999,
+                  backgroundColor: colors.success + '22',
+                }}
+              >
+                <Ionicons
+                  name="checkmark-circle"
+                  size={13}
+                  color={colors.success}
+                />
+                <Text
+                  style={{
+                    fontSize: 12,
+                    fontWeight: '700',
+                    color: colors.success,
+                  }}
+                >
+                  {t('library.row.finished')}
+                </Text>
+              </View>
+            ) : null}
+          </View>
         </View>
 
-        {/* Right side: paused chip + status pill + chevron */}
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-          {statusChip ? (
-            <View
-              testID={statusChip.testID}
-              style={{
-                paddingHorizontal: 8,
-                paddingVertical: 2,
-                borderRadius: 10,
-                backgroundColor: statusChip.backgroundColor,
-              }}
-            >
-              <Text
-                style={{
-                  fontSize: 11,
-                  fontWeight: '500',
-                  color: statusChip.color,
-                }}
-              >
-                {statusChip.label}
-              </Text>
-            </View>
-          ) : null}
-
-          {needsReview ? (
-            <View
-              testID={`shelf-row-review-${subjectId}`}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 3,
-                paddingHorizontal: 8,
-                paddingVertical: 2,
-                borderRadius: 10,
-                backgroundColor: colors.retentionWeak + '22',
-              }}
-            >
-              <Ionicons
-                name="refresh-circle"
-                size={12}
-                color={colors.retentionWeak}
-              />
-              <Text
-                style={{
-                  fontSize: 11,
-                  fontWeight: '600',
-                  color: colors.retentionWeak,
-                }}
-              >
-                {t('library.row.review')}
-              </Text>
-            </View>
-          ) : null}
-
-          {showFinished ? (
-            <View
-              testID={`shelf-row-finished-${subjectId}`}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 3,
-                paddingHorizontal: 8,
-                paddingVertical: 2,
-                borderRadius: 10,
-                backgroundColor: colors.success + '22',
-              }}
-            >
-              <Ionicons
-                name="checkmark-circle"
-                size={12}
-                color={colors.success}
-              />
-              <Text
-                style={{
-                  fontSize: 11,
-                  fontWeight: '600',
-                  color: colors.success,
-                }}
-              >
-                {t('library.row.finished')}
-              </Text>
-            </View>
-          ) : null}
-
+        <View style={{ paddingTop: 8 }}>
           <Ionicons
             name="chevron-forward"
-            size={16}
+            size={22}
             color={colors.textSecondary}
             accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"

--- a/apps/mobile/src/hooks/use-homework-ocr.test.ts
+++ b/apps/mobile/src/hooks/use-homework-ocr.test.ts
@@ -6,6 +6,18 @@ const mockFetch = jest.fn();
 const mockTrackHomeworkOcrGateAccepted = jest.fn();
 const mockTrackHomeworkOcrGateRejected = jest.fn();
 const mockTrackHomeworkOcrGateShortcircuit = jest.fn();
+const formDataGlobal = global as typeof globalThis & {
+  FormData: typeof FormData;
+};
+const originalFormData = formDataGlobal.FormData;
+
+class MockFormData {
+  private readonly parts: Array<[string, unknown]> = [];
+
+  append(name: string, value: unknown) {
+    this.parts.push([name, value]);
+  }
+}
 
 jest.mock('@clerk/clerk-expo', () => ({
   useAuth: () => ({
@@ -61,7 +73,12 @@ beforeEach(() => {
   mockRecognize.mockReset();
   mockManipulateAsync.mockReset();
   mockManipulateAsync.mockResolvedValue({ uri: 'file:///cache/resized.jpg' });
+  formDataGlobal.FormData = MockFormData as unknown as typeof FormData;
   global.fetch = mockFetch as typeof fetch;
+});
+
+afterAll(() => {
+  formDataGlobal.FormData = originalFormData;
 });
 
 describe('useHomeworkOcr', () => {

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -857,6 +857,11 @@
     "subtitleGuardianNoTopics": "Deine persönliche Bibliothek · {{subjectCount}} Fächer",
     "statusPaused": "Pausiert",
     "statusArchived": "Archiviert",
+    "sections": {
+      "active": "Aktive Regale",
+      "paused": "Pausierte Regale",
+      "archived": "Archivierte Regale"
+    },
     "loadTimeout": {
       "title": "Bibliothek lädt zu lange",
       "message": "Überprüfe deine Verbindung und versuche es erneut."
@@ -1576,7 +1581,8 @@
       "staleSummary": "Die Zusammenfassung ist möglicherweise noch nicht auf dem neuesten Stand.",
       "nudgeCta": "Ein Anstupser könnte {{name}} helfen, neu zu starten.",
       "nudgeA11y": "{{name}} einen Anstupser senden",
-      "viewAllReports": "Alle Berichte ansehen"
+      "viewAllReports": "Alle Berichte ansehen",
+      "subjectsTitle": "Fächer"
     }
   },
   "onboarding": {

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -927,6 +927,11 @@
     "subtitleGuardianNoTopics": "Your personal library · {{subjectCount}} subjects",
     "statusPaused": "Paused",
     "statusArchived": "Archived",
+    "sections": {
+      "active": "Active shelves",
+      "paused": "Paused shelves",
+      "archived": "Archived shelves"
+    },
     "loadTimeout": {
       "title": "Library is taking too long to load",
       "message": "Check your connection and try again."
@@ -1405,7 +1410,8 @@
       "staleSummary": "Summary may not reflect the latest activity yet.",
       "nudgeCta": "A short nudge might help {{name}} restart",
       "nudgeA11y": "Send {{name}} a nudge",
-      "viewAllReports": "View all reports"
+      "viewAllReports": "View all reports",
+      "subjectsTitle": "Subjects"
     },
     "weeklyReport": {
       "thisWeekSoFar": "This week so far",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -857,6 +857,11 @@
     "subtitleGuardianNoTopics": "Tu biblioteca personal · {{subjectCount}} materias",
     "statusPaused": "En pausa",
     "statusArchived": "Archivado",
+    "sections": {
+      "active": "Estantes activos",
+      "paused": "Estantes en pausa",
+      "archived": "Estantes archivados"
+    },
     "loadTimeout": {
       "title": "La biblioteca está tardando demasiado en cargar",
       "message": "Revisa tu conexión e inténtalo de nuevo."
@@ -1576,7 +1581,8 @@
       "staleSummary": "Puede que el resumen aún no refleje la actividad más reciente.",
       "nudgeCta": "Un recordatorio podría ayudar a {{name}} a retomar.",
       "nudgeA11y": "Enviar un recordatorio a {{name}}",
-      "viewAllReports": "Ver todos los informes"
+      "viewAllReports": "Ver todos los informes",
+      "subjectsTitle": "Materias"
     }
   },
   "onboarding": {

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -857,6 +857,11 @@
     "subtitleGuardianNoTopics": "あなたの個人ライブラリ・{{subjectCount}}科目",
     "statusPaused": "一時停止中",
     "statusArchived": "アーカイブ済み",
+    "sections": {
+      "active": "学習中の棚",
+      "paused": "一時停止中の棚",
+      "archived": "アーカイブ済みの棚"
+    },
     "loadTimeout": {
       "title": "ライブラリの読み込みに時間がかかりすぎています",
       "message": "接続を確認して、もう一度お試しください。"
@@ -1576,7 +1581,8 @@
       "staleSummary": "概要には、最新のアクティビティがまだ反映されていない場合があります。",
       "nudgeCta": "{{name}}さんにリマインダーを送って再開を促しましょう。",
       "nudgeA11y": "{{name}}さんにリマインダーを送信",
-      "viewAllReports": "すべてのレポートを表示"
+      "viewAllReports": "すべてのレポートを表示",
+      "subjectsTitle": "科目"
     }
   },
   "onboarding": {

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -857,6 +857,11 @@
     "subtitleGuardianNoTopics": "Ditt personlige bibliotek · {{subjectCount}} emner",
     "statusPaused": "Pauset",
     "statusArchived": "Arkivert",
+    "sections": {
+      "active": "Aktive hyller",
+      "paused": "Pausede hyller",
+      "archived": "Arkiverte hyller"
+    },
     "loadTimeout": {
       "title": "Biblioteket tar for lang tid å laste",
       "message": "Sjekk tilkoblingen din og prøv igjen."
@@ -1576,7 +1581,8 @@
       "staleSummary": "Oppsummeringen gjenspeiler kanskje ikke den siste aktiviteten ennå.",
       "nudgeCta": "Et lite dytt kan hjelpe {{name}} i gang igjen",
       "nudgeA11y": "Send {{name}} et dytt",
-      "viewAllReports": "Se alle rapporter"
+      "viewAllReports": "Se alle rapporter",
+      "subjectsTitle": "Emner"
     }
   },
   "onboarding": {

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -882,6 +882,11 @@
     "subtitleGuardianNoTopics": "Twoja osobista biblioteka · {{subjectCount}} przedmiotów",
     "statusPaused": "Wstrzymany",
     "statusArchived": "Zarchiwizowany",
+    "sections": {
+      "active": "Aktywne półki",
+      "paused": "Wstrzymane półki",
+      "archived": "Zarchiwizowane półki"
+    },
     "loadTimeout": {
       "title": "Ładowanie biblioteki trwa zbyt długo",
       "message": "Sprawdź połączenie i spróbuj ponownie."
@@ -1601,7 +1606,8 @@
       "staleSummary": "Podsumowanie może nie uwzględniać ostatniej aktywności.",
       "nudgeCta": "Krótka zachęta może pomóc {{name}} wrócić do nauki.",
       "nudgeA11y": "Wyślij {{name}} zachętę",
-      "viewAllReports": "Zobacz wszystkie raporty"
+      "viewAllReports": "Zobacz wszystkie raporty",
+      "subjectsTitle": "Przedmioty"
     }
   },
   "onboarding": {

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -882,6 +882,11 @@
     "subtitleGuardianNoTopics": "Sua biblioteca pessoal · {{subjectCount}} matérias",
     "statusPaused": "Pausado",
     "statusArchived": "Arquivado",
+    "sections": {
+      "active": "Prateleiras ativas",
+      "paused": "Prateleiras pausadas",
+      "archived": "Prateleiras arquivadas"
+    },
     "loadTimeout": {
       "title": "A biblioteca está demorando muito para carregar",
       "message": "Verifique sua conexão e tente novamente."
@@ -1601,7 +1606,8 @@
       "staleSummary": "O resumo pode ainda não refletir a atividade mais recente.",
       "nudgeCta": "Um pequeno incentivo pode ajudar {{name}} a recomeçar",
       "nudgeA11y": "Enviar um incentivo para {{name}}",
-      "viewAllReports": "Ver todos os relatórios"
+      "viewAllReports": "Ver todos os relatórios",
+      "subjectsTitle": "Matérias"
     }
   },
   "onboarding": {

--- a/apps/mobile/src/lib/subject-tints.test.ts
+++ b/apps/mobile/src/lib/subject-tints.test.ts
@@ -1,4 +1,8 @@
-import { getSubjectTint, SUBJECT_TINT_PALETTE } from './subject-tints';
+import {
+  getSubjectTint,
+  getSubjectTintMap,
+  SUBJECT_TINT_PALETTE,
+} from './subject-tints';
 
 describe('getSubjectTint', () => {
   it('keeps the subject palette limited to five colors per scheme', () => {
@@ -37,5 +41,29 @@ describe('getSubjectTint', () => {
     const tints = ids.map((id) => getSubjectTint(id, 'dark'));
     const uniqueSolids = new Set(tints.map((t) => t.solid));
     expect(uniqueSolids.size).toBeGreaterThanOrEqual(4);
+  });
+
+  it('keeps a single subject on its stable hash tint', () => {
+    const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    expect(getSubjectTintMap([id], 'light').get(id)).toEqual(
+      getSubjectTint(id, 'light'),
+    );
+  });
+
+  it('nudges adjacent subjects away from the same palette color', () => {
+    const idsByTint = new Map<string, string[]>();
+    for (let index = 0; index < 50; index += 1) {
+      const id = `subject-${index}`;
+      const tint = getSubjectTint(id, 'light');
+      idsByTint.set(tint.solid, [...(idsByTint.get(tint.solid) ?? []), id]);
+    }
+    const collision = [...idsByTint.values()].find((ids) => ids.length >= 2);
+    expect(collision).toBeDefined();
+
+    const first = collision![0]!;
+    const second = collision![1]!;
+    const tintMap = getSubjectTintMap([first, second], 'light');
+
+    expect(tintMap.get(first)?.solid).not.toBe(tintMap.get(second)?.solid);
   });
 });

--- a/apps/mobile/src/lib/subject-tints.ts
+++ b/apps/mobile/src/lib/subject-tints.ts
@@ -6,17 +6,45 @@ import {
 
 export { SUBJECT_TINT_PALETTE };
 
-export function getSubjectTint(
-  subjectId: string,
-  colorScheme: ColorScheme,
-): SubjectTint {
-  const palette = SUBJECT_TINT_PALETTE[colorScheme];
+function getSubjectTintIndex(subjectId: string, paletteLength: number): number {
   const hex = subjectId.replace(/-/g, '');
   let hash = 0x811c9dc5; // FNV offset basis
   for (let i = 0; i < hex.length; i++) {
     hash ^= hex.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193); // FNV prime
   }
-  const index = (hash >>> 0) % palette.length;
+  return (hash >>> 0) % paletteLength;
+}
+
+export function getSubjectTint(
+  subjectId: string,
+  colorScheme: ColorScheme,
+): SubjectTint {
+  const palette = SUBJECT_TINT_PALETTE[colorScheme];
+  const index = getSubjectTintIndex(subjectId, palette.length);
   return palette[index] ?? palette[0];
+}
+
+export function getSubjectTintMap(
+  subjectIds: readonly string[],
+  colorScheme: ColorScheme,
+): Map<string, SubjectTint> {
+  const palette = SUBJECT_TINT_PALETTE[colorScheme];
+  const map = new Map<string, SubjectTint>();
+  let previousIndex = -1;
+
+  for (const subjectId of subjectIds) {
+    if (map.has(subjectId)) continue;
+
+    const preferredIndex = getSubjectTintIndex(subjectId, palette.length);
+    let index = preferredIndex;
+    if (index === previousIndex && palette.length > 1) {
+      index = (preferredIndex + 1) % palette.length;
+    }
+
+    map.set(subjectId, palette[index] ?? palette[0]);
+    previousIndex = index;
+  }
+
+  return map;
 }


### PR DESCRIPTION
## Summary
- Align Library subject rows with the Progress shelf-card layout and grouped shelf sections.
- Add stable subject tint assignment shared across Home, Library, and Progress, avoiding adjacent duplicate colors where possible.
- Move the Progress report CTA above long subject lists, compact large Progress subject lists, and tint Home subject cards consistently.
- Stabilize the OCR hook test's FormData mock so the full mobile test receipt can run reliably.

## Validation
- pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json
- pnpm exec jest --config apps/mobile/jest.config.cjs --testMatch "**/apps/mobile/src/app/**/library.test.tsx" "**/apps/mobile/src/app/**/progress.test.tsx" "**/apps/mobile/src/components/home/LearnerScreen.test.tsx" "**/apps/mobile/src/lib/subject-tints.test.ts" "**/apps/mobile/src/components/home/SubjectTile.test.tsx" "**/apps/mobile/src/components/library/ShelfRow.test.tsx" "**/apps/mobile/src/components/library/LibrarySearchResults.test.tsx" --no-coverage --runInBand --forceExit
- pnpm exec jest --config apps/mobile/jest.config.cjs apps/mobile/src/app/uppercase.test.ts apps/mobile/src/hooks/use-homework-ocr.test.ts --no-coverage --runInBand
- pnpm check:i18n
- bash scripts/record-test-receipt.sh mobile
- pre-commit hook: tsc --build and related Jest tests passed