### PR TITLE
fix(api): clear refunded quota headers

### DIFF
--- a/apps/api/src/middleware/metering.test.ts
+++ b/apps/api/src/middleware/metering.test.ts
@@ -533,13 +533,15 @@ describe('metering middleware', () => {
 
     it('refunds quota when a metered route rejects before producing an answer', async () => {
       mockEnsureFreeSubscription.mockResolvedValue(mockSubscription());
-      mockGetQuotaPool.mockResolvedValue(mockQuota({ usedThisMonth: 100 }));
+      mockGetQuotaPool.mockResolvedValue(
+        mockQuota({ usedThisMonth: 100, dailyLimit: 10, usedToday: 1 }),
+      );
       mockDecrementQuota.mockResolvedValue({
         success: true,
         source: 'monthly',
         remainingMonthly: 399,
         remainingTopUp: 0,
-        remainingDaily: null,
+        remainingDaily: 8,
       });
 
       const res = await app.request(
@@ -566,6 +568,9 @@ describe('metering middleware', () => {
           profileId: 'test-profile-id',
         }),
       );
+      expect(res.headers.get('X-Quota-Remaining')).toBeNull();
+      expect(res.headers.get('X-Quota-Warning-Level')).toBeNull();
+      expect(res.headers.get('X-Daily-Remaining')).toBeNull();
     });
 
     it('[BUG-623 / A-6] decrements quota for POST /sessions/:id/recall-bridge', async () => {

--- a/apps/api/src/middleware/metering.ts
+++ b/apps/api/src/middleware/metering.ts
@@ -154,11 +154,22 @@ function shouldRefundAfterHandler(status: number): boolean {
   return status >= 400;
 }
 
-function withoutQuotaHeaders(response: Response): Response {
+function withQuotaHeaders(
+  response: Response,
+  headersToSet: {
+    remaining: number;
+    warningLevel: string;
+    remainingDaily: number | null;
+  },
+): Response {
   const headers = new Headers(response.headers);
-  headers.delete('X-Quota-Remaining');
-  headers.delete('X-Quota-Warning-Level');
-  headers.delete('X-Daily-Remaining');
+  headers.set('X-Quota-Remaining', String(headersToSet.remaining));
+  headers.set('X-Quota-Warning-Level', headersToSet.warningLevel);
+  if (headersToSet.remainingDaily !== null) {
+    headers.set('X-Daily-Remaining', String(headersToSet.remainingDaily));
+  } else {
+    headers.delete('X-Daily-Remaining');
+  }
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -477,23 +488,20 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
     const baseLlmTier = getTierConfig(tier).llmTier;
     c.set('llmTier', profileMeta?.hasPremiumLlm ? 'premium' : baseLlmTier);
 
-    // Set quota headers for client-side UI
-    const remaining = decrement.remainingMonthly + decrement.remainingTopUp;
-    c.header('X-Quota-Remaining', String(remaining));
-    c.header('X-Quota-Warning-Level', result.warningLevel);
-    if (decrement.remainingDaily !== null) {
-      c.header('X-Daily-Remaining', String(decrement.remainingDaily));
-    }
-
     await next();
     if (shouldRefundAfterHandler(c.res.status)) {
       await safeRefundQuota(db, subscriptionId, {
         route: `metering.${c.req.method}.${c.req.path}`,
         profileId,
       });
-      c.res = withoutQuotaHeaders(c.res);
       return;
     }
+
+    c.res = withQuotaHeaders(c.res, {
+      remaining: decrement.remainingMonthly + decrement.remainingTopUp,
+      warningLevel: result.warningLevel,
+      remainingDaily: decrement.remainingDaily,
+    });
 
     // I7 fix: Update KV cache after decrement so next request sees fresh count.
     // Derive from the atomic DB result (decrement.remainingMonthly/Daily) to

--- a/apps/api/src/middleware/metering.ts
+++ b/apps/api/src/middleware/metering.ts
@@ -75,9 +75,13 @@ export type MeteringEnv = {
 
 // Routes that consume LLM exchanges on BOTH GET and POST. Currently every
 // session-scoped LLM endpoint that may be invoked via SSE/GET counts here.
-const LLM_ROUTE_PATTERNS_ANY_METHOD = [
+const SESSION_MESSAGE_STREAM_PATTERNS = [
   /\/sessions\/[^/]+\/messages\/?$/,
   /\/sessions\/[^/]+\/stream\/?$/,
+];
+
+const LLM_ROUTE_PATTERNS_ANY_METHOD = [
+  ...SESSION_MESSAGE_STREAM_PATTERNS,
   // [BUG-623 / A-6] generateRecallBridge calls the LLM but was missing from
   // this list, so any authenticated user could call recall-bridge in a tight
   // loop and burn unlimited LLM capacity at zero cost. Meter it like any
@@ -110,10 +114,7 @@ const PROFILE_REQUIRED_BEFORE_METERING_PATTERNS = [
   /\/dictation\/review\/?$/,
 ];
 
-const IDEMPOTENT_SESSION_ROUTE_PATTERNS = [
-  /\/sessions\/[^/]+\/messages\/?$/,
-  /\/sessions\/[^/]+\/stream\/?$/,
-];
+const IDEMPOTENT_SESSION_ROUTE_PATTERNS = SESSION_MESSAGE_STREAM_PATTERNS;
 
 function isLlmRoute(path: string, method: string): boolean {
   // GET methods never decrement quota for POST-only endpoints. The any-method
@@ -151,6 +152,18 @@ function profileRequiredResponse(c: Context<MeteringEnv>): Response {
 
 function shouldRefundAfterHandler(status: number): boolean {
   return status >= 400;
+}
+
+function withoutQuotaHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.delete('X-Quota-Remaining');
+  headers.delete('X-Quota-Warning-Level');
+  headers.delete('X-Daily-Remaining');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 async function maybeReplayIdempotentSessionRequest(
@@ -478,6 +491,7 @@ export const meteringMiddleware = createMiddleware<MeteringEnv>(
         route: `metering.${c.req.method}.${c.req.path}`,
         profileId,
       });
+      c.res = withoutQuotaHeaders(c.res);
       return;
     }
 


### PR DESCRIPTION
## Summary
- clear quota response headers when a metered request is refunded after a handler error
- share session message/stream route patterns between metering and idempotency replay matching
- extend the refund regression test to assert quota headers are removed

## Validation
- git diff --check
- CI pending on PR