### PR TITLE
Tune parent starter cards

### DIFF
--- a/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
@@ -175,6 +175,21 @@ async function waitForParentTransitionNotice(): Promise<void> {
   });
 }
 
+function resolvedBackgroundColor(testID: string): unknown {
+  const style = screen.getByTestId(testID).props.style as unknown;
+  const resolved = (
+    typeof style === 'function' ? style({ pressed: false }) : style
+  ) as
+    | Record<string, unknown>
+    | Array<Record<string, unknown> | null | undefined>;
+
+  if (Array.isArray(resolved)) {
+    return resolved.find((entry) => entry?.backgroundColor)?.backgroundColor;
+  }
+
+  return resolved?.backgroundColor;
+}
+
 describe('ParentHomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -324,6 +339,13 @@ describe('ParentHomeScreen', () => {
     expect(
       screen.queryByText('Emma: What made Fractions click today?'),
     ).toBeNull();
+    expect(
+      new Set([
+        resolvedBackgroundColor('parent-home-tonight-child-a-primary'),
+        resolvedBackgroundColor('parent-home-tonight-child-a-trickiest'),
+        resolvedBackgroundColor('parent-home-tonight-child-a-tomorrow'),
+      ]).size,
+    ).toBe(3);
     screen.getByText('Fractions · 18 min this week');
     screen.getByText('Emma · 18 min this week');
     screen.getByText('2 of 5 profiles used');

--- a/apps/mobile/src/components/home/ParentHomeScreen.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.tsx
@@ -26,7 +26,12 @@ import {
 import { getGreeting, getTimeOfDay } from '../../lib/greeting';
 import { platformAlert } from '../../lib/platform-alert';
 import { useLinkedChildren } from '../../lib/profile';
-import { useThemeColors } from '../../lib/theme';
+import { useTheme, useThemeColors } from '../../lib/theme';
+import { getSubjectTintMap } from '../../lib/subject-tints';
+import {
+  SUBJECT_TINT_PALETTE,
+  type SubjectTint,
+} from '../../lib/design-tokens';
 import { MentomateLogo } from '../MentomateLogo';
 import {
   WithdrawalCountdownBanner,
@@ -694,6 +699,7 @@ export function ParentHomeScreen({
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
+  const { colorScheme } = useTheme();
   const role = useActiveProfileRole();
   const linkedChildren = useLinkedChildren();
   const { data: dashboard } = useDashboard();
@@ -798,6 +804,32 @@ export function ParentHomeScreen({
       }),
     });
   }
+  const tonightPrompts = useMemo(
+    () => buildTonightPrompts(linkedChildren, dashboard, t),
+    [linkedChildren, dashboard, t],
+  );
+  const promptTintsByKey = useMemo(() => {
+    const tints = new Map<string, SubjectTint>();
+    const palette = SUBJECT_TINT_PALETTE[colorScheme];
+
+    if (linkedChildren.length === 1) {
+      tonightPrompts.forEach((prompt, index) => {
+        const tint = palette[index % palette.length] ?? palette[0];
+        if (tint) tints.set(prompt.key, tint);
+      });
+      return tints;
+    }
+
+    const childTintsById = getSubjectTintMap(
+      tonightPrompts.map((prompt) => prompt.childId),
+      colorScheme,
+    );
+    tonightPrompts.forEach((prompt) => {
+      const tint = childTintsById.get(prompt.childId);
+      if (tint) tints.set(prompt.key, tint);
+    });
+    return tints;
+  }, [colorScheme, linkedChildren.length, tonightPrompts]);
 
   const navigateToCreateChildProfile = useCallback(() => {
     if (Platform.OS === 'web') {
@@ -906,8 +938,8 @@ export function ParentHomeScreen({
 
   return (
     <View className="flex-1 bg-background" testID="parent-home-screen">
-      <View className="px-5" style={{ paddingTop: insets.top + 12 }}>
-        <View className="flex-row items-center justify-between mb-3">
+      <View className="px-5" style={{ paddingTop: insets.top + 4 }}>
+        <View className="flex-row items-center justify-between mb-2">
           <MentomateLogo size="sm" orientation="horizontal" />
           <Pressable
             onPress={() => router.push('/(app)/more/account' as Href)}
@@ -940,33 +972,37 @@ export function ParentHomeScreen({
         }}
         showsVerticalScrollIndicator={false}
       >
-        <View className="mt-4">
-          <WithdrawalCountdownBanner
-            childrenInGracePeriod={childrenInGracePeriod}
-          />
-        </View>
-        {linkedChildren.length > 0 ? (
-          <ParentTransitionNotice
-            profileId={activeProfile?.id}
-            childNames={childNames}
-          />
+        {childrenInGracePeriod.length > 0 ? (
+          <View className="mt-3">
+            <WithdrawalCountdownBanner
+              childrenInGracePeriod={childrenInGracePeriod}
+            />
+          </View>
         ) : null}
 
         {linkedChildren.length > 0 ? (
-          <View className="mt-5" testID="parent-home-tonight-section">
+          <View className="mt-4" testID="parent-home-tonight-section">
             <Text className="text-h3 font-bold text-text-primary mb-3">
               {t(tonightTitleKey(now))}
             </Text>
             <View style={{ gap: 10 }}>
-              {buildTonightPrompts(linkedChildren, dashboard, t).map(
-                (prompt) => (
+              <ParentTransitionNotice
+                profileId={activeProfile?.id}
+                childNames={childNames}
+              />
+              {tonightPrompts.map((prompt) => {
+                const tint = promptTintsByKey.get(prompt.key);
+                return (
                   <Pressable
                     key={`tonight-${prompt.key}`}
                     onPress={() => pushChildProgress(prompt.childId)}
-                    className="bg-coaching-card rounded-card px-4 py-3 flex-row items-start"
-                    style={
-                      Platform.OS === 'web' ? { cursor: 'pointer' } : undefined
-                    }
+                    className="rounded-card px-4 py-3 flex-row items-start"
+                    style={({ pressed }) => ({
+                      backgroundColor: tint?.soft ?? colors.coachingCard,
+                      borderColor: tint ? tint.solid + '33' : colors.border,
+                      borderWidth: 1,
+                      opacity: pressed ? 0.76 : 1,
+                    })}
                     accessibilityRole="button"
                     accessibilityLabel={prompt.text}
                     testID={`parent-home-tonight-${prompt.key}`}
@@ -974,15 +1010,15 @@ export function ParentHomeScreen({
                     <Ionicons
                       name="chatbubble-outline"
                       size={18}
-                      color={colors.textSecondary}
+                      color={tint?.solid ?? colors.textSecondary}
                       style={{ marginTop: 2 }}
                     />
                     <Text className="text-body-sm text-text-primary ms-3 flex-1">
                       {prompt.text}
                     </Text>
                   </Pressable>
-                ),
-              )}
+                );
+              })}
             </View>
           </View>
         ) : null}

--- a/apps/mobile/src/components/home/ParentTransitionNotice.tsx
+++ b/apps/mobile/src/components/home/ParentTransitionNotice.tsx
@@ -49,7 +49,7 @@ export function ParentTransitionNotice({
 
   return (
     <View
-      className="bg-primary-soft rounded-card px-4 py-3.5 mt-4"
+      className="bg-primary-soft rounded-card px-4 py-3.5"
       testID="parent-transition-notice"
       accessibilityRole="alert"
     >

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -177,7 +177,7 @@
       },
       "encouragementNote": "Nudges sind sanfte Ermutigungen in eine Richtung.",
       "transitionNoticeTitle": "Du begleitest jetzt {{childNames}}",
-      "transitionNoticeBody": "Tippe jederzeit auf Home, um den Fortschritt und dein eigenes Lernen zu sehen.",
+      "transitionNoticeBody": "Probiere heute Abend eine dieser Einstiegsfragen aus.",
       "cards": {
         "checkChild": "Schau nach, wie es {{childName}} geht",
         "checkChildFallback": "Tippe, um den Fortschritt dieser Woche zu sehen",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -196,7 +196,7 @@
       },
       "encouragementNote": "Nudges are gentle one-way encouragements.",
       "transitionNoticeTitle": "You're now mentoring {{childNames}}",
-      "transitionNoticeBody": "Tap Home anytime to check in on their progress and your own learning.",
+      "transitionNoticeBody": "Try one of these check-in questions tonight.",
       "cards": {
         "checkChild": "See how {{childName}} is doing",
         "checkChildFallback": "Tap to see this week's progress",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -177,7 +177,7 @@
       },
       "encouragementNote": "Los nudges son ánimos suaves de una sola dirección.",
       "transitionNoticeTitle": "Ahora guías a {{childNames}}",
-      "transitionNoticeBody": "Toca Inicio en cualquier momento para ver su progreso y tu aprendizaje.",
+      "transitionNoticeBody": "Prueba esta noche una de estas preguntas para iniciar la conversación.",
       "cards": {
         "checkChild": "Ver cómo le va a {{childName}}",
         "checkChildFallback": "Toca para ver el progreso de esta semana",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -177,7 +177,7 @@
       },
       "encouragementNote": "ナッジは短い応援メッセージです。返信は必要ありません。",
       "transitionNoticeTitle": "{{childNames}}のメンターになりました",
-      "transitionNoticeBody": "ホームをタップして、いつでも進捗と自分の学習を確認できます。",
+      "transitionNoticeBody": "今夜、この会話のきっかけを1つ試してみましょう。",
       "cards": {
         "checkChild": "{{childName}}さんの様子を見る",
         "checkChildFallback": "今週の進み具合を見る",

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -177,7 +177,7 @@
       },
       "encouragementNote": "Nudger er korte, milde oppmuntringer en vei.",
       "transitionNoticeTitle": "Du veileder nå {{childNames}}",
-      "transitionNoticeBody": "Trykk Hjem når som helst for å se fremgangen og din egen læring.",
+      "transitionNoticeBody": "Prøv et av disse innsjekkingsspørsmålene i kveld.",
       "cards": {
         "checkChild": "Se hvordan det går med {{childName}}",
         "checkChildFallback": "Trykk for å se ukens fremgang",

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -177,7 +177,7 @@
       },
       "encouragementNote": "Zachęty to krótkie, łagodne wiadomości w jedną stronę.",
       "transitionNoticeTitle": "Teraz mentorujesz {{childNames}}",
-      "transitionNoticeBody": "Naciśnij Start w dowolnym momencie, aby sprawdzić postępy i swoją naukę.",
+      "transitionNoticeBody": "Wypróbuj dziś wieczorem jedno z tych pytań na początek rozmowy.",
       "cards": {
         "checkChild": "Sprawdź, jak idzie {{childName}}",
         "checkChildFallback": "Dotknij, aby zobaczyć postępy z tego tygodnia",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -177,7 +177,7 @@
       },
       "encouragementNote": "Nudges sao incentivos breves e gentis, sem resposta obrigatoria.",
       "transitionNoticeTitle": "Agora você orienta {{childNames}}",
-      "transitionNoticeBody": "Toque em Início a qualquer momento para ver o progresso e seu aprendizado.",
+      "transitionNoticeBody": "Experimente uma destas perguntas para puxar conversa hoje à noite.",
       "cards": {
         "checkChild": "Ver como {{childName}} esta indo",
         "checkChildFallback": "Toque para ver o progresso desta semana",


### PR DESCRIPTION
## Summary
- tighten the parent home header/logo spacing and transition notice placement
- tint the tonight starter cards with distinct subject colors
- update the transition notice copy across supported locales
- add a regression check that the starter cards use distinct backgrounds

## Verification
- pnpm run check:i18n
- pnpm exec tsc --build
- pnpm --dir apps/mobile exec jest --findRelatedTests src/components/home/ParentHomeScreen.test.tsx src/components/home/ParentHomeScreen.tsx src/components/home/ParentTransitionNotice.tsx --no-coverage
- Git-for-Windows bash scripts/record-test-receipt.sh mobile
- normal git push accepted the fresh mobile receipt for 3 affected files
