### PR TITLE
fix(mobile): preserve library recovery paths

### DIFF
--- a/apps/mobile/src/app/(app)/library.tsx
+++ b/apps/mobile/src/app/(app)/library.tsx
@@ -708,7 +708,7 @@ export default function LibraryScreen() {
             {shelfGroups.map((group) => (
               <View key={group.status}>
                 {showShelfGroupLabels ? (
-                  <Text className="text-caption font-bold uppercase text-text-secondary mt-1 mb-2">
+                  <Text className="text-caption font-bold text-text-secondary mt-1 mb-2">
                     {t(`library.sections.${group.status}`)}
                   </Text>
                 ) : null}

--- a/apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx
+++ b/apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx
@@ -328,10 +328,35 @@ describe('PickBookScreen', () => {
     );
   });
 
-  it('shows error message and retry button on fetch error', async () => {
+  it('keeps manual entry available when suggestions fetch fails', async () => {
     mockFetch.setRoute('/book-suggestions', () =>
       Promise.resolve(
         new Response(JSON.stringify({ message: 'Failed' }), { status: 500 }),
+      ),
+    );
+
+    const { getByTestId, getByText, queryByTestId } = render(
+      <PickBookScreen />,
+      {
+        wrapper: TestWrapper,
+      },
+    );
+
+    await waitFor(() => {
+      getByTestId('pick-book-suggestions-inline-error');
+    });
+    expect(queryByTestId('pick-book-error')).toBeNull();
+    getByText('Suggestions did not load');
+    getByTestId('pick-book-inline-retry');
+    getByTestId('pick-book-custom-input');
+  });
+
+  it('keeps blocking error state for not-found suggestions errors', async () => {
+    mockFetch.setRoute('/book-suggestions', () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ message: 'Subject not found' }), {
+          status: 404,
+        }),
       ),
     );
 
@@ -342,8 +367,7 @@ describe('PickBookScreen', () => {
     await waitFor(() => {
       getByTestId('pick-book-error');
     });
-    // UX-DE-M11: recoveryActions maps retry → "Try Again" label (app-wide convention)
-    getByText('Try Again');
+    getByText('Go Back');
     getByTestId('pick-book-back-button');
   });
 

--- a/apps/mobile/src/app/(app)/pick-book/[subjectId].tsx
+++ b/apps/mobile/src/app/(app)/pick-book/[subjectId].tsx
@@ -168,18 +168,40 @@ export default function PickBookScreen(): React.ReactElement {
     ? suggestions.filter((s) => s.category === null)
     : [];
   const subject = subjects?.find((s) => s.id === subjectId);
+  const suggestionsError =
+    suggestionsQuery.isError && !suggestionsQuery.data
+      ? classifyApiError(suggestionsQuery.error)
+      : null;
+  const suggestionsErrorStatus =
+    suggestionsQuery.error &&
+    typeof suggestionsQuery.error === 'object' &&
+    'status' in suggestionsQuery.error &&
+    typeof suggestionsQuery.error.status === 'number'
+      ? suggestionsQuery.error.status
+      : undefined;
+  const suggestionsErrorBlocksManualEntry =
+    suggestionsErrorStatus === 401 ||
+    suggestionsErrorStatus === 403 ||
+    suggestionsErrorStatus === 404 ||
+    suggestionsErrorStatus === 410;
+  const canContinueWithoutSuggestions =
+    !suggestionsErrorBlocksManualEntry &&
+    (suggestionsError?.category === 'network' ||
+      suggestionsError?.category === 'server' ||
+      suggestionsError?.category === 'unknown');
 
   // BUG-318: Auto-open custom input when suggestions load empty — the user
   // shouldn't have to find and tap "Something else..." when there's nothing to pick.
   useEffect(() => {
     if (
       !suggestionsQuery.isLoading &&
-      !suggestionsQuery.isError &&
+      (canContinueWithoutSuggestions || !suggestionsQuery.isError) &&
       suggestions.length === 0
     ) {
       setShowCustomInput(true);
     }
   }, [
+    canContinueWithoutSuggestions,
     suggestionsQuery.isLoading,
     suggestionsQuery.isError,
     suggestions.length,
@@ -343,9 +365,8 @@ export default function PickBookScreen(): React.ReactElement {
   // For the two common recovery shapes we want a Retry + Go Back pair on this
   // screen, so build the actions directly rather than delegating to
   // recoveryActions (which defaults secondary to Go Home for retry cases).
-  if (suggestionsQuery.isError && !suggestionsQuery.data) {
-    const classified = classifyApiError(suggestionsQuery.error);
-    const canRetry = classified.recovery === 'retry';
+  if (suggestionsError && !canContinueWithoutSuggestions) {
+    const canRetry = suggestionsError.recovery === 'retry';
 
     return (
       <View
@@ -355,7 +376,7 @@ export default function PickBookScreen(): React.ReactElement {
       >
         <ErrorFallback
           variant="centered"
-          message={classified.message}
+          message={suggestionsError.message}
           primaryAction={
             canRetry
               ? {
@@ -419,6 +440,31 @@ export default function PickBookScreen(): React.ReactElement {
         <Text className="text-body text-text-secondary mb-6">
           Pick what interests you
         </Text>
+
+        {canContinueWithoutSuggestions ? (
+          <View
+            className="bg-surface rounded-card px-4 py-4 mb-6 border border-border"
+            testID="pick-book-suggestions-inline-error"
+          >
+            <Text className="text-body font-semibold text-text-primary mb-2">
+              Suggestions did not load
+            </Text>
+            <Text className="text-body-sm text-text-secondary mb-3">
+              You can still type the book or topic you want to add.
+            </Text>
+            <Pressable
+              onPress={() => void suggestionsQuery.refetch()}
+              className="self-start px-1 py-2 min-h-[40px] justify-center"
+              testID="pick-book-inline-retry"
+              accessibilityRole="button"
+              accessibilityLabel="Try again"
+            >
+              <Text className="text-body font-semibold text-primary">
+                Try again
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
 
         {/* Flat grid — no books yet (first visit / narrow subject) */}
         {!hasAnyBook && (
@@ -502,7 +548,7 @@ export default function PickBookScreen(): React.ReactElement {
             users (and us, in OTA-built APKs without log access) can tell
             whether suggestions are loading, cooling down, or genuinely
             failing rather than seeing one silent dead-end string. */}
-        {suggestions.length === 0 && (
+        {suggestions.length === 0 && !canContinueWithoutSuggestions && (
           <View
             className="bg-surface rounded-card px-4 py-6 items-center mb-6"
             testID="pick-book-empty"

--- a/apps/mobile/src/app/(app)/pick-book/[subjectId].tsx
+++ b/apps/mobile/src/app/(app)/pick-book/[subjectId].tsx
@@ -172,23 +172,8 @@ export default function PickBookScreen(): React.ReactElement {
     suggestionsQuery.isError && !suggestionsQuery.data
       ? classifyApiError(suggestionsQuery.error)
       : null;
-  const suggestionsErrorStatus =
-    suggestionsQuery.error &&
-    typeof suggestionsQuery.error === 'object' &&
-    'status' in suggestionsQuery.error &&
-    typeof suggestionsQuery.error.status === 'number'
-      ? suggestionsQuery.error.status
-      : undefined;
-  const suggestionsErrorBlocksManualEntry =
-    suggestionsErrorStatus === 401 ||
-    suggestionsErrorStatus === 403 ||
-    suggestionsErrorStatus === 404 ||
-    suggestionsErrorStatus === 410;
   const canContinueWithoutSuggestions =
-    !suggestionsErrorBlocksManualEntry &&
-    (suggestionsError?.category === 'network' ||
-      suggestionsError?.category === 'server' ||
-      suggestionsError?.category === 'unknown');
+    suggestionsError !== null && !suggestionsError.blocksManualEntry;
 
   // BUG-318: Auto-open custom input when suggestions load empty — the user
   // shouldn't have to find and tap "Something else..." when there's nothing to pick.

--- a/apps/mobile/src/app/(app)/progress/index.tsx
+++ b/apps/mobile/src/app/(app)/progress/index.tsx
@@ -1058,7 +1058,7 @@ export default function ProgressScreen(): React.ReactElement {
                 ) : null}
                 {inventory?.subjects?.length ? (
                   <View testID="progress-subject-breakdown" className="mt-5">
-                    <Text className="text-caption font-bold uppercase text-text-secondary mb-2">
+                    <Text className="text-caption font-bold text-text-secondary mb-2">
                       {t('progress.guardian.subjectsTitle')}
                     </Text>
                     {inventory.subjects.map((subject) => (

--- a/apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx
+++ b/apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].test.tsx
@@ -1144,6 +1144,59 @@ describe('BookScreen', () => {
     expect(retryCallCount).toBe(1);
   });
 
+  it('lets the learner set up the book after generation times out', async () => {
+    mockUseBookWithTopics.mockReturnValue(
+      makeBookQuery({
+        data: {
+          book: {
+            id: 'book-1',
+            title: 'Algebra',
+            emoji: '📐',
+            topicsGenerated: false,
+            description: 'Basic algebra',
+          },
+          topics: [],
+          completedTopicCount: 0,
+        },
+      }),
+    );
+
+    mockGenerateMutate.mockImplementationOnce(
+      (_input: unknown, callbacks: { onError: (error: Error) => void }) => {
+        callbacks.onError(new Error('initial failure'));
+      },
+    );
+
+    const { getByTestId } = render(<BookScreen />);
+
+    await waitFor(() => {
+      getByTestId('book-gen-build-path');
+    });
+
+    fireEvent.press(getByTestId('book-gen-build-path'));
+
+    await waitFor(() => {
+      expect(mockStartFirstCurriculumMutateAsync).toHaveBeenCalledWith({
+        bookId: 'book-1',
+        sessionType: 'learning',
+        inputMode: 'text',
+      });
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: '/(app)/session',
+          params: expect.objectContaining({
+            mode: 'learning',
+            subjectId: 'sub-1',
+            bookId: 'book-1',
+            sessionId: 'session-1',
+            topicId: 'topic-1',
+            subjectName: 'Algebra',
+          }),
+        }),
+      );
+    });
+  });
+
   // Back button explicitly replaces with the shelf grid (one screen up).
   // router.back() falls through to the Tabs navigator's `firstRoute` (Home)
   // when the inner stack lacks a sibling `index` — common after cross-tab

--- a/apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].tsx
+++ b/apps/mobile/src/app/(app)/shelf/[subjectId]/book/[bookId].tsx
@@ -1164,6 +1164,18 @@ export default function BookScreen() {
               </Text>
             </Pressable>
             <Pressable
+              onPress={handleBuildLearningPath}
+              disabled={startFirstCurriculumSession.isPending}
+              className="bg-surface-elevated rounded-button px-6 py-3 items-center min-h-[48px] justify-center mb-3"
+              accessibilityRole="button"
+              accessibilityLabel="Set up this book"
+              testID="book-gen-build-path"
+            >
+              <Text className="text-text-primary text-body font-semibold">
+                Set up this book
+              </Text>
+            </Pressable>
+            <Pressable
               onPress={handleBack}
               className="px-5 py-3"
               testID="book-gen-back"

--- a/apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx
+++ b/apps/mobile/src/app/(app)/shelf/[subjectId]/index.test.tsx
@@ -460,8 +460,28 @@ describe('ShelfScreen', () => {
       getByTestId('shelf-empty');
     });
     getByText('This shelf is still getting ready');
+    getByText('Pick a book to start');
+    getByTestId('shelf-empty-pick-book');
     getByTestId('shelf-empty-retry');
     getByTestId('shelf-empty-back');
+  });
+
+  it('empty state pick button opens the book picker', async () => {
+    mockFetch.setRoute('/subjects/sub-1/books', { books: [] });
+
+    const { getByTestId } = render(<ShelfScreen />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      getByTestId('shelf-empty-pick-book');
+    });
+    fireEvent.press(getByTestId('shelf-empty-pick-book'));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/(app)/pick-book/[subjectId]',
+        params: { subjectId: 'sub-1' },
+      }),
+    );
   });
 
   it('empty state retry reloads shelf data', async () => {

--- a/apps/mobile/src/app/(app)/shelf/[subjectId]/index.tsx
+++ b/apps/mobile/src/app/(app)/shelf/[subjectId]/index.tsx
@@ -422,13 +422,29 @@ export default function ShelfScreen() {
                 {t('library.shelf.emptyMessage')}
               </Text>
               <Pressable
-                onPress={handleRetry}
+                onPress={() =>
+                  router.push({
+                    pathname: '/(app)/pick-book/[subjectId]',
+                    params: { subjectId },
+                  } as Href)
+                }
                 className="bg-primary rounded-button px-6 py-3 items-center min-h-[48px] justify-center mb-3 w-full"
+                testID="shelf-empty-pick-book"
+                accessibilityRole="button"
+                accessibilityLabel={t('library.shelf.emptyPickTitle')}
+              >
+                <Text className="text-text-inverse text-body font-semibold">
+                  {t('library.shelf.emptyPickTitle')}
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={handleRetry}
+                className="bg-surface-elevated rounded-button px-6 py-3 items-center min-h-[48px] justify-center mb-3 w-full"
                 testID="shelf-empty-retry"
                 accessibilityRole="button"
                 accessibilityLabel={t('common.retry')}
               >
-                <Text className="text-text-inverse text-body font-semibold">
+                <Text className="text-text-primary text-body font-semibold">
                   {t('common.retry')}
                 </Text>
               </Pressable>

--- a/apps/mobile/src/lib/format-api-error.test.ts
+++ b/apps/mobile/src/lib/format-api-error.test.ts
@@ -87,6 +87,7 @@ describe('classifyApiError', () => {
     const result = classifyApiError(err);
     expect(result.category).toBe('network');
     expect(result.recovery).toBe('retry');
+    expect(result.blocksManualEntry).toBe(false);
     expect(result.message).toContain('offline');
   });
 
@@ -95,6 +96,7 @@ describe('classifyApiError', () => {
     const result = classifyApiError(err);
     expect(result.category).toBe('not-found');
     expect(result.recovery).toBe('go-back');
+    expect(result.blocksManualEntry).toBe(true);
   });
 
   it('classifies ResourceGoneError as not-found / go-back', () => {
@@ -166,6 +168,16 @@ describe('classifyApiError', () => {
     expect(result.recovery).toBe('go-back');
     // Applies FRIENDLY_MESSAGE_MAP translation
     expect(result.message).toContain('session');
+  });
+
+  it('classifies Error objects with status 404 as not-found / go-back', () => {
+    const err = Object.assign(new Error('Subject not found'), {
+      status: 404,
+    });
+    const result = classifyApiError(err);
+    expect(result.category).toBe('not-found');
+    expect(result.recovery).toBe('go-back');
+    expect(result.blocksManualEntry).toBe(true);
   });
 
   it('classifies API error 401 as auth / sign-out', () => {
@@ -568,6 +580,7 @@ describe('recoveryActions', () => {
     message: 'test',
     category: 'unknown',
     recovery: 'retry',
+    blocksManualEntry: false,
   };
   const retry = jest.fn();
   const goBack = jest.fn();

--- a/apps/mobile/src/lib/format-api-error.ts
+++ b/apps/mobile/src/lib/format-api-error.ts
@@ -256,11 +256,41 @@ function parseApiBody(message: string): {
  * - `category` — what kind of error it is (drives icon / heading choice in UI)
  * - `recovery` — what the user should do next (drives which action buttons to show)
  * - `message` — kid-friendly body text (reuses all FRIENDLY_MESSAGE_MAP logic)
+ * - `blocksManualEntry` — true when the current resource/profile context is
+ *   invalid enough that screens should not keep manual fallback entry open
  */
-export interface FormattedApiError {
+type ApiErrorCategory =
+  | 'network'
+  | 'not-found'
+  | 'quota'
+  | 'auth'
+  | 'server'
+  | 'unknown';
+type ApiErrorRecovery = 'retry' | 'go-back' | 'sign-out' | 'none';
+
+interface ClassifiedApiErrorCore {
   message: string;
-  category: 'network' | 'not-found' | 'quota' | 'auth' | 'server' | 'unknown';
-  recovery: 'retry' | 'go-back' | 'sign-out' | 'none';
+  category: ApiErrorCategory;
+  recovery: ApiErrorRecovery;
+}
+
+export interface FormattedApiError extends ClassifiedApiErrorCore {
+  blocksManualEntry: boolean;
+}
+
+function blocksManualEntryForCategory(category: ApiErrorCategory): boolean {
+  return (
+    category === 'not-found' || category === 'quota' || category === 'auth'
+  );
+}
+
+function formatClassifiedApiError(
+  error: ClassifiedApiErrorCore,
+): FormattedApiError {
+  return {
+    ...error,
+    blocksManualEntry: blocksManualEntryForCategory(error.category),
+  };
 }
 
 interface RecoveryAction {
@@ -342,14 +372,14 @@ export function recoveryActions(
  *  1. Typed NetworkError / TypeError network failures → network / retry
  *  2. Typed error classes from api-client.ts boundary (HMR-safe name guards)
  *  3. Error codes on the error object (apiCode, code)
- *  4. HTTP status from the "API error {status}: …" shape (plain Error fallback)
+ *  4. HTTP status on Error objects or the "API error {status}: …" fallback
  *  5. Message pattern heuristics (network keywords)
  *  6. Anything else → unknown / retry
  *
  * The message is derived AFTER classification so the classifier never
  * string-matches on formatted output.
  */
-export function classifyApiError(error: unknown): FormattedApiError {
+function classifyApiErrorCore(error: unknown): ClassifiedApiErrorCore {
   // 1. Typed NetworkError — thrown by customFetch on fetch rejection
   if (isNetworkError(error)) {
     return {
@@ -526,6 +556,47 @@ export function classifyApiError(error: unknown): FormattedApiError {
       };
     }
 
+    if (typeof apiErrorLike.status === 'number') {
+      const status = apiErrorLike.status;
+      const userMsg =
+        msg.length < 200 ? (friendlyMessage(msg) ?? msg) : undefined;
+
+      if (status === 401 || status === 403) {
+        return {
+          message: userMsg ?? i18next.t('errors.forbidden'),
+          category: 'auth',
+          recovery: 'sign-out',
+        };
+      }
+
+      if (status === 404 || status === 410) {
+        return {
+          message: userMsg ?? i18next.t('errors.notFound'),
+          category: 'not-found',
+          recovery: 'go-back',
+        };
+      }
+
+      if (status === 429) {
+        return {
+          message: userMsg ?? i18next.t('errors.rateLimited'),
+          category: 'quota',
+          recovery: 'retry',
+        };
+      }
+
+      if (status >= 500) {
+        return {
+          message:
+            userMsg && !isGenericServerMessage(userMsg)
+              ? userMsg
+              : SERVER_MESSAGE(),
+          category: 'server',
+          recovery: 'retry',
+        };
+      }
+    }
+
     // 3b. SSE timeout
     if (msgLower.includes('timed out while waiting for a reply')) {
       return {
@@ -635,6 +706,10 @@ export function classifyApiError(error: unknown): FormattedApiError {
 
   // 7. Fallback for null / undefined / non-Error values
   return { message: DEFAULT_MESSAGE(), category: 'unknown', recovery: 'retry' };
+}
+
+export function classifyApiError(error: unknown): FormattedApiError {
+  return formatClassifiedApiError(classifyApiErrorCore(error));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Keep book picking and setup routes available when generated suggestions, empty shelves, or book topic generation fail to hydrate.
- Centralize manual-entry blocking decisions in classifyApiError via blocksManualEntry, including Error objects with numeric status values.
- Preserve full error fallback for blocking auth/not-found states while keeping retryable failures open to manual entry.

## Validation
- pnpm exec jest --config apps/mobile/jest.config.cjs --runInBand --no-coverage --forceExit --runTestsByPath apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx
- pnpm exec jest --config apps/mobile/jest.config.cjs --runInBand --no-coverage --forceExit apps/mobile/src/lib/format-api-error.test.ts
- Commit hook ran tsc --build.
- Commit hook ran related mobile Jest set: 104 suites, 1570 tests passed.

## Push notes
- Normal push was attempted first and was blocked by the affected-file mobile receipt gate.
- Used SKIP_RECEIPT_CHECK=1 for the requested workaround after validation had passed.
- The branch was already rebased locally, so updating the open PR required force-with-lease against the exact previous remote SHA 7135d964f65c8350eda135fb42e8c51a060932da.
