### PR TITLE
fix(release): address prepublish readiness blockers

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -75,11 +75,11 @@ Two production dead-code branches removed 2026-04-19 in commit `970a82a5`: `AgeB
 - [project_inngest_staging.md](project_inngest_staging.md) — Inngest sync URL is `/v1/inngest` (not `/inngest`). Staging synced 2026-04-17.
 - [project_deploy_safety.md](project_deploy_safety.md) — deploy.yml uses drizzle-kit migrate (not push --force) for prod.
 
-## Store Publishing — BOTH BLOCKED (2026-03-27)
+## Store Publishing
 
-- [project_apple_enrollment.md](project_apple_enrollment.md) — Apple enrollment pending since ~2026-03-13.
-- [google_play_publishing.md](google_play_publishing.md) — Account flagged/disabled 2026-03-26, appeal in progress.
-- [project_revenuecat_setup.md](project_revenuecat_setup.md) — RevenueCat project created, store connections blocked.
+- [project_apple_enrollment.md](project_apple_enrollment.md) — Apple Developer account available as of 2026-05-15; old enrollment blocker resolved.
+- [google_play_publishing.md](google_play_publishing.md) — Google Play account available as of 2026-05-15; old flagged-account blocker resolved.
+- [project_revenuecat_setup.md](project_revenuecat_setup.md) — RevenueCat project exists; remaining work is store product/connection/webhook setup.
 
 ## Brand & UX Decisions
 

--- a/.claude/memory/google_play_publishing.md
+++ b/.claude/memory/google_play_publishing.md
@@ -1,22 +1,11 @@
 ---
-name: Google Play Publishing — Account Flagged
-description: Google Play developer account (zwizzly.app@gmail.com) disabled 2026-03-26. Appeal in progress. Backup plan: personal or Workspace account.
+name: Google Play Publishing — Account Available
+description: Google Play developer account access is available as of 2026-05-15; old 2026-03-26 disabled-account blocker is resolved.
 type: project
 ---
 
-Google Play Developer account (`zwizzly.app@gmail.com`) **disabled by Google on 2026-03-26**.
-
-**Reason:** "This account was created or used with multiple other accounts to violate Google's policies. The account might have been created by a computer program or bot." Account will be considered for deletion starting 2027-02-19.
-
-**Context:** Account was registered 2026-03-21 as a company account, verified successfully, then flagged ~5 days later. User has a separate personal Google account — Google's policy explicitly allows multiple accounts for personal vs business use.
-
-**Appeal:** Submitted 2026-03-27. Status unknown.
-
-**Backup plans if appeal fails:**
-1. Register new developer account under personal Google account (instant, but 14-day closed testing gate with 12+ testers required for production access)
-2. Register under Google Workspace domain (if available) — faster verification, less bot-detection risk
-3. App can be transferred between developer accounts after publishing
+Google Play developer account access is available as of 2026-05-15.
 
 **Why:** Required for Google Play Store submission and RevenueCat Android integration.
 
-**How to apply:** Do not assume Google Play is available. Check appeal status before planning Android store tasks. RevenueCat project is created ("MentoMate" with `Premium` entitlement) but can't connect Google Play until account is restored or replaced.
+**How to apply:** Do not treat Google Play account access as a blocker. The remaining Android-side work is Play Console app setup, closed testing/review requirements as applicable, product creation, service account JSON for RevenueCat, RevenueCat connection, and Play Billing sandbox testing.

--- a/.claude/memory/project_apple_enrollment.md
+++ b/.claude/memory/project_apple_enrollment.md
@@ -1,15 +1,11 @@
 ---
-name: Apple Developer enrollment pending
-description: Applied ~2026-03-13, still not processed as of 2026-03-27. Both stores blocked — Apple pending, Google flagged.
+name: Apple Developer account available
+description: Apple Developer account is available as of 2026-05-15; old March 2026 enrollment blocker is resolved.
 type: project
 ---
 
-Apple Developer Program enrollment applied ~2026-03-13, still pending as of 2026-03-27 (2+ weeks). No action available — just waiting.
+Apple Developer Program access is available as of 2026-05-15.
 
 **Why:** Required for App Store submission and iOS In-App Purchase testing via StoreKit 2.
 
-**How to apply:** Both app stores are currently blocked:
-- Apple: enrollment pending (no ETA)
-- Google Play: account flagged/disabled (appeal in progress)
-
-Don't plan store-specific launch tasks until at least one store account is available. All code and infrastructure is ready — the blockers are purely administrative.
+**How to apply:** Do not treat Apple enrollment as a launch blocker. The remaining Apple-side work is App Store Connect app setup, subscription/product creation, RevenueCat connection, sandbox purchase testing, and EAS submit credentials/IDs.

--- a/.claude/memory/project_revenuecat_setup.md
+++ b/.claude/memory/project_revenuecat_setup.md
@@ -1,13 +1,13 @@
 ---
 name: RevenueCat project setup status
-description: RevenueCat project "MentoMate" created with Premium entitlement. Store connections blocked by account issues.
+description: RevenueCat project "MentoMate" created with Premium entitlement. Store accounts are available; remaining work is product, connection, webhook, and Doppler setup.
 type: project
 ---
 
 RevenueCat project created on 2026-03-27:
 - **Project name:** MentoMate
 - **Entitlement:** `Premium` (one entitlement for all paid tiers — API resolves specific tier from product ID)
-- **Store connections:** Not yet connected (Google Play account flagged, Apple enrollment pending)
+- **Store connections:** Account access is available as of 2026-05-15; connect App Store and Google Play when products/service credentials are ready.
 
 **Product ID mapping (must match code exactly):**
 Code reference: `apps/api/src/routes/revenuecat-webhook.ts:81-104`
@@ -23,12 +23,12 @@ Subscriptions (6):
 Consumable (1):
 - `com.eduagent.topup.500[.android]` → 500 credits
 
-**Remaining setup (when stores unblock):**
+**Remaining setup:**
 1. Connect Google Play (needs service account JSON from Play Console)
-2. Connect App Store (when Apple enrollment completes)
+2. Connect App Store
 3. Create products in store dashboards matching above IDs
 4. Create offerings with 6 subscription packages + 1 consumable
 5. Configure webhook URL → `https://api-domain/v1/revenuecat/webhook`
 6. Add to Doppler: `REVENUECAT_WEBHOOK_SECRET`, `EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID`, `EXPO_PUBLIC_REVENUECAT_API_KEY_IOS`
 
-**How to apply:** When store accounts are restored/approved, follow the step-by-step guide from the 2026-03-27 session. Product IDs are non-negotiable — they must match `PRODUCT_TIER_MAP` exactly.
+**How to apply:** Product IDs are non-negotiable — they must match `PRODUCT_TIER_MAP` exactly. After connecting stores, validate real sandbox purchase → RevenueCat webhook → API entitlement/quota sync before publishing.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -318,13 +318,12 @@ jobs:
       - name: Resolve staging API URL
         id: resolve-url
         run: |
-          # Use the STAGING_API_URL secret if configured; default to workers.dev URL.
-          # The custom domain (api-stg.mentomate.com) is the preferred target but
-          # requires the secret to be set in GitHub Actions.
+          # Use the STAGING_API_URL secret if configured; default to the custom
+          # domain routed in apps/api/wrangler.toml.
           if [ -n "${{ secrets.STAGING_API_URL }}" ]; then
             RESOLVED_URL="${{ secrets.STAGING_API_URL }}"
           else
-            RESOLVED_URL="https://mentomate-api-stg.zwizzly.workers.dev"
+            RESOLVED_URL="https://api-stg.mentomate.com"
           fi
           echo "url=${RESOLVED_URL}" >> "$GITHUB_OUTPUT"
           echo "Staging API URL: ${RESOLVED_URL}"
@@ -420,6 +419,89 @@ jobs:
                 `_This issue was created automatically by the Deploy workflow. Close it once staging is healthy._`,
               ].join('\n'),
               labels: ['deploy-failure', 'smoke-test', 'automated'],
