### PR TITLE
fix(api): protect visible question quota

### DIFF
--- a/.claude/memory/pricing_dual_cap.md
+++ b/.claude/memory/pricing_dual_cap.md
@@ -26,3 +26,5 @@ Free tier uses a **dual-cap model: 10 questions/day AND 100 questions/month** (c
 - Response headers: `X-Quota-Remaining` (only set when dailyLimit is non-null)
 - Integration test seed accounts use Plus tier (700) — expect `X-Quota-Remaining: '699'` after 1 message
 - This is A/B testable — numbers can change without architectural changes
+- Product invariant (2026-05-15): quota must count visible learner/user questions or deliberate user-triggered AI actions only. Do not burn quota for invisible reports, book/topic generation, summaries, telemetry, or automatic prefetch/background work. If an internal LLM task needs cost protection, add separate abuse/rate limiting instead of consuming the learner's visible-question pool.
+- Parent-proxy invariant (2026-05-15): when a parent is viewing a child profile, metered LLM routes must reject before subscription lookup or quota decrement. A blocked proxy action must not consume the child's or family's visible-question pool.

--- a/apps/api/src/middleware/metering.test.ts
+++ b/apps/api/src/middleware/metering.test.ts
@@ -449,6 +449,30 @@ describe('metering middleware', () => {
       expect(mockDecrementQuota).not.toHaveBeenCalled();
     });
 
+    it('rejects unresolved profile-only LLM routes before quota lookup/decrement', async () => {
+      const { findOwnerProfile } = jest.requireMock('../services/profile') as {
+        findOwnerProfile: jest.Mock;
+      };
+      findOwnerProfile.mockResolvedValueOnce(null);
+
+      const res = await app.request(
+        '/v1/dictation/prepare-homework',
+        {
+          method: 'POST',
+          headers: makeAuthHeaders(),
+          body: JSON.stringify({ text: 'Hello world.' }),
+        },
+        TEST_ENV,
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('VALIDATION_ERROR');
+      expect(mockEnsureFreeSubscription).not.toHaveBeenCalled();
+      expect(mockGetQuotaPool).not.toHaveBeenCalled();
+      expect(mockDecrementQuota).not.toHaveBeenCalled();
+    });
+
     it('rejects non-owner child-profile LLM requests before quota lookup/decrement', async () => {
       const { getProfile } = jest.requireMock('../services/profile') as {
         getProfile: jest.Mock;

--- a/apps/api/src/middleware/metering.test.ts
+++ b/apps/api/src/middleware/metering.test.ts
@@ -152,6 +152,7 @@ jest.mock('../services/subject' /* gc1-allow: pattern-a conversion */, () => {
 const mockEnsureFreeSubscription = jest.fn();
 const mockGetQuotaPool = jest.fn();
 const mockDecrementQuota = jest.fn();
+const mockSafeRefundQuota = jest.fn();
 const mockGetTopUpCreditsRemaining = jest.fn().mockResolvedValue(0);
 
 jest.mock('../services/billing' /* gc1-allow: pattern-a conversion */, () => {
@@ -164,6 +165,7 @@ jest.mock('../services/billing' /* gc1-allow: pattern-a conversion */, () => {
       mockEnsureFreeSubscription(...args),
     getQuotaPool: (...args: unknown[]) => mockGetQuotaPool(...args),
     decrementQuota: (...args: unknown[]) => mockDecrementQuota(...args),
+    safeRefundQuota: (...args: unknown[]) => mockSafeRefundQuota(...args),
     getTopUpCreditsRemaining: (...args: unknown[]) =>
       mockGetTopUpCreditsRemaining(...args),
     createSubscription: jest.fn(),
@@ -297,6 +299,7 @@ beforeEach(() => {
     remainingTopUp: 0,
     remainingDaily: null,
   });
+  mockSafeRefundQuota.mockResolvedValue({ refunded: true });
   mockGetTopUpCreditsRemaining.mockResolvedValue(0);
 });
 
@@ -329,6 +332,54 @@ describe('metering middleware', () => {
 
       expect(mockDecrementQuota).not.toHaveBeenCalled();
     });
+
+    it.each([
+      [
+        'book suggestion generation/read surface',
+        'GET',
+        '/v1/subjects/00000000-0000-4000-8000-000000000101/book-suggestions',
+        undefined,
+      ],
+      [
+        'manual book topic generation',
+        'POST',
+        '/v1/subjects/00000000-0000-4000-8000-000000000101/books/00000000-0000-4000-8000-000000000102/generate-topics',
+        { priorKnowledge: 'some' },
+      ],
+      [
+        'learner monthly reports list',
+        'GET',
+        '/v1/progress/reports',
+        undefined,
+      ],
+      [
+        'parent progress summary read',
+        'GET',
+        '/v1/dashboard/children/00000000-0000-4000-8000-000000000103/progress-summary',
+        undefined,
+      ],
+    ])(
+      'does not burn visible-question quota for %s',
+      async (_label, method, path, body) => {
+        const res = await app.request(
+          path,
+          {
+            method,
+            headers: AUTH_HEADERS,
+            body: body === undefined ? undefined : JSON.stringify(body),
+          },
+          TEST_ENV,
+        );
+
+        expect(mockDecrementQuota).not.toHaveBeenCalled();
+        expect(mockEnsureFreeSubscription).not.toHaveBeenCalled();
+        // The route may still reject because its own fixtures are not seeded;
+        // this test is only the metering boundary guard.
+        expect(
+          [200, 400, 401, 403, 404, 405, 409, 500].includes(res.status),
+        ).toBe(true);
+      },
+    );
 
     // [BUG-763] GET /v1/quiz/* is DB-only and must not decrement quota.
     // Before fix: classifier did `LLM_ROUTE_PATTERNS.filter(p => !p.source.includes('quiz'))`
@@ -379,6 +430,120 @@ describe('metering middleware', () => {
   // -----------------------------------------------------------------------
 
   describe('LLM routes with quota available', () => {
+    it('rejects parent-proxy LLM requests before quota lookup/decrement', async () => {
+      const res = await app.request(
+        '/v1/sessions/session-1/messages',
+        {
+          method: 'POST',
+          headers: { ...AUTH_HEADERS, 'X-Proxy-Mode': 'true' },
+          body: JSON.stringify({ message: 'hello' }),
+        },
+        TEST_ENV,
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe('PROXY_MODE');
+      expect(mockEnsureFreeSubscription).not.toHaveBeenCalled();
+      expect(mockGetQuotaPool).not.toHaveBeenCalled();
+      expect(mockDecrementQuota).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-owner child-profile LLM requests before quota lookup/decrement', async () => {
+      const { getProfile } = jest.requireMock('../services/profile') as {
+        getProfile: jest.Mock;
+      };
+      getProfile.mockResolvedValueOnce({
+        id: 'child-profile-id',
+        birthYear: 2012,
+        location: 'EU',
+        consentStatus: 'CONSENTED',
+        hasPremiumLlm: false,
+        conversationLanguage: null,
+        isOwner: false,
+      });
+
+      const res = await app.request(
+        '/v1/sessions/session-1/messages',
+        {
+          method: 'POST',
+          headers: { ...AUTH_HEADERS, 'X-Profile-Id': 'child-profile-id' },
+          body: JSON.stringify({ message: 'hello' }),
+        },
+        TEST_ENV,
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe('PROXY_MODE');
+      expect(mockEnsureFreeSubscription).not.toHaveBeenCalled();
+      expect(mockGetQuotaPool).not.toHaveBeenCalled();
+      expect(mockDecrementQuota).not.toHaveBeenCalled();
+    });
+
+    it('returns idempotency replays before quota lookup/decrement', async () => {
+      fakeKV.store.set('idem:test-profile-id:session:retry-key', '1');
+
+      const res = await app.request(
+        '/v1/sessions/session-1/messages',
+        {
+          method: 'POST',
+          headers: { ...AUTH_HEADERS, 'Idempotency-Key': 'retry-key' },
+          body: JSON.stringify({ message: 'hello' }),
+        },
+        { ...TEST_ENV, IDEMPOTENCY_KV: fakeKV.namespace },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Idempotency-Replay')).toBe('true');
+      const body = await res.json();
+      expect(body).toMatchObject({
+        replayed: true,
+        clientId: 'retry-key',
+        status: 'persisted',
+      });
+      expect(mockEnsureFreeSubscription).not.toHaveBeenCalled();
+      expect(mockGetQuotaPool).not.toHaveBeenCalled();
+      expect(mockDecrementQuota).not.toHaveBeenCalled();
+    });
+
+    it('refunds quota when a metered route rejects before producing an answer', async () => {
+      mockEnsureFreeSubscription.mockResolvedValue(mockSubscription());
+      mockGetQuotaPool.mockResolvedValue(mockQuota({ usedThisMonth: 100 }));
+      mockDecrementQuota.mockResolvedValue({
+        success: true,
+        source: 'monthly',
+        remainingMonthly: 399,
+        remainingTopUp: 0,
+        remainingDaily: null,
+      });
+
+      const res = await app.request(
+        '/v1/sessions/session-1/messages',
+        {
+          method: 'POST',
+          headers: AUTH_HEADERS,
+          body: JSON.stringify({}),
+        },
+        TEST_ENV,
+      );
+
+      expect(res.status).toBe(400);
+      expect(mockDecrementQuota).toHaveBeenCalledWith(
+        expect.anything(),
+        'sub-1',
+        'test-profile-id',
+      );
+      expect(mockSafeRefundQuota).toHaveBeenCalledWith(
+        expect.anything(),
+        'sub-1',
+        expect.objectContaining({
+          route: 'metering.POST./v1/sessions/session-1/messages',
+          profileId: 'test-profile-id',
+        }),
+      );
+    });
+
     it('[BUG-623 / A-6] decrements quota for POST /sessions/:id/recall-bridge', async () => {
       mockEnsureFreeSubscription.mockResolvedValue(mockSubscription());
       mockGetQuotaPool.mockResolvedValue(mockQuota({ usedThisMonth: 100 }));

--- a/apps/api/src/middleware/metering.ts
+++ b/apps/api/src/middleware/metering.ts
@@ -15,20 +15,28 @@
 // ---------------------------------------------------------------------------
 
 import { createMiddleware } from 'hono/factory';
+import type { Context } from 'hono';
 import type { Database } from '@eduagent/database';
 import { ERROR_CODES } from '@eduagent/schemas';
 import type { SubscriptionTier, SubscriptionStatus } from '@eduagent/schemas';
 import type { Account } from '../services/account';
 import type { LLMTier } from '../services/subscription';
 import type { ProfileMeta } from './profile-scope';
+import { assertNotProxyMode } from './proxy-guard';
 import {
   ensureFreeSubscription,
   getQuotaPool,
   decrementQuota,
   getTopUpCreditsRemaining,
+  safeRefundQuota,
 } from '../services/billing';
 import { getTierConfig } from '../services/subscription';
 import { checkQuota } from '../services/metering';
+import {
+  buildIdempotencyCacheKey,
+  MAX_IDEMPOTENCY_KEY_LENGTH,
+} from '../services/idempotency-marker';
+import { lookupAssistantTurnState } from '../services/idempotency-assistant-state';
 import {
   readSubscriptionStatus,
   writeSubscriptionStatus,
@@ -43,7 +51,7 @@ const logger = createLogger();
 // ---------------------------------------------------------------------------
 
 export type MeteringEnv = {
-  Bindings: { SUBSCRIPTION_KV?: KVNamespace };
+  Bindings: { SUBSCRIPTION_KV?: KVNamespace; IDEMPOTENCY_KV?: KVNamespace };
   Variables: {
     db: Database;
     account: Account;
@@ -97,6 +105,11 @@ const LLM_ROUTE_PATTERNS_POST_ONLY = [
   /\/sessions\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/retry-filing\/?$/,
 ];
 
+const IDEMPOTENT_SESSION_ROUTE_PATTERNS = [
+  /\/sessions\/[^/]+\/messages\/?$/,
+  /\/sessions\/[^/]+\/stream\/?$/,
+];
+
 function isLlmRoute(path: string, method: string): boolean {
   // GET methods never decrement quota for POST-only endpoints. The any-method
   // list is what bills GET requests (SSE streams, recall-bridge, etc.).
@@ -107,6 +120,72 @@ function isLlmRoute(path: string, method: string): boolean {
     LLM_ROUTE_PATTERNS_ANY_METHOD.some((pattern) => pattern.test(path)) ||
     LLM_ROUTE_PATTERNS_POST_ONLY.some((pattern) => pattern.test(path))
   );
+}
+
+function isIdempotentSessionRoute(path: string): boolean {
+  return IDEMPOTENT_SESSION_ROUTE_PATTERNS.some((pattern) =>
+    pattern.test(path),
+  );
+}
+
+function shouldRefundAfterHandler(status: number): boolean {
+  return status >= 400;
+}
+
+async function maybeReplayIdempotentSessionRequest(
+  c: Context<MeteringEnv>,
+  db: Database,
+  profileId: string | undefined,
+): Promise<Response | null> {
+  if (!isIdempotentSessionRoute(c.req.path)) return null;
+
+  const key = c.req.header('Idempotency-Key')?.trim();
+  if (!key) return null;
+
+  if (key.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+    return c.json(
+      {
+        code: ERROR_CODES.INVALID_IDEMPOTENCY_KEY,
+        message: `Idempotency-Key exceeds ${MAX_IDEMPOTENCY_KEY_LENGTH} characters`,
+      },
+      400,
+    );
+  }
+
+  if (!profileId) return null;
+
+  const kv = c.env?.IDEMPOTENCY_KV;
+  if (!kv) return null;
+
+  let existing: string | null = null;
+  try {
+    existing = await kv.get(buildIdempotencyCacheKey(profileId, 'session', key));
+  } catch (error) {
+    logger.warn('[metering] Idempotency replay lookup failed', {
+      event: 'metering.idempotency_replay_lookup_failed',
+      profileId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+
+  if (!existing) return null;
+
+  const state = await lookupAssistantTurnState({
+    db,
+    profileId,
+    flow: 'session',
+    key,
+  });
+
+  c.header('Idempotency-Replay', 'true');
+  return c.json({
+    replayed: true,
+    clientId: key,
+    status: 'persisted',
+    assistantTurnReady: state.assistantTurnReady,
+    latestExchangeId: state.latestExchangeId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -199,6 +278,20 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
     const db = c.get('db');
     const kv = c.env?.SUBSCRIPTION_KV;
     const freeTier = getTierConfig('free');
+    const profileMeta = c.get('profileMeta');
+    const profileId = c.get('profileId');
+
+    // Metering runs before route handlers. Run the proxy guard here too so a
+    // parent viewing a child profile cannot burn quota on a request that the
+    // endpoint would later reject.
+    assertNotProxyMode(c);
+
+    const idempotentReplay = await maybeReplayIdempotentSessionRequest(
+      c,
+      db,
+      profileId,
+    );
+    if (idempotentReplay) return idempotentReplay;
 
     // 1. Try KV cache for fast quota check (I4: wrapped in try/catch)
     let cached: CachedSubscriptionStatus | null = null;
@@ -303,8 +396,6 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
     }
 
     // 4. Attempt to decrement quota (atomic, handles top-up FIFO fallback + daily guard)
-    const profileMeta = c.get('profileMeta');
-    const profileId = c.get('profileId');
     const decrement = await decrementQuota(db, subscriptionId, profileId);
 
     if (!decrement.success) {
@@ -339,6 +430,23 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
     const baseLlmTier = getTierConfig(tier).llmTier;
     c.set('llmTier', profileMeta?.hasPremiumLlm ? 'premium' : baseLlmTier);
 
+    // Set quota headers for client-side UI
+    const remaining = decrement.remainingMonthly + decrement.remainingTopUp;
+    c.header('X-Quota-Remaining', String(remaining));
+    c.header('X-Quota-Warning-Level', result.warningLevel);
+    if (decrement.remainingDaily !== null) {
+      c.header('X-Daily-Remaining', String(decrement.remainingDaily));
+    }
+
+    await next();
+    if (shouldRefundAfterHandler(c.res.status)) {
+      await safeRefundQuota(db, subscriptionId, {
+        route: `metering.${c.req.method}.${c.req.path}`,
+        profileId,
+      });
+      return;
+    }
+
     // I7 fix: Update KV cache after decrement so next request sees fresh count.
     // Derive from the atomic DB result (decrement.remainingMonthly/Daily) to
     // avoid stale-read races under concurrency — two requests reading the same
@@ -365,16 +473,6 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
         usedToday: atomicUsedToday,
       });
     }
-
-    // Set quota headers for client-side UI
-    const remaining = decrement.remainingMonthly + decrement.remainingTopUp;
-    c.header('X-Quota-Remaining', String(remaining));
-    c.header('X-Quota-Warning-Level', result.warningLevel);
-    if (decrement.remainingDaily !== null) {
-      c.header('X-Daily-Remaining', String(decrement.remainingDaily));
-    }
-
-    await next();
     return;
   },
 );

--- a/apps/api/src/middleware/metering.ts
+++ b/apps/api/src/middleware/metering.ts
@@ -105,6 +105,11 @@ const LLM_ROUTE_PATTERNS_POST_ONLY = [
   /\/sessions\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/retry-filing\/?$/,
 ];
 
+const PROFILE_REQUIRED_BEFORE_METERING_PATTERNS = [
+  /\/dictation\/prepare-homework\/?$/,
+  /\/dictation\/review\/?$/,
+];
+
 const IDEMPOTENT_SESSION_ROUTE_PATTERNS = [
   /\/sessions\/[^/]+\/messages\/?$/,
   /\/sessions\/[^/]+\/stream\/?$/,
@@ -122,9 +127,25 @@ function isLlmRoute(path: string, method: string): boolean {
   );
 }
 
+function shouldReturnProfileRequiredBeforeMetering(path: string): boolean {
+  return PROFILE_REQUIRED_BEFORE_METERING_PATTERNS.some((pattern) =>
+    pattern.test(path),
+  );
+}
+
 function isIdempotentSessionRoute(path: string): boolean {
   return IDEMPOTENT_SESSION_ROUTE_PATTERNS.some((pattern) =>
     pattern.test(path),
+  );
+}
+
+function profileRequiredResponse(c: Context<MeteringEnv>): Response {
+  return c.json(
+    {
+      code: ERROR_CODES.VALIDATION_ERROR,
+      message: 'Profile required — no profile resolved for this request',
+    },
+    400,
   );
 }
 
@@ -280,11 +301,24 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
     const freeTier = getTierConfig('free');
     const profileMeta = c.get('profileMeta');
     const profileId = c.get('profileId');
+    const proxyModeHeader = c.req.header('X-Proxy-Mode') === 'true';
+
+    if (
+      (!profileId || !profileMeta) &&
+      !proxyModeHeader &&
+      shouldReturnProfileRequiredBeforeMetering(c.req.path)
+    ) {
+      return profileRequiredResponse(c);
+    }
 
     // Metering runs before route handlers. Run the proxy guard here too so a
     // parent viewing a child profile cannot burn quota on a request that the
     // endpoint would later reject.
     assertNotProxyMode(c);
+
+    if (!profileId) {
+      return profileRequiredResponse(c);
+    }
 
     const idempotentReplay = await maybeReplayIdempotentSessionRequest(
       c,

--- a/apps/mobile/src/app/(app)/quiz/play.test.tsx
+++ b/apps/mobile/src/app/(app)/quiz/play.test.tsx
@@ -209,6 +209,15 @@ describe('QuizPlayScreen', () => {
     });
   });
 
+  it('does not auto-prefetch another round while the learner is playing', async () => {
+    render(<QuizPlayScreen />);
+
+    await waitFor(() => {
+      expect(mockPrefetchMutate).not.toHaveBeenCalled();
+      expect(mockSetPrefetchedRoundId).not.toHaveBeenCalled();
+    });
+  });
+
   // [BUG-928] Path 7 spec: "Question header: '1 of 7' + dot indicators +
   // elapsed seconds". The previous F-Q-13 implementation hid the timer for
   // anxiety, but this is a count-UP timer so motivation > anxiety.

--- a/apps/mobile/src/app/(app)/quiz/play.tsx
+++ b/apps/mobile/src/app/(app)/quiz/play.tsx
@@ -23,11 +23,7 @@ import type {
   CompleteRoundResponse,
   QuestionResult,
 } from '@eduagent/schemas';
-import {
-  useCheckAnswer,
-  useCompleteRound,
-  usePrefetchRound,
-} from '../../../hooks/use-quiz';
+import { useCheckAnswer, useCompleteRound } from '../../../hooks/use-quiz';
 import { PolarStar } from '../../../components/common';
 import { platformAlert } from '../../../lib/platform-alert';
 // platformAlert maps to window.confirm on web for 2-button prompts, which
@@ -67,7 +63,6 @@ export default function QuizPlayScreen(): React.ReactElement {
     round,
     activityType,
     returnTo,
-    subjectId,
     setPrefetchedRoundId,
     setRound,
     setCompletionResult,
@@ -75,13 +70,6 @@ export default function QuizPlayScreen(): React.ReactElement {
   const exitHref = returnTo === 'practice' ? '/(app)/practice' : '/(app)/quiz';
   const completeRound = useCompleteRound();
   const completeRoundMutate = completeRound.mutate;
-  const prefetchRound = usePrefetchRound();
-  // [BUG-542] Extract .mutate so the useEffect dep array references a stable
-  // variable rather than a member-access expression. ESLint exhaustive-deps
-  // treats `prefetchRound.mutate` in a dep array as an undeclared dep on
-  // `prefetchRound` (the whole object), which is recreated each render. The
-  // extracted local is still the stable TanStack Query .mutate ref.
-  const prefetchRoundMutate = prefetchRound.mutate;
   const checkAnswer = useCheckAnswer();
   // [ASSUMP-F10] When completeRound fails we surface an inline retry UI
   // instead of silently fabricating a 0-XP "nice" result and navigating.
@@ -126,7 +114,6 @@ export default function QuizPlayScreen(): React.ReactElement {
   const questionStartTimeRef = useRef(Date.now());
   const resultsRef = useRef<QuestionResult[]>([]);
   const continueEnabledAtRef = useRef(0);
-  const prefetchTriggeredRef = useRef(false);
   const continueHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -188,34 +175,6 @@ export default function QuizPlayScreen(): React.ReactElement {
 
     return () => clearInterval(interval);
   }, [currentIndex, currentQuestion]);
-
-  useEffect(() => {
-    if (
-      prefetchTriggeredRef.current ||
-      !activityType ||
-      totalQuestions === 0 ||
-      currentIndex < Math.floor(totalQuestions / 2)
-    ) {
-      return;
-    }
-
-    prefetchTriggeredRef.current = true;
-    prefetchRoundMutate(
-      { activityType, subjectId: subjectId ?? undefined },
-      {
-        onSuccess: (data) => setPrefetchedRoundId(data.id),
-      },
-    );
-    // [BUG-542] Use extracted .mutate local (stable ref) instead of whole
-    // mutation result or member-access expression in the dep array.
-  }, [
-    activityType,
-    currentIndex,
-    prefetchRoundMutate,
-    setPrefetchedRoundId,
-    subjectId,
-    totalQuestions,
-  ]);
 
   useEffect(() => {
     return () => {

--- a/apps/mobile/src/app/session-summary/[sessionId].test.tsx
+++ b/apps/mobile/src/app/session-summary/[sessionId].test.tsx
@@ -9,7 +9,10 @@ import {
 import React from 'react';
 import { platformAlert } from '../../lib/platform-alert';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createRoutedMockFetch } from '../../test-utils/mock-api-routes';
+import {
+  createRoutedMockFetch,
+  fetchCallsMatching,
+} from '../../test-utils/mock-api-routes';
 
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
@@ -122,14 +125,6 @@ jest.mock('../../hooks/use-rating-prompt', () => ({
   useRatingPrompt: () => ({
     onSuccessfulRecall: mockOnSuccessfulRecall,
   }),
-}));
-
-// useDepthEvaluation fires a mutation from a useEffect on mount (fire-and-forget
-// analytics). With TanStack Query's synchronous notifyManager in tests, calling
-// mutate() from within a useEffect causes React 19 to throw an invariant error
-// (sync state update from within effect commit). Keep as a no-op direct mock.
-jest.mock('../../hooks/use-depth-evaluation', () => ({
-  useDepthEvaluation: () => ({ mutate: jest.fn() }),
 }));
 
 const mockReadSummaryDraft = jest.fn();
@@ -417,6 +412,14 @@ describe('SessionSummaryScreen', () => {
     // 5 exchanges, rung 2 → "strong independent thinking"
     screen.getByText(/worked through 5 exchanges/);
     screen.getByText(/strong independent thinking/);
+  });
+
+  it('does not fire hidden depth evaluation on mount', async () => {
+    render(<SessionSummaryScreen />, { wrapper: Wrapper });
+
+    await flushAsyncEffects();
+
+    expect(fetchCallsMatching(mockFetch, 'evaluate-depth')).toHaveLength(0);
   });
 
   // [BUG-801] When the URL passes exchangeCount='0' (legitimate value for

--- a/apps/mobile/src/app/session-summary/[sessionId].tsx
+++ b/apps/mobile/src/app/session-summary/[sessionId].tsx
@@ -28,7 +28,6 @@ import {
   useRecallBridge,
 } from '../../hooks/use-sessions';
 import { useSessionBookmarks } from '../../hooks/use-bookmarks';
-import { useDepthEvaluation } from '../../hooks/use-depth-evaluation';
 import { useTotalSessionCount } from '../../hooks/use-session-context';
 import { usePostSessionNotificationAsk } from '../../hooks/use-post-session-notification-ask';
 import { goBackOrReplace, homeHrefForReturnTo } from '../../lib/navigation';
@@ -127,7 +126,6 @@ export default function SessionSummaryScreen() {
       ? computeAgeBracket(activeProfile.birthYear)
       : 'adolescent';
   const recallBridge = useRecallBridge(sessionId ?? '');
-  const depthEvaluation = useDepthEvaluation();
   const totalSessionCount = useTotalSessionCount();
   // JIT notification permission ask — fires once after the user has
   // completed at least one session (the post-value moment). Skipped in
@@ -170,20 +168,6 @@ export default function SessionSummaryScreen() {
     persisted?.status === 'submitted' || persisted?.status === 'accepted';
   const isPersistedSkipped = persisted?.status === 'skipped';
   const isAlreadyPersisted = isPersistedSubmitted || isPersistedSkipped;
-
-  // Fire depth evaluation for fresh sessions to trigger server-side telemetry
-  // (session quality gating, topic detection). Fire-and-forget — the result
-  // drives analytics, not UI. Skip for revisited/persisted sessions.
-  // Ref (not state) because the guard must be synchronous: Strict Mode and
-  // rapid rerenders can re-run this effect before a setState would flush,
-  // but the ref assignment lands immediately so the second pass short-circuits.
-  const depthFiredRef = useRef(false);
-  useEffect(() => {
-    if (sessionId && !isAlreadyPersisted && !depthFiredRef.current) {
-      depthFiredRef.current = true;
-      depthEvaluation.mutate({ sessionId });
-    }
-  }, [sessionId, isAlreadyPersisted, depthEvaluation]);
 
   useEffect(() => {
     setRecapTimedOut(false);


### PR DESCRIPTION
Summary:
- keep visible-question metering centralized and prevent proxy/idempotency/pre-answer failures from burning quota
- remove hidden mobile quota burns from quiz prefetch and session-summary depth evaluation
- record the durable visible-question quota invariant in project memory

Validation:
- git diff --check
- attempted: pnpm exec jest apps/api/src/middleware/metering.test.ts --runInBand --no-coverage (blocked locally: jest not installed in this worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic round prefetching during active quiz play
  * Removed hidden evaluation triggered on session summary screen

* **New Features**
  * Added idempotent replay support for selected routes to improve request reliability
  * Implemented quota refund mechanism for failed requests
  * Added response headers to display quota status and remaining daily limits

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/281)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->