+            });
+
+  api-production-smoke-test:
+    name: Smoke Test — Production API
+    needs: api-deploy
+    # Only run after an approved production deploy. Keep this read-only:
+    # /v1/health proves the custom domain is routed to the fresh Worker and
+    # env validation passed without exercising user data.
+    if: |
+      needs.api-deploy.result == 'success' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.api_environment == 'production'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve production API URL
+        id: resolve-url
+        run: |
+          if [ -n "${{ secrets.PRODUCTION_API_URL }}" ]; then
+            RESOLVED_URL="${{ secrets.PRODUCTION_API_URL }}"
+          else
+            RESOLVED_URL="https://api.mentomate.com"
+          fi
+          echo "url=${RESOLVED_URL}" >> "$GITHUB_OUTPUT"
+          echo "Production API URL: ${RESOLVED_URL}"
+
+      - name: Smoke — GET /v1/health (200, status ok)
+        env:
+          PRODUCTION_API_URL: ${{ steps.resolve-url.outputs.url }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            echo "Attempt ${attempt}: hitting ${PRODUCTION_API_URL}/v1/health"
+            HTTP_CODE=$(curl -s --max-time 15 -o /tmp/health.json -w "%{http_code}" \
+              "${PRODUCTION_API_URL}/v1/health") || HTTP_CODE=000
+            echo "HTTP status: ${HTTP_CODE}"
+            if [ "${HTTP_CODE}" = "200" ]; then
+              break
+            fi
+            if [ "${attempt}" -eq 5 ]; then
+              echo "✗ /v1/health returned ${HTTP_CODE} after 5 attempts"
+              cat /tmp/health.json || true
+              exit 1
+            fi
+            sleep 5
+          done
+          STATUS=$(python3 -c "import json; print(json.load(open('/tmp/health.json')).get('status',''))")
+          echo "status field: ${STATUS}"
+          if [ "${STATUS}" != "ok" ]; then
+            echo "✗ /v1/health body.status = '${STATUS}', expected 'ok'"
+            cat /tmp/health.json
+            exit 1
+          fi
+          echo "✓ /v1/health OK"
+
+      - name: Notify on production smoke test failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const branch = context.ref.replace('refs/heads/', '');
+            const sha = context.sha.slice(0, 8);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Smoke test failure: production API (${sha})`,
+              body: [
+                `## Production Smoke Test Failed`,
+                ``,
+                `The production API deployed successfully but failed the read-only health check.`,
+                ``,
+                `| Field | Value |`,
+                `|-------|-------|`,
+                `| Environment | \`production\` |`,
+                `| Branch | \`${branch}\` |`,
+                `| Commit | \`${sha}\` |`,
+                `| Run | [View run](${runUrl}) |`,
+                `| Triggered by | @${context.actor} |`,
+                ``,
+                `**Action required:** Check the run log, verify the custom domain route, and confirm production env validation passed.`,
+                ``,
+                `_This issue was created automatically by the Deploy workflow. Close it once production is healthy._`,
+              ].join('\n'),
+              labels: ['deploy-failure', 'smoke-test', 'production', 'automated'],
             });
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/e2e-web-cleanup.yml
+++ b/.github/workflows/e2e-web-cleanup.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Reset seeded staging accounts
         env:
           # Match the web smoke fallback; repos can override with E2E_API_URL.
-          API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
+          API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
           TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -66,9 +66,9 @@ jobs:
       # NOTE: switching E2E_API_URL from *.workers.dev to a custom domain
       # (e.g. api-test.mentomate.com) will also change Playwright from 1 → 4
       # workers via the usesSharedStagingApi check in playwright.config.ts.
-      EXPO_PUBLIC_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
+      EXPO_PUBLIC_API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
       EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY_PREVIEW }}
-      PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
+      PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
       PLAYWRIGHT_SKIP_LOCAL_API: '1'
       PLAYWRIGHT_TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
@@ -112,7 +112,7 @@ jobs:
       - name: Reset seeded staging accounts (always)
         if: always()
         env:
-          PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://mentomate-api-stg.zwizzly.workers.dev' }}
+          PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL || 'https://api-stg.mentomate.com' }}
           PLAYWRIGHT_TEST_SEED_SECRET: ${{ secrets.TEST_SEED_SECRET }}
           PLAYWRIGHT_RUN_ID: ${{ env.PLAYWRIGHT_RUN_ID }}
         run: |

--- a/.test-receipts/mobile.json
+++ b/.test-receipts/mobile.json
@@ -1,10 +1,19 @@
 {
   "scope": "mobile",
-  "verifiedAt": "2026-05-15T16:36:36Z",
-  "verifiedBy": "Zuzana Kopečná @ ZLY-Orion",
-  "command": "pnpm exec nx run mobile:test",
+  "verifiedAt": "2026-05-15T19:10:01Z",
+  "maxAgeHours": 24,
+  "verifiedBy": "Zuzana Kopečná @ ZLY-ORION",
+  "command": "pnpm exec jest --config apps/mobile/jest.config.cjs --runTestsByPath <42 related route/component test files> --runInBand --no-coverage --forceExit --silent && pnpm exec jest --config apps/mobile/jest.config.cjs --runTestsByPath apps/mobile/src/app/(app)/pick-book/[subjectId].test.tsx --runInBand --no-coverage --forceExit --silent",
   "passed": true,
-  "testFiles": {
-    "apps/mobile/src/components/home/ParentHomeScreen.test.tsx": "f0d696a1ab62faa05d4bc56c47cfde9ffb693198"
+  "affectedFiles": {
+    "apps/mobile/src/app/(app)/library.tsx": true,
+    "apps/mobile/src/app/(app)/progress/index.tsx": true,
+    "apps/mobile/src/app/(app)/quiz/history.test.tsx": true,
+    "apps/mobile/src/app/(app)/quiz/history.tsx": true,
+    "apps/mobile/src/app/_layout.tsx": true,
+    "apps/mobile/src/components/AnimatedSplash.test.tsx": true,
+    "apps/mobile/src/components/AnimatedSplash.tsx": true,
+    "apps/mobile/src/components/common/TimeoutLoader.test.tsx": true,
+    "apps/mobile/src/components/common/TimeoutLoader.tsx": true
   }
 }

--- a/apps/api/src/wrangler-config.test.ts
+++ b/apps/api/src/wrangler-config.test.ts
@@ -24,12 +24,16 @@ const WRANGLER_TOML_PATH = join(__dirname, '..', 'wrangler.toml');
 function getTableSection(toml: string, tableName: string): string {
   const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const section = toml.match(
-    new RegExp(`^\\[${escaped}\\]([\\s\\S]*?)(?=^\\[|$)`, 'm'),
+    new RegExp(`^\\[${escaped}\\]([\\s\\S]*?)(?=^\\[|$(?![\\r\\n]))`, 'm'),
   );
-  if (!section?.[1]) {
+  if (!section) {
     throw new Error(`Missing wrangler.toml section [${tableName}]`);
   }
-  return section[1];
+  const tableBody = section[1];
+  if (tableBody === undefined) {
+    throw new Error(`Missing wrangler.toml section body [${tableName}]`);
+  }
+  return tableBody;
 }
 
 describe('wrangler.toml config guards', () => {

--- a/apps/api/src/wrangler-config.test.ts
+++ b/apps/api/src/wrangler-config.test.ts
@@ -12,12 +12,25 @@
  *   BUG-784            [CFG-4] — when a root [[kv_namespaces]] block declares
  *     preview_id, it must differ from id. Equal IDs cause `wrangler dev --remote`
  *     to write to the live namespace, polluting production KV with dev data.
+ *   CFG-13 — public API origins must use the configured custom domains, not
+ *     legacy workers.dev URLs that bypass custom-domain WAF/routing assumptions.
  */
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const WRANGLER_TOML_PATH = join(__dirname, '..', 'wrangler.toml');
+
+function getTableSection(toml: string, tableName: string): string {
+  const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const section = toml.match(
+    new RegExp(`^\\[${escaped}\\]([\\s\\S]*?)(?=^\\[|$)`, 'm'),
+  );
+  if (!section?.[1]) {
+    throw new Error(`Missing wrangler.toml section [${tableName}]`);
+  }
+  return section[1];
+}
 
 describe('wrangler.toml config guards', () => {
   let content: string;
@@ -90,6 +103,24 @@ describe('wrangler.toml config guards', () => {
       const block = findKvBlock(getRootSection(content), 'COACHING_KV');
       expect(block).not.toBeNull();
       checkBlock(block!);
+    });
+  });
+
+  describe('[CFG-13] custom domain origins', () => {
+    it('staging API_ORIGIN uses the staging custom domain', () => {
+      const stagingVars = getTableSection(content, 'env.staging.vars');
+      expect(stagingVars).toMatch(
+        /^API_ORIGIN\s*=\s*"https:\/\/api-stg\.mentomate\.com"/m,
+      );
+      expect(stagingVars).not.toMatch(/workers\.dev/);
+    });
+
+    it('production API_ORIGIN uses the production custom domain', () => {
+      const productionVars = getTableSection(content, 'env.production.vars');
+      expect(productionVars).toMatch(
+        /^API_ORIGIN\s*=\s*"https:\/\/api\.mentomate\.com"/m,
+      );
+      expect(productionVars).not.toMatch(/workers\.dev/);
     });
   });
 });

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -29,7 +29,7 @@ compatibility_flags = ["nodejs_compat"]
 [vars]
 ENVIRONMENT = "development"
 # These vars have defaults in config.ts but can be overridden per environment:
-#   APP_URL       = "https://app.mentomate.com"
+#   APP_URL       = "https://www.mentomate.com"
 #   LOG_LEVEL     = "info"          (debug | info | warn | error)
 #   EMAIL_FROM    = "noreply@mentomate.com"
 
@@ -68,12 +68,18 @@ ENVIRONMENT = "development"
 #
 # --- Email (Resend) ---
 #   RESEND_API_KEY            Resend transactional email API key
+#   RESEND_WEBHOOK_SECRET     Resend webhook signing secret
 #
 # --- Testing ---
 #   TEST_SEED_SECRET          Shared secret for /__test/* routes (dev/staging only)
 #
 # --- Observability ---
 #   SENTRY_DSN                Sentry error tracking DSN
+#
+# --- Prelaunch overrides ---
+#   ALLOW_MISSING_IDEMPOTENCY_KV
+#     Set to "true" only if production must launch before IDEMPOTENCY_KV is
+#     bound. Production otherwise refuses traffic when the binding is missing.
 
 # =============================================================================
 # KV Namespaces (Zwizzly account)
@@ -97,13 +103,9 @@ id = "db6f91e2639e44ce931f63f858593f3c"
 # TODO [BUG-12]: Create "IDEMPOTENCY_KV" namespace in the Zwizzly Cloudflare
 # account (Workers & Pages → KV → Create) and uncomment the binding below for
 # all three environments. apps/api/src/routes/resend-webhook.ts:322 reads
-# c.env.IDEMPOTENCY_KV for svix-id replay deduplication; until this binding
-# exists the route gracefully degrades to alerting-only mode (Inngest event
-# app/resend-webhook.dedup_kv_missing fires on every request in staging /
-# production). That is the deliberate launch posture — replay is signed +
-# timestamp-windowed already, so the marginal exposure is a 5-minute replay
-# window — but the dedup itself is OFF in every deployed environment until
-# the namespace exists. See BUG-12 (Notion) for tracking.
+# c.env.IDEMPOTENCY_KV for svix-id replay deduplication. Production env
+# validation refuses traffic without this binding unless Doppler prd explicitly
+# sets ALLOW_MISSING_IDEMPOTENCY_KV="true" as a prelaunch override.
 #
 # [[kv_namespaces]]
 # binding = "IDEMPOTENCY_KV"
@@ -127,7 +129,7 @@ routes = [
 [env.staging.vars]
 ENVIRONMENT = "staging"
 APP_URL = "https://www.mentomate.com"
-API_ORIGIN = "https://mentomate-api-stg.zwizzly.workers.dev"
+API_ORIGIN = "https://api-stg.mentomate.com"
 LOG_LEVEL = "warn"
 EMAIL_FROM = "staging-noreply@mentomate.com"
 
@@ -177,9 +179,11 @@ binding = "COACHING_KV"
 id = "76b36f4748fe4d77b27387a5bebf4be6"
 
 # TODO [BUG-12]: Add IDEMPOTENCY_KV production binding before any traffic that
-# would re-trigger billing/consent side-effects on replay. Pre-launch (no
-# active users) the alerting-only posture is acceptable. Once enabled, the
-# Inngest signal app/resend-webhook.dedup_kv_missing should stop firing.
+# would re-trigger billing/consent side-effects on replay. If production must
+# launch before this namespace exists, set ALLOW_MISSING_IDEMPOTENCY_KV="true"
+# in Doppler prd and treat the resulting env-validation warning as a temporary
+# launch exception. Once enabled, the Inngest signal
+# app/resend-webhook.dedup_kv_missing should stop firing.
 # [[env.production.kv_namespaces]]
 # binding = "IDEMPOTENCY_KV"
 # id = "<replace-after-namespace-creation>"

--- a/apps/mobile/e2e-web/README.md
+++ b/apps/mobile/e2e-web/README.md
@@ -8,8 +8,8 @@ Shared staging full suite:
 
 ```bash
 CI=1 PLAYWRIGHT_SKIP_LOCAL_API=1 \
-  PLAYWRIGHT_API_URL="https://mentomate-api-stg.zwizzly.workers.dev" \
-  EXPO_PUBLIC_API_URL="https://mentomate-api-stg.zwizzly.workers.dev" \
+  PLAYWRIGHT_API_URL="https://api-stg.mentomate.com" \
+  EXPO_PUBLIC_API_URL="https://api-stg.mentomate.com" \
   doppler run --project mentomate --config stg -- \
   pnpm run test:e2e:web --reporter=list,json
 ```
@@ -18,15 +18,17 @@ Target opt-in P1B coverage without retries:
 
 ```bash
 CI=1 PLAYWRIGHT_SKIP_LOCAL_API=1 PLAYWRIGHT_INCLUDE_P1B=1 \
-  PLAYWRIGHT_API_URL="https://mentomate-api-stg.zwizzly.workers.dev" \
-  EXPO_PUBLIC_API_URL="https://mentomate-api-stg.zwizzly.workers.dev" \
+  PLAYWRIGHT_API_URL="https://api-stg.mentomate.com" \
+  EXPO_PUBLIC_API_URL="https://api-stg.mentomate.com" \
   doppler run --project mentomate --config stg -- \
   pnpm exec playwright test -c apps/mobile/playwright.config.ts \
   apps/mobile/e2e-web/flows/journeys/j20-vocabulary-quiz-answer-mapping.spec.ts \
   --project=later-phases --workers=1 --retries=0 --reporter=list
 ```
 
-Local API mode starts `wrangler dev` unless `PLAYWRIGHT_SKIP_LOCAL_API=1` is set. The web server rewrites `.env.local` and `.env.development.local` before `expo export` so the built web bundle uses `PLAYWRIGHT_API_URL`, then restores those files after export.
+Local API mode starts `wrangler dev` unless `PLAYWRIGHT_SKIP_LOCAL_API=1` is set. The API server and Expo export are launched from `apps/mobile`, so `pnpm --dir ../api exec wrangler dev --port 8787` targets `apps/api` and `node e2e-web/helpers/serve-exported-web.mjs` serves `apps/mobile/dist`.
+
+Before `expo export`, the web server rewrites `apps/mobile/.env.local` and `apps/mobile/.env.development.local` so the built web bundle uses the same API URL as the Playwright seed helpers. Set `PLAYWRIGHT_API_URL` to override it; `EXPO_PUBLIC_API_URL` is accepted as a fallback for compatibility. If neither is set, local mode uses `http://127.0.0.1:8787` and staging mode uses the default shared test API.
 
 ## Safety
 

--- a/apps/mobile/e2e-web/flows/journeys/j13-consent-pending-parent-approval.spec.ts
+++ b/apps/mobile/e2e-web/flows/journeys/j13-consent-pending-parent-approval.spec.ts
@@ -29,9 +29,19 @@ test('J-13 pending consent blocks app until parent approval completes', async ({
       approvalPage.getByRole('button', { name: 'Approve' }),
     ).toBeVisible({ timeout: 30_000 });
     await approvalPage.getByRole('button', { name: 'Approve' }).click();
-    await expect(approvalPage.getByText(/family account ready!/i)).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(approvalPage.locator('body')).toContainText(
+      /family account ready|you may now close this tab/i,
+      { timeout: 30_000 },
+    );
+    await expect(
+      approvalPage.getByRole('link', { name: /open mentomate|progress/i }),
+    ).toHaveAttribute('href', /mentomate:\/\/home/);
+    await expect(
+      approvalPage.getByRole('link', { name: /google play/i }),
+    ).toBeVisible();
+    await expect(
+      approvalPage.getByRole('link', { name: /app store/i }),
+    ).toBeVisible();
 
     await pressableClick(page.getByTestId('consent-check-again'));
 

--- a/apps/mobile/e2e-web/flows/journeys/j19-subscription-paywall-ui.spec.ts
+++ b/apps/mobile/e2e-web/flows/journeys/j19-subscription-paywall-ui.spec.ts
@@ -27,9 +27,9 @@ test('J-19 free-tier learner sees subscription paywall with static tier comparis
 }) => {
   // ── 1. Navigate to More tab and open Subscription via the nav row ──────────
   await page.goto('/more', { waitUntil: 'commit' });
-  await expect(
-    page.getByRole('button', { name: 'Profile', exact: true }),
-  ).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByTestId('more-row-account')).toBeVisible({
+    timeout: 60_000,
+  });
 
   await pressableClick(page.getByTestId('more-row-account'));
   await expect(page.getByTestId('more-account-scroll')).toBeVisible({

--- a/apps/mobile/e2e-web/flows/navigation/w05-tab-routes-render-correct-screen.spec.ts
+++ b/apps/mobile/e2e-web/flows/navigation/w05-tab-routes-render-correct-screen.spec.ts
@@ -25,9 +25,9 @@ test('W-05 tab URLs render the correct screen on web', async ({ page }) => {
   });
 
   await page.goto('/more', { waitUntil: 'commit' });
-  await expect(
-    page.getByRole('button', { name: 'Profile', exact: true }),
-  ).toBeVisible({
+  await expect(page.getByTestId('more-row-account')).toBeVisible({
     timeout: 30_000,
   });
+  await expect(page.getByTestId('more-row-privacy')).toBeVisible();
+  await expect(page.getByTestId('more-row-help')).toBeVisible();
 });

--- a/apps/mobile/e2e-web/helpers/runtime.ts
+++ b/apps/mobile/e2e-web/helpers/runtime.ts
@@ -20,7 +20,9 @@ export const seedEmailPrefix =
 process.env.PLAYWRIGHT_EMAIL_PREFIX = seedEmailPrefix;
 
 export const apiBaseUrl = trimTrailingSlash(
-  process.env.PLAYWRIGHT_API_URL ?? defaultApiUrl,
+  process.env.PLAYWRIGHT_API_URL ??
+    process.env.EXPO_PUBLIC_API_URL ??
+    defaultApiUrl,
 );
 
 export const appBaseUrl = trimTrailingSlash(

--- a/apps/mobile/e2e-web/helpers/serve-exported-web.mjs
+++ b/apps/mobile/e2e-web/helpers/serve-exported-web.mjs
@@ -122,7 +122,10 @@ const envFilesToOverride = ['.env.local', '.env.development.local'].map(
 );
 const require = createRequire(import.meta.url);
 const { defaultApiUrl } = require('./e2e-defaults.js');
-const apiUrl = process.env.PLAYWRIGHT_API_URL ?? defaultApiUrl;
+const apiUrl =
+  process.env.PLAYWRIGHT_API_URL ??
+  process.env.EXPO_PUBLIC_API_URL ??
+  defaultApiUrl;
 process.env.EXPO_PUBLIC_API_URL = apiUrl;
 const generatedEnvFiles = new Set();
 

--- a/apps/mobile/e2e/flows/regression/bug-233-chat-classifier-easter.yaml
+++ b/apps/mobile/e2e/flows/regression/bug-233-chat-classifier-easter.yaml
@@ -31,7 +31,7 @@ tags:
       id: "learner-screen"
     timeout: 15000
 
-# 3. Start a freeform session via intent-ask card (replaced coaching-card-primary)
+# 3. Start a freeform session via home-ask-anything card (replaced coaching-card-primary)
 - tapOn:
     id: "home-ask-anything"
 

--- a/apps/mobile/e2e/flows/regression/bug-234-chat-subject-picker.yaml
+++ b/apps/mobile/e2e/flows/regression/bug-234-chat-subject-picker.yaml
@@ -33,7 +33,7 @@ tags:
       id: "learner-screen"
     timeout: 15000
 
-# 3. Navigate to freeform session via intent-ask (replaced coaching-card-primary)
+# 3. Navigate to freeform session via home-ask-anything (replaced coaching-card-primary)
 - tapOn:
     id: "home-ask-anything"
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -45,10 +45,8 @@
   },
   "submit": {
     "production": {
-      "ios": {
-        "appleId": "APPLE_ID_PLACEHOLDER",
-        "ascAppId": "ASC_APP_ID_PLACEHOLDER"
-      }
+      "android": {},
+      "ios": {}
     }
   }
 }

--- a/apps/mobile/playwright.config.ts
+++ b/apps/mobile/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 import { apiBaseUrl, appBaseUrl, runId } from './e2e-web/helpers/runtime';
 
 const e2eWebDir = path.join(process.cwd(), 'apps', 'mobile', 'e2e-web');
+const mobileDir = path.join(process.cwd(), 'apps', 'mobile');
 const shouldStartLocalApi = process.env.PLAYWRIGHT_SKIP_LOCAL_API !== '1';
 const includeP1BCoverage = process.env.PLAYWRIGHT_INCLUDE_P1B === '1';
 // *.workers.dev URLs are platform-rate-limited → 1 worker.
@@ -56,6 +57,7 @@ export default defineConfig({
       ? [
           {
             command: 'pnpm --dir ../api exec wrangler dev --port 8787',
+            cwd: mobileDir,
             url: `${apiBaseUrl}/v1/health`,
             reuseExistingServer: !process.env.CI,
             stdout: 'pipe' as const,
@@ -66,6 +68,7 @@ export default defineConfig({
       : []),
     {
       command: 'node e2e-web/helpers/serve-exported-web.mjs',
+      cwd: mobileDir,
       url: appBaseUrl,
       // CI (false): always export a fresh bundle — prevents stale API URL
       // from a prior run being silently reused. Safe at 1 worker (CI smoke).

--- a/apps/mobile/src/app/(app)/library.tsx
+++ b/apps/mobile/src/app/(app)/library.tsx
@@ -708,7 +708,7 @@ export default function LibraryScreen() {
             {shelfGroups.map((group) => (
               <View key={group.status}>
                 {showShelfGroupLabels ? (
-                  <Text className="text-caption font-bold uppercase text-text-secondary mt-1 mb-2">
+                  <Text className="text-caption font-bold text-text-secondary mt-1 mb-2">
                     {t(`library.sections.${group.status}`)}
                   </Text>
                 ) : null}

--- a/apps/mobile/src/app/(app)/progress/index.tsx
+++ b/apps/mobile/src/app/(app)/progress/index.tsx
@@ -1058,7 +1058,7 @@ export default function ProgressScreen(): React.ReactElement {
                 ) : null}
                 {inventory?.subjects?.length ? (
                   <View testID="progress-subject-breakdown" className="mt-5">
-                    <Text className="text-caption font-bold uppercase text-text-secondary mb-2">
+                    <Text className="text-caption font-bold text-text-secondary mb-2">
                       {t('progress.guardian.subjectsTitle')}
                     </Text>
                     {inventory.subjects.map((subject) => (

--- a/apps/mobile/src/app/(app)/quiz/history.test.tsx
+++ b/apps/mobile/src/app/(app)/quiz/history.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import QuizHistoryScreen from './history';
 
 const mockPush = jest.fn();
@@ -94,6 +94,10 @@ describe('QuizHistoryScreen', () => {
     });
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('navigates back to quiz index via goBackOrReplace', () => {
     render(<QuizHistoryScreen />);
     fireEvent.press(screen.getByTestId('quiz-history-back'));
@@ -121,6 +125,31 @@ describe('QuizHistoryScreen', () => {
     });
     render(<QuizHistoryScreen />);
     expect(screen.getByTestId('quiz-history-loading')).toBeTruthy();
+    screen.getByText('quiz.history.loadingText');
+    screen.getByTestId('quiz-history-loading-back');
+  });
+
+  it('turns the loading state into retry and back actions after timeout', () => {
+    jest.useFakeTimers();
+    const refetch = jest.fn();
+    mockUseRecentRounds.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch,
+    });
+
+    render(<QuizHistoryScreen />);
+
+    act(() => {
+      jest.advanceTimersByTime(15_000);
+    });
+
+    fireEvent.press(screen.getByTestId('quiz-history-timeout-retry'));
+    expect(refetch).toHaveBeenCalled();
+
+    fireEvent.press(screen.getByTestId('quiz-history-timeout-go-back'));
+    expect(mockReplace).toHaveBeenCalledWith('/(app)/quiz');
   });
 
   it('shows empty state with try-quiz CTA', () => {

--- a/apps/mobile/src/app/(app)/quiz/history.tsx
+++ b/apps/mobile/src/app/(app)/quiz/history.tsx
@@ -3,11 +3,12 @@ import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter, type Href } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { i18next } from '../../../i18n';
+import { ErrorFallback } from '../../../components/common/ErrorFallback';
+import { TimeoutLoader } from '../../../components/common/TimeoutLoader';
 import { useRecentRounds } from '../../../hooks/use-quiz';
+import { extractLanguageFromTheme } from '../../../lib/extract-vocabulary-language';
 import { goBackOrReplace } from '../../../lib/navigation';
 import { useThemeColors } from '../../../lib/theme';
-import { ErrorFallback } from '../../../components/common/ErrorFallback';
-import { extractLanguageFromTheme } from '../../../lib/extract-vocabulary-language';
 import { useScreenTopInset } from '../../../lib/use-screen-top-inset';
 
 // [F-037] Friendly date label — "Today" / "Yesterday" / locale long date.
@@ -46,12 +47,43 @@ export default function QuizHistoryScreen() {
   if (isLoading) {
     return (
       <View
-        testID="quiz-history-loading"
-        className="flex-1 items-center justify-center"
+        testID="quiz-history-loading-screen"
+        className="flex-1 bg-background"
       >
-        <Text className="text-on-surface-muted">
-          {t('quiz.history.loadingText')}
-        </Text>
+        <View
+          className="flex-row items-center px-4 pb-4"
+          style={{ paddingTop: insets.top + 16 }}
+        >
+          <Pressable
+            testID="quiz-history-loading-back"
+            onPress={() => router.replace(backHref as Href)}
+            className="min-h-[44px] min-w-[44px] items-center justify-center"
+            accessibilityRole="button"
+            accessibilityLabel={t('quiz.history.goBack')}
+          >
+            <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+          </Pressable>
+          <Text className="text-on-surface ml-4 text-xl font-bold">
+            {t('quiz.history.title')}
+          </Text>
+        </View>
+        <TimeoutLoader
+          isLoading
+          testID="quiz-history-loading"
+          loadingLabel={t('quiz.history.loadingText')}
+          title={t('quiz.history.errorTitle')}
+          message={t('quiz.history.errorMessage')}
+          primaryAction={{
+            label: t('common.retry'),
+            onPress: () => void refetch(),
+            testID: 'quiz-history-timeout-retry',
+          }}
+          secondaryAction={{
+            label: t('common.goBack'),
+            onPress: () => router.replace(backHref as Href),
+            testID: 'quiz-history-timeout-go-back',
+          }}
+        />
       </View>
     );
   }

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -454,16 +454,14 @@ export default function RootLayout() {
     };
   }, []);
 
-  // Splash stays visible until BOTH conditions are met:
-  //   1. The animated splash sequence has completed (or timed out)
-  //   2. Clerk has finished initializing (app content is ready to render)
-  // This prevents the white-screen gap that occurs when the splash dismisses
-  // before ClerkLoaded resolves — especially on slower devices or with larger
-  // JS bundles where Clerk init can take > 3 seconds.
+  // The animated splash must unmount as soon as its own sequence completes.
+  // Keeping the absolute overlay mounted while Clerk finishes can leave a
+  // faded React Native Web Pressable in the pointer-event path after the app
+  // screen looks ready.
   const [animDone, setAnimDone] = useState(false);
   const [clerkReady, setClerkReady] = useState(false);
   const [clerkTimedOut, setClerkTimedOut] = useState(false);
-  const showSplash = !animDone || !clerkReady;
+  const showSplash = !animDone;
 
   const onAnimComplete = useCallback(() => {
     if (__DEV__) console.log('[Splash] Animation complete');

--- a/apps/mobile/src/components/AnimatedSplash.test.tsx
+++ b/apps/mobile/src/components/AnimatedSplash.test.tsx
@@ -8,14 +8,7 @@ import { AnimatedSplash } from './AnimatedSplash';
 beforeEach(() => {
   const reanimated = require('react-native-reanimated');
   reanimated.useReducedMotion = () => false;
-  reanimated.withTiming = (
-    value: unknown,
-    _options?: unknown,
-    callback?: (finished: boolean) => void,
-  ) => {
-    callback?.(true);
-    return value;
-  };
+  reanimated.withTiming = (value: unknown) => value;
 });
 
 afterEach(() => {
@@ -24,6 +17,17 @@ afterEach(() => {
 });
 
 describe('AnimatedSplash', () => {
+  const completeTimingCallbacksSynchronously = () => {
+    require('react-native-reanimated').withTiming = (
+      value: unknown,
+      _options?: unknown,
+      callback?: (finished: boolean) => void,
+    ) => {
+      callback?.(true);
+      return value;
+    };
+  };
+
   it('renders without crashing', () => {
     const onComplete = jest.fn();
     const { getByTestId } = render(<AnimatedSplash onComplete={onComplete} />);
@@ -38,6 +42,7 @@ describe('AnimatedSplash', () => {
 
   it('calls onComplete when reduced motion is enabled', () => {
     require('react-native-reanimated').useReducedMotion = () => true;
+    completeTimingCallbacksSynchronously();
 
     const onComplete = jest.fn();
     render(<AnimatedSplash onComplete={onComplete} />);
@@ -76,14 +81,36 @@ describe('AnimatedSplash', () => {
   it('calls onComplete on tap (skip)', () => {
     const onComplete = jest.fn();
     const { getByTestId } = render(<AnimatedSplash onComplete={onComplete} />);
-    // The Pressable wraps the full splash area — press on the root
-    fireEvent.press(getByTestId('animated-splash'));
+
+    fireEvent.press(getByTestId('animated-splash-skip'));
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the splash from the tree after tap-to-skip', () => {
+    const onComplete = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <AnimatedSplash onComplete={onComplete} />,
+    );
+
+    fireEvent.press(getByTestId('animated-splash-skip'));
+
+    expect(queryByTestId('animated-splash')).toBeNull();
+  });
+
+  it('removes the splash from the tree after animation completion', () => {
+    completeTimingCallbacksSynchronously();
+
+    const onComplete = jest.fn();
+    const { queryByTestId } = render(
+      <AnimatedSplash onComplete={onComplete} />,
+    );
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('animated-splash')).toBeNull();
   });
 
   it('stops accepting touches when the fade-out phase begins', () => {
     jest.useFakeTimers();
-    require('react-native-reanimated').withTiming = (value: unknown) => value;
 
     const onComplete = jest.fn();
     const { getByTestId } = render(<AnimatedSplash onComplete={onComplete} />);
@@ -100,14 +127,16 @@ describe('AnimatedSplash', () => {
 
   it('delivers completion from the watchdog when animation callbacks are dropped', () => {
     jest.useFakeTimers();
-    require('react-native-reanimated').withTiming = (value: unknown) => value;
 
     const onComplete = jest.fn();
-    render(<AnimatedSplash onComplete={onComplete} />);
+    const { queryByTestId } = render(
+      <AnimatedSplash onComplete={onComplete} />,
+    );
 
     act(() => {
       jest.advanceTimersByTime(3300);
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('animated-splash')).toBeNull();
   });
 });

--- a/apps/mobile/src/components/AnimatedSplash.tsx
+++ b/apps/mobile/src/components/AnimatedSplash.tsx
@@ -150,27 +150,38 @@ export function AnimatedSplash({ onComplete }: AnimatedSplashProps) {
   const wordOp = useSharedValue(0);
   const fade = useSharedValue(1);
   const [acceptsTouches, setAcceptsTouches] = useState(true);
+  const [hasExited, setHasExited] = useState(false);
 
   // Use a ref so the effect closure always calls the latest onComplete
   // without re-triggering the animation choreography on prop identity changes.
   const onCompleteRef = useRef(onComplete);
   const completionDeliveredRef = useRef(false);
+  const mountedRef = useRef(true);
   onCompleteRef.current = onComplete;
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const done = useCallback(() => {
     if (completionDeliveredRef.current) return;
     completionDeliveredRef.current = true;
     if (__DEV__)
       console.log('[Splash] done() called — animation completed normally');
-    setAcceptsTouches(false);
+    if (mountedRef.current) {
+      setAcceptsTouches(false);
+      setHasExited(true);
+    }
     onCompleteRef.current();
   }, []);
 
   // Tap to skip
   const skip = useCallback(() => {
     setAcceptsTouches(false);
-    fade.value = withTiming(0, { duration: 200 }, (finished) => {
-      if (finished) runOnJS(done)();
-    });
+    fade.value = 0;
+    done();
   }, [done, fade]);
 
   // --- Choreography ---
@@ -408,13 +419,19 @@ export function AnimatedSplash({ onComplete }: AnimatedSplashProps) {
   const containerStyle = useAnimatedStyle(() => ({ opacity: fade.value }));
   const wordmarkStyle = useAnimatedStyle(() => ({ opacity: wordOp.value }));
 
+  if (hasExited) return null;
+
   return (
     <Animated.View
       style={[styles.container, { backgroundColor: C.bg }, containerStyle]}
       testID="animated-splash"
       pointerEvents={acceptsTouches ? 'auto' : 'none'}
     >
-      <Pressable onPress={skip} style={styles.pressable}>
+      <Pressable
+        onPress={skip}
+        style={styles.pressable}
+        testID="animated-splash-skip"
+      >
         <Svg width={ICON_SIZE} height={ICON_SIZE} viewBox="-5 -15 130 130">
           <Defs>
             <LinearGradient id="splash-arc" x1="0" y1="1" x2="1" y2="0">

--- a/apps/mobile/src/components/common/TimeoutLoader.test.tsx
+++ b/apps/mobile/src/components/common/TimeoutLoader.test.tsx
@@ -1,0 +1,61 @@
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { TimeoutLoader } from './TimeoutLoader';
+
+describe('TimeoutLoader', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows contextual loading copy before the timeout fallback', () => {
+    render(
+      <TimeoutLoader
+        isLoading
+        loadingLabel="Loading history..."
+        loadingDescription="Checking recent quiz rounds."
+        primaryAction={{ label: 'Retry', onPress: jest.fn() }}
+        testID="loader"
+      />,
+    );
+
+    screen.getByTestId('loader');
+    screen.getByText('Loading history...');
+    screen.getByText('Checking recent quiz rounds.');
+  });
+
+  it('replaces the spinner with actionable fallback after timeout', () => {
+    jest.useFakeTimers();
+    const retry = jest.fn();
+    const goBack = jest.fn();
+
+    render(
+      <TimeoutLoader
+        isLoading
+        timeoutMs={1000}
+        title="Could not load history"
+        message="Check your connection and try again."
+        primaryAction={{
+          label: 'Retry',
+          onPress: retry,
+          testID: 'loader-retry',
+        }}
+        secondaryAction={{
+          label: 'Go Back',
+          onPress: goBack,
+          testID: 'loader-back',
+        }}
+        testID="loader"
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    screen.getByText('Could not load history');
+    fireEvent.press(screen.getByTestId('loader-retry'));
+    fireEvent.press(screen.getByTestId('loader-back'));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(goBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/components/common/TimeoutLoader.tsx
+++ b/apps/mobile/src/components/common/TimeoutLoader.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ErrorFallback } from './ErrorFallback';
 
@@ -22,6 +22,10 @@ interface TimeoutLoaderProps {
   primaryAction: TimeoutLoaderAction;
   /** Optional secondary action for the ErrorFallback (e.g. Go Back). */
   secondaryAction?: TimeoutLoaderAction;
+  /** Optional label shown next to the spinner before timeout. */
+  loadingLabel?: string;
+  /** Optional supporting text shown before timeout. */
+  loadingDescription?: string;
   /** testID forwarded to the spinner View. */
   testID?: string;
 }
@@ -38,6 +42,8 @@ export function TimeoutLoader({
   message,
   primaryAction,
   secondaryAction,
+  loadingLabel,
+  loadingDescription,
   testID,
 }: TimeoutLoaderProps) {
   const { t } = useTranslation();
@@ -70,10 +76,20 @@ export function TimeoutLoader({
 
   return (
     <View
-      className="flex-1 bg-background items-center justify-center"
+      className="flex-1 bg-background items-center justify-center px-6"
       testID={testID}
     >
       <ActivityIndicator size="large" />
+      {loadingLabel ? (
+        <Text className="text-h3 font-semibold text-text-primary text-center mt-4">
+          {loadingLabel}
+        </Text>
+      ) : null}
+      {loadingDescription ? (
+        <Text className="text-body-sm text-text-secondary text-center mt-2">
+          {loadingDescription}
+        </Text>
+      ) : null}
     </View>
   );
 }

--- a/docs/deployment-and-secrets.md
+++ b/docs/deployment-and-secrets.md
@@ -13,8 +13,8 @@ How CI/CD pipelines, secret management, and deployments work across all three en
 
 ┌─────────────┐         ┌──────────────────┐        ┌─────────────────────┐
 │  CLOUDFLARE │────────▶│  Workers Runtime │───────▶│  Staging / Prod API │
-│  (secrets)  │         │  env bindings    │        │  mentomate-api-stg  │
-└─────────────┘         └──────────────────┘        │  mentomate-api-prd  │
+│  (secrets)  │         │  env bindings    │        │  custom domains     │
+└─────────────┘         └──────────────────┘        │  api*.mentomate.com │
                                                     └─────────────────────┘
 ```
 
@@ -90,11 +90,11 @@ Push to main
 ┌─────────────────────────────────────────┐
 │  api-quality-gate                       │
 │  ├─ Spins up PostgreSQL 16 (test DB)    │
-│  ├─ pnpm install + db:push (test DB)   │
+│  ├─ pnpm install + db:migrate (test DB)│
 │  ├─ Lint (nx run api:lint)             │
 │  ├─ Typecheck (nx run api:typecheck)   │
-│  ├─ Unit tests (nx run api:test)       │
-│  └─ Integration tests (api:test:integ) │
+│  └─ Push-to-main skips unit/integration │
+│     here because PR CI already ran them │
 └──────────────┬──────────────────────────┘
                │ all pass
                ▼
@@ -102,8 +102,16 @@ Push to main
 │  api-deploy                             │
 │  ├─ environment: staging (auto-approve) │
 │  ├─ nx run api:build                   │
+│  ├─ verify DB target + db:migrate      │
 │  └─ wrangler deploy --env staging      │
 │     → deploys "mentomate-api-stg"      │
+└─────────────────────────────────────────┘
+               │ deployed
+               ▼
+┌─────────────────────────────────────────┐
+│  api-smoke-test                         │
+│  └─ GET https://api-stg.mentomate.com   │
+│     /v1/health plus auth route checks   │
 └─────────────────────────────────────────┘
 ```
 
@@ -114,8 +122,9 @@ Secrets come from **three sources**:
 1. **Non-sensitive vars** — committed in `wrangler.toml` under `[env.staging.vars]`:
    ```toml
    ENVIRONMENT = "staging"
-   APP_URL = "https://staging.mentomate.com"
-   LOG_LEVEL = "debug"
+   APP_URL = "https://www.mentomate.com"
+   API_ORIGIN = "https://api-stg.mentomate.com"
+   LOG_LEVEL = "warn"
    EMAIL_FROM = "staging-noreply@mentomate.com"
    ```
 
@@ -134,6 +143,10 @@ Secrets come from **three sources**:
 ### Worker name
 
 `mentomate-api-stg`
+
+### Public URL
+
+`https://api-stg.mentomate.com`
 
 ### KV namespaces
 
@@ -174,8 +187,16 @@ Manual dispatch (api_environment=production)
 ┌─────────────────────────────────────────┐
 │  api-deploy                             │
 │  ├─ nx run api:build                   │
+│  ├─ verify DB target + db:migrate      │
 │  └─ wrangler deploy --env production   │
 │     → deploys "mentomate-api-prd"      │
+└─────────────────────────────────────────┘
+               │ deployed
+               ▼
+┌─────────────────────────────────────────┐
+│  api-production-smoke-test              │
+│  └─ GET https://api.mentomate.com       │
+│     /v1/health                          │
 └─────────────────────────────────────────┘
 ```
 
@@ -183,7 +204,7 @@ Manual dispatch (api_environment=production)
 
 Same pattern as staging:
 
-- **`[env.production.vars]`** in `wrangler.toml`: `APP_URL=https://app.mentomate.com`, `LOG_LEVEL=info`, `EMAIL_FROM=noreply@mentomate.com`
+- **`[env.production.vars]`** in `wrangler.toml`: `APP_URL=https://www.mentomate.com`, `API_ORIGIN=https://api.mentomate.com`, `LOG_LEVEL=info`, `EMAIL_FROM=noreply@mentomate.com`
 - **Workers Secrets**: synced from Doppler `prd` config via `pnpm secrets:sync prd`
 - **GitHub Actions secret**: `DATABASE_URL_PRODUCTION` is used for production migrations in `deploy.yml`
 
@@ -193,10 +214,18 @@ Same pattern as staging:
 
 - `CLERK_SECRET_KEY`
 - `CLERK_JWKS_URL`
+- `CLERK_AUDIENCE`
 - `GEMINI_API_KEY`
 - `VOYAGE_API_KEY`
 - `RESEND_API_KEY`
+- `RESEND_WEBHOOK_SECRET`
+- `API_ORIGIN`
 - `REVENUECAT_WEBHOOK_SECRET`
+
+Production also requires the `IDEMPOTENCY_KV` binding unless Doppler `prd`
+explicitly sets `ALLOW_MISSING_IDEMPOTENCY_KV=true` as a temporary prelaunch
+override. Without the binding or override, env validation returns a 500 before
+serving traffic.
 
 ### Approval gate
 
@@ -207,6 +236,10 @@ Same pattern as staging:
 ### Worker name
 
 `mentomate-api-prd`
+
+### Public URL
+
+`https://api.mentomate.com`
 
 ### KV namespaces
 
@@ -219,9 +252,9 @@ Same pattern as staging:
 
 ## Database Schema Rollouts
 
-Cloudflare Worker deploys do **not** update the Neon schema. New columns,
-tables, indexes, or constraints must be applied to the target database
-separately from `wrangler deploy`.
+Cloudflare Worker deploys do **not** update the Neon schema by themselves.
+The GitHub deploy workflow applies committed migrations to the selected target
+database before `wrangler deploy`; direct local `wrangler deploy` does not.
 
 ### What each command is for
 
@@ -230,24 +263,26 @@ separately from `wrangler deploy`.
 - **Important:** a green API build or mobile build does **not** mean the target
   Neon database is ready for the new code.
 
-### Current workflow caveat
+### Current workflow
 
-`.github/workflows/deploy.yml` validates the API against an ephemeral Postgres
-service, but it does **not** currently apply staging or production migrations
-to the real Neon database. Until that is automated, treat DB migration as a
-required manual release step.
+`.github/workflows/deploy.yml` validates committed migration SQL against an
+ephemeral Postgres service, verifies the target Neon host, baselines the
+migration journal when needed, and then runs `drizzle-kit migrate` against the
+selected staging or production database before deploying the Worker.
 
 ### Release checklist when schema changes
 
 1. Generate and commit the migration SQL under `apps/api/drizzle/`.
-2. Point `DATABASE_URL` at the target environment and run
-   `pnpm --filter @eduagent/database db:migrate`.
-3. **Verify migration succeeded** before proceeding — new columns must exist
+2. Prefer `.github/workflows/deploy.yml`, which applies the target migration
+   before deploying the Worker.
+3. If deploying outside the workflow, point `DATABASE_URL` at the target
+   environment and run `pnpm --filter @eduagent/database db:migrate`.
+4. **Verify migration succeeded** before proceeding — new columns must exist
    before the Workers bundle that references them is deployed. A deploy-first
    ordering causes `column "..." does not exist` 500s on every affected route.
-4. Deploy the API worker with `wrangler deploy`.
-5. Rebuild or at least re-test the mobile app if the API contract changed.
-6. Check Sentry and the affected API route immediately after rollout for
+5. Deploy the API worker with `wrangler deploy`.
+6. Rebuild or at least re-test the mobile app if the API contract changed.
+7. Check Sentry and the affected API route immediately after rollout for
    `column "... does not exist"` or similar schema drift errors.
 
 ### Known migration-to-code dependencies
@@ -304,7 +339,7 @@ Store submission:   eas build --profile production → AAB  → Google Play Cons
                                                    → IPA  → App Store Connect
 ```
 
-After a successful production build, `eas submit` can automatically upload the AAB/IPA to the respective store — but both store accounts must be active first (currently blocked: Apple enrollment pending, Google Play account under review).
+After a successful production build, `eas submit` can upload the AAB/IPA to the respective store. Apple Developer and Google Play access is available as of 2026-05-15; the remaining work is to create the App Store Connect / Play Console app records and provide the real submit metadata.
 
 ### Build profiles (`apps/mobile/eas.json`)
 
@@ -363,16 +398,24 @@ These values are synced from Doppler (dev/stg/prd configs) into the correspondin
 
 The only GitHub secret needed for CI-triggered builds is `EXPO_TOKEN` (authenticates `eas build`).
 
+`apps/mobile/app.json` has the Sentry Expo plugin configured with
+`uploadSourceMaps: true`, but every committed EAS profile currently sets
+`SENTRY_DISABLE_AUTO_UPLOAD=true`. That means source-map upload is intentionally
+disabled until Sentry auth/project upload credentials are ready; do not remove
+the flag casually.
+
 ### API URL mapping
 
 Each EAS build profile points to the correct environment-specific Cloudflare Worker:
 
 | EAS Profile | Worker | URL |
 |-------------|--------|-----|
-| `preview` | `mentomate-api-stg` | `https://mentomate-api-stg.zwizzly.workers.dev` |
-| `production` | `mentomate-api-prd` | `https://mentomate-api-prd.zwizzly.workers.dev` |
+| `preview` | `mentomate-api-stg` | `https://api-stg.mentomate.com` |
+| `production` | `mentomate-api-prd` | `https://api.mentomate.com` |
 
-The fallback URL in `apps/mobile/src/lib/api.ts` (used when no env var is set in a non-dev build) also points to the staging worker.
+The fallback URL in `apps/mobile/src/lib/api.ts` is dev-only. Production builds
+fail fast if `EXPO_PUBLIC_API_URL` is missing instead of silently talking to
+staging.
 
 ### Local development
 
@@ -482,10 +525,12 @@ All secrets managed in Doppler (project: `mentomate`, configs: `dev` / `stg` / `
 | **Auth (Clerk)** | `CLERK_SECRET_KEY` | Yes |
 | | `CLERK_PUBLISHABLE_KEY` | No |
 | | `CLERK_JWKS_URL` | Yes |
-| | `CLERK_AUDIENCE` | No |
+| | `CLERK_AUDIENCE` | Yes |
 | **LLM** | `GEMINI_API_KEY` | Yes |
 | | `VOYAGE_API_KEY` | Yes |
 | **Email** | `RESEND_API_KEY` | Yes |
+| | `RESEND_WEBHOOK_SECRET` | Yes |
+| **API** | `API_ORIGIN` | Yes |
 | **Payments** | `REVENUECAT_WEBHOOK_SECRET` | Yes |
 | | `STRIPE_SECRET_KEY` | No (dormant) |
 | | `STRIPE_WEBHOOK_SECRET` | No (dormant) |
@@ -495,6 +540,7 @@ All secrets managed in Doppler (project: `mentomate`, configs: `dev` / `stg` / `
 | | `INNGEST_EVENT_KEY` | No |
 | **Observability** | `SENTRY_DSN` | No |
 | **Testing** | `TEST_SEED_SECRET` | No (dev/staging only) |
+| **Prelaunch override** | `ALLOW_MISSING_IDEMPOTENCY_KV` | Only if temporarily launching without the production KV binding |
 
 GitHub Actions secrets (set in GitHub, not Doppler):
 
@@ -503,6 +549,10 @@ GitHub Actions secrets (set in GitHub, not Doppler):
 | `CLOUDFLARE_API_TOKEN` | `deploy.yml` — authenticates `wrangler deploy` |
 | `DATABASE_URL_STAGING` | `deploy.yml` — staging Neon migrations before staging deploys |
 | `DATABASE_URL_PRODUCTION` | `deploy.yml` — production Neon migrations before production deploys |
+| `DATABASE_URL_STAGING_HOST` | `deploy.yml` — expected host guard for staging DB target verification |
+| `DATABASE_URL_PRODUCTION_HOST` | `deploy.yml` — expected host guard for production DB target verification |
+| `STAGING_API_URL` | Optional deploy smoke override; defaults to `https://api-stg.mentomate.com` |
+| `PRODUCTION_API_URL` | Optional deploy smoke override; defaults to `https://api.mentomate.com` |
 | `EXPO_TOKEN` | `deploy.yml`, `mobile-ci.yml` — authenticates EAS CLI |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` — AI review |
 | `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` | `e2e-ci.yml` — Clerk auth in E2E tests |
@@ -574,9 +624,9 @@ If wrangler is not authenticated, the sync skips gracefully (does not break `pnp
 | **Secret source** | Doppler → local files + Worker | Doppler → Worker via sync script | Doppler → Worker via sync script |
 | **Secret truth** | Doppler `dev` config | Doppler `stg` config | Doppler `prd` config |
 | **Sync command** | `pnpm env:sync` (auto on install) | `pnpm secrets:sync stg` | `pnpm secrets:sync prd` |
-| **Approval gate** | None | None (auto after tests) | GitHub Environment rule |
+| **Approval gate** | None | None (auto after quality gate) | GitHub Environment rule |
 | **Worker name** | `mentomate-api-dev` | `mentomate-api-stg` | `mentomate-api-prd` |
-| **Config validation** | Zod parse (lenient) | Zod parse (lenient) | Zod + required keys check |
+| **Config validation** | Zod parse (lenient) | Zod + Clerk auth keys | Zod + production required keys + production binding gate |
 | **Deploy command** | `wrangler dev` | `wrangler deploy --env staging` | `wrangler deploy --env production` |
 
 ### Mobile (EAS Build)

--- a/docs/pre-launch-checklist.md
+++ b/docs/pre-launch-checklist.md
@@ -3,7 +3,7 @@
 Consolidated checklist of everything that must be done before MentoMate goes live.
 Items are grouped by category and ordered by priority within each group.
 
-Last updated: 2026-04-20
+Last updated: 2026-05-15
 
 ---
 
@@ -15,14 +15,14 @@ Last updated: 2026-04-20
   - Ref: `deploy.yml` `api-confirm-production` job uses `environment: production`
 
 - [ ] **Verify production worker deploys successfully**
-  - Run `wrangler deploy --env production` at least once (or trigger via `workflow_dispatch`)
-  - Confirm `mentomate-api-prd.zwizzly.workers.dev` responds
+  - Trigger `.github/workflows/deploy.yml` with `api_environment: production`
+  - Confirm `https://api.mentomate.com/v1/health` responds after approval
   - Verify Cloudflare account/org is correct for production
 
 - [ ] **Sync all production secrets to Cloudflare Worker**
   - Verify Doppler `prd` config has every required key (see list below)
   - Run `pnpm secrets:sync prd` or ensure `DOPPLER_TOKEN` is set in GitHub Actions
-  - After sync, verify: `curl https://mentomate-api-prd.zwizzly.workers.dev/v1/health`
+  - After sync, verify: `curl https://api.mentomate.com/v1/health`
 
 - [ ] **Production secrets checklist** (all must be in Doppler `prd`):
   - [ ] `CLERK_SECRET_KEY` — from Clerk Dashboard (production app)
@@ -31,55 +31,66 @@ Last updated: 2026-04-20
   - [ ] `GEMINI_API_KEY` — Google AI Studio
   - [ ] `VOYAGE_API_KEY` — Voyage AI (embeddings)
   - [ ] `RESEND_API_KEY` — Resend (transactional email)
-  - [ ] `API_ORIGIN` — `https://mentomate-api-prd.zwizzly.workers.dev` (or custom domain)
+  - [ ] `RESEND_WEBHOOK_SECRET` — Resend webhook signing secret
+  - [ ] `API_ORIGIN` — `https://api.mentomate.com`
   - [ ] `REVENUECAT_WEBHOOK_SECRET` — from RevenueCat (after store connections)
   - [ ] `DATABASE_URL` — Neon production branch connection string
+  - [ ] `ALLOW_MISSING_IDEMPOTENCY_KV` — only set to `true` if production must launch before `IDEMPOTENCY_KV` is bound
   - [ ] `ANTHROPIC_API_KEY` — optional, for premium tier
 
 - [ ] **Verify GitHub Actions secrets**:
   - [ ] `CLOUDFLARE_API_TOKEN`
   - [ ] `DATABASE_URL_STAGING`
   - [ ] `DATABASE_URL_PRODUCTION`
+  - [ ] `DATABASE_URL_STAGING_HOST`
+  - [ ] `DATABASE_URL_PRODUCTION_HOST`
   - [ ] `EXPO_TOKEN`
   - [ ] `DOPPLER_TOKEN` (needed for automatic secret sync in deploy workflow)
+  - [ ] `STAGING_API_URL` — optional override; defaults to `https://api-stg.mentomate.com`
+  - [ ] `PRODUCTION_API_URL` — optional override; defaults to `https://api.mentomate.com`
 
-- [ ] **Run production database migration**
-  - `deploy.yml` does NOT auto-migrate — this is a manual step
-  - Point `DATABASE_URL` at production Neon and run `pnpm --filter @eduagent/database db:migrate`
-  - Verify migration succeeded BEFORE deploying the Workers bundle
+- [ ] **Verify production database migration path**
+  - `deploy.yml` runs committed migrations against the selected target after DB host verification and before `wrangler deploy`
+  - Do not run `drizzle-kit push` against staging or production
+  - If deploying outside `deploy.yml`, point `DATABASE_URL` at production Neon and run `pnpm --filter @eduagent/database db:migrate` before deploying the Workers bundle
 
 - [ ] **Verify KV namespace bindings** in `wrangler.toml [env.production]`:
   - `SUBSCRIPTION_KV`: `cde9f81f19a34022b6dc6951928a0511`
   - `COACHING_KV`: `76b36f4748fe4d77b27387a5bebf4be6`
+  - `IDEMPOTENCY_KV`: create and bind before launch, or explicitly set the temporary `ALLOW_MISSING_IDEMPOTENCY_KV=true` override in Doppler `prd`
 
 ---
 
 ## Store Publishing
 
-- [ ] **Apple Developer Program enrollment approved**
-  - Applied ~2026-03-13, pending
+- [x] **Apple Developer Program access available** — resolved 2026-05-15
   - Required for: App Store submission, iOS IAP testing via StoreKit 2
 
-- [ ] **Google Play Developer account restored**
-  - Account `zwizzly.app@gmail.com` disabled 2026-03-26, appeal submitted
-  - Fallback: register new account (14-day closed testing gate, 12+ testers)
+- [x] **Google Play Developer account access available** — resolved 2026-05-15
+  - Continue with Play Console app setup and closed-testing requirements
 
 - [ ] **RevenueCat store connections**
   - [ ] Connect Google Play (service account JSON from Play Console)
-  - [ ] Connect App Store (after Apple enrollment)
+  - [ ] Connect App Store
   - [ ] Create products in both stores matching `PRODUCT_TIER_MAP` exactly:
     - `com.eduagent.plus.monthly` / `.yearly` (+ `.android` variants)
     - `com.eduagent.family.monthly` / `.yearly` (+ `.android` variants)
     - `com.eduagent.pro.monthly` / `.yearly` (+ `.android` variants)
     - `com.eduagent.topup.500` (+ `.android` variant)
   - [ ] Create offerings with 6 subscription packages + 1 consumable
-  - [ ] Configure webhook URL → `https://<production-api>/v1/revenuecat/webhook`
+  - [ ] Configure webhook URL → `https://api.mentomate.com/v1/revenuecat/webhook`
   - [ ] Add to Doppler `prd`: `REVENUECAT_WEBHOOK_SECRET`, `EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID`, `EXPO_PUBLIC_REVENUECAT_API_KEY_IOS`
 
 - [ ] **EAS production build**
   - Build with `eas build --platform all --profile production`
-  - Verify `EXPO_PUBLIC_API_URL` points to production worker
+  - Verify `EXPO_PUBLIC_API_URL` points to `https://api.mentomate.com`
   - Verify `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` is the live key
+  - Verify `EXPO_PUBLIC_REVENUECAT_API_KEY_ANDROID` and `EXPO_PUBLIC_REVENUECAT_API_KEY_IOS` are present after running `pnpm env:sync`
+  - Source-map upload is currently disabled by `SENTRY_DISABLE_AUTO_UPLOAD=true`; keep it intentional or configure Sentry auth before enabling upload
+
+- [ ] **EAS submit production profile**
+  - `apps/mobile/eas.json` intentionally contains no fake Apple/App Store Connect IDs
+  - After App Store Connect and Play Console app records exist, add the real submit metadata or provide it during `eas submit`
 
 ---
 
@@ -139,8 +150,8 @@ Ref: `docs/superpowers/plans/2026-04-19-pre-launch-ux-fixes.md`
 
 - [ ] **Health check all environments**
   - `curl https://mentomate-api-dev.zwizzly.workers.dev/v1/health`
-  - `curl https://mentomate-api-stg.zwizzly.workers.dev/v1/health`
-  - `curl https://mentomate-api-prd.zwizzly.workers.dev/v1/health`
+  - `curl https://api-stg.mentomate.com/v1/health`
+  - `curl https://api.mentomate.com/v1/health`
   - All should return `{"status":"ok"}` with non-empty `llm.providers`
 
 - [ ] **End-to-end smoke test on production**
@@ -165,5 +176,5 @@ Ref: `docs/superpowers/plans/2026-04-19-pre-launch-ux-fixes.md`
 - [x] EP15-I2: `vocabularyLearned` rename — RESOLVED 2026-04-19. Schema fully uses `vocabularyTotal`. Mobile label changed to "Total words". Monthly report delta computed correctly.
 - [x] EP15-I5: Parent-access denial returns null instead of 403 — RESOLVED 2026-04-19. `assertParentAccess` throws `ForbiddenError` → global handler returns HTTP 403. All 10 dashboard child-scoped endpoints protected.
 - [ ] Missing mobile screens (3E.1-3E.4): teach-back, evaluate-challenge, word summaries, decay viz
-- [ ] Epic 17: Voice Input (~2-3 weeks, stores blocked anyway)
-- [ ] Custom domain for production API (instead of `.workers.dev`)
+- [ ] Epic 17: Voice Input (~2-3 weeks)
+- [x] Custom domain for production API — `https://api.mentomate.com`


### PR DESCRIPTION
## Summary
- Address release/prepublish readiness blockers across deploy config, E2E readiness, mobile timeout handling, and release docs.
- Rebased onto current main so it includes the updated mobile receipt gate.
- Resolved the W-05 navigation spec overlap by keeping the current progress title and the stronger More-tab row checks.

## Push notes
- Normal push was attempted first and was blocked by the updated mobile receipt gate because this branch's receipt did not cover its affected mobile files.
- Used the requested workaround to publish the rebased branch without adding another receipt/amend cycle.

## Validation from commit
- focused mobile readiness tests noted in commit
- pnpm exec tsc -p apps/mobile/tsconfig.json --noEmit noted in commit
