### PR TITLE
Show latest report with inline history

### DIFF
--- a/apps/mobile/src/app/(app)/child/[profileId]/reports.test.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/reports.test.tsx
@@ -256,6 +256,72 @@ describe('ChildReportsScreen', () => {
       expect(screen.getAllByText('+2 vs last week').length).toBeGreaterThan(0);
     });
 
+    it('opens older weekly reports inline and can return to the latest report', () => {
+      mockUseChildWeeklyReports.mockReturnValue({
+        data: [
+          {
+            id: 'wr-latest',
+            reportWeek: '2026-05-11',
+            viewedAt: '2026-05-12T03:00:00Z',
+            createdAt: '2026-05-18T03:00:00Z',
+            headlineStat: {
+              label: 'Topics mastered',
+              value: '4',
+              comparison: '+2 vs last week',
+            },
+            thisWeek: {
+              totalSessions: 5,
+              totalActiveMinutes: 120,
+              topicsMastered: 4,
+              topicsExplored: 8,
+              vocabularyTotal: 50,
+              streakBest: 3,
+            },
+          },
+          {
+            id: 'wr-older',
+            reportWeek: '2026-05-04',
+            viewedAt: null,
+            createdAt: '2026-05-11T03:00:00Z',
+            headlineStat: {
+              label: 'Topics mastered',
+              value: '1',
+              comparison: '+1 vs last week',
+            },
+            thisWeek: {
+              totalSessions: 2,
+              totalActiveMinutes: 30,
+              topicsMastered: 1,
+              topicsExplored: 2,
+              vocabularyTotal: 10,
+              streakBest: 1,
+            },
+          },
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      });
+      mockUseChildReports.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      });
+
+      render(<ChildReportsScreen />);
+
+      screen.getByText('Topics mastered: 4');
+      fireEvent.press(screen.getByTestId('weekly-report-card-wr-older'));
+
+      screen.getByText('Topics mastered: 1');
+      screen.getByTestId('child-reports-back-to-latest');
+      expect(mockPush).not.toHaveBeenCalled();
+
+      fireEvent.press(screen.getByTestId('child-reports-back-to-latest'));
+      screen.getByText('Topics mastered: 4');
+    });
+
     it('renders report cards when reports exist', () => {
       mockUseChildReports.mockReturnValue({
         data: [

--- a/apps/mobile/src/app/(app)/child/[profileId]/reports.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/reports.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter, type Href } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -69,6 +70,7 @@ function ReportsHeaderSummary({
 }: {
   latestReport: WeeklyReportSummary | undefined;
 }): React.ReactElement | null {
+  const { t } = useTranslation();
   if (!latestReport?.headlineStat) return null;
   const { headlineStat, thisWeek } = latestReport;
   return (
@@ -88,9 +90,40 @@ function ReportsHeaderSummary({
         </Text>
       ) : null}
       {thisWeek ? (
-        <Text className="text-caption text-text-secondary mt-2">
-          {thisWeek.totalSessions} sessions · {thisWeek.totalActiveMinutes} min
-        </Text>
+        <View className="flex-row flex-wrap mt-3" style={{ gap: 18 }}>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.sessionsThisWeek')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.totalSessions}
+            </Text>
+          </View>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.timeOnApp')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.totalActiveMinutes} min
+            </Text>
+          </View>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.topicsMastered')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.topicsMastered}
+            </Text>
+          </View>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.totalWordsKnown')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.vocabularyTotal}
+            </Text>
+          </View>
+        </View>
       ) : null}
     </View>
   );
@@ -121,6 +154,9 @@ export default function ChildReportsScreen(): React.ReactElement {
     refetch: weeklyRefetch,
   } = useChildWeeklyReports(profileId);
   const childName = child?.displayName ?? t('parentView.index.yourChild');
+  const [selectedWeeklyReportId, setSelectedWeeklyReportId] = useState<
+    string | null
+  >(null);
 
   const combinedLoading = isLoading || weeklyLoading;
   const hasAnyData =
@@ -130,6 +166,26 @@ export default function ChildReportsScreen(): React.ReactElement {
   // showed neither an error banner nor a retry path. The retry handler
   // already calls both refetches, so widening this condition is sufficient.
   const combinedError = !hasAnyData && (isError || weeklyError);
+  const latestWeeklyReport = weeklyReports?.[0];
+  const selectedWeeklyReport = useMemo(() => {
+    if (!weeklyReports?.length) return undefined;
+    return (
+      weeklyReports.find((report) => report.id === selectedWeeklyReportId) ??
+      latestWeeklyReport
+    );
+  }, [latestWeeklyReport, selectedWeeklyReportId, weeklyReports]);
+  const remainingWeeklyReports = useMemo(
+    () =>
+      (weeklyReports ?? []).filter(
+        (report) => report.id !== selectedWeeklyReport?.id,
+      ),
+    [selectedWeeklyReport?.id, weeklyReports],
+  );
+  const hasOtherReports =
+    remainingWeeklyReports.length > 0 || (reports?.length ?? 0) > 0;
+  const isViewingLatestWeeklyReport =
+    !!selectedWeeklyReport &&
+    selectedWeeklyReport.id === latestWeeklyReport?.id;
 
   return (
     <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
@@ -164,7 +220,22 @@ export default function ChildReportsScreen(): React.ReactElement {
           </View>
         </View>
 
-        <ReportsHeaderSummary latestReport={weeklyReports?.[0]} />
+        <ReportsHeaderSummary latestReport={selectedWeeklyReport} />
+        {selectedWeeklyReport && !isViewingLatestWeeklyReport ? (
+          <Pressable
+            onPress={() =>
+              setSelectedWeeklyReportId(latestWeeklyReport?.id ?? null)
+            }
+            className="self-start mt-3 px-1 py-2"
+            accessibilityRole="button"
+            accessibilityLabel={t('parentView.reports.backToLatest')}
+            testID="child-reports-back-to-latest"
+          >
+            <Text className="text-body-sm font-semibold text-primary">
+              {t('parentView.reports.backToLatest')}
+            </Text>
+          </Pressable>
+        ) : null}
 
         {combinedLoading ? (
           <View className="bg-surface rounded-card p-4 mt-4">
@@ -222,11 +293,11 @@ export default function ChildReportsScreen(): React.ReactElement {
               </Pressable>
             </View>
           </View>
-        ) : hasAnyData ? (
+        ) : hasAnyData && hasOtherReports ? (
           <View className="mt-4">
             <ReportsList
               monthlyReports={reports ?? []}
-              weeklyReports={weeklyReports ?? []}
+              weeklyReports={remainingWeeklyReports}
               onPressMonthly={(reportId) => {
                 if (!profileId) return;
                 router.push({
@@ -235,12 +306,7 @@ export default function ChildReportsScreen(): React.ReactElement {
                 } as Href);
               }}
               onPressWeekly={(reportId) => {
-                if (!profileId) return;
-                router.push({
-                  pathname:
-                    '/(app)/child/[profileId]/weekly-report/[weeklyReportId]',
-                  params: { profileId, weeklyReportId: reportId },
-                } as Href);
+                setSelectedWeeklyReportId(reportId);
               }}
               showNewBadge
             />

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "Wöchentliche Momentaufnahme",
       "monthlyReport": "Monatsbericht",
       "newBadge": "Neu",
+      "backToLatest": "Zurück zum neuesten Bericht",
       "nextReportIn": "Nächster Bericht in {{timeContext}}",
       "noReportScheduled": "Kein Bericht geplant",
       "subtitle": "Monatliche und wöchentliche Lernzusammenfassungen",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -1995,6 +1995,7 @@
       "weeklySnapshot": "Weekly snapshot",
       "monthlyReport": "Monthly report",
       "newBadge": "New",
+      "backToLatest": "Back to latest report",
       "nextReportIn": "Next report in {{timeContext}}",
       "noReportScheduled": "No report scheduled",
       "subtitle": "Monthly and weekly learning summaries",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "Resumen semanal",
       "monthlyReport": "Informe mensual",
       "newBadge": "Nuevo",
+      "backToLatest": "Volver al informe más reciente",
       "nextReportIn": "Próximo informe en {{timeContext}}",
       "noReportScheduled": "No hay informe programado",
       "subtitle": "Resúmenes de aprendizaje mensuales y semanales",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "週次スナップショット",
       "monthlyReport": "月次レポート",
       "newBadge": "新規",
+      "backToLatest": "最新のレポートに戻る",
       "nextReportIn": "次のレポートまで{{timeContext}}",
       "noReportScheduled": "レポートの予定はありません",
       "subtitle": "月次および週次の学習要約",

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "Ukentlig øyeblikksbilde",
       "monthlyReport": "Månedsrapport",
       "newBadge": "Ny",
+      "backToLatest": "Tilbake til nyeste rapport",
       "nextReportIn": "Neste rapport om {{timeContext}}",
       "noReportScheduled": "Ingen rapport planlagt",
       "subtitle": "Månedlige og ukentlige læringssammendrag",

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -1950,6 +1950,7 @@
       "weeklySnapshot": "Migawka tygodniowa",
       "monthlyReport": "Raport miesięczny",
       "newBadge": "Nowy",
+      "backToLatest": "Wróć do najnowszego raportu",
       "nextReportIn": "Następny raport za {{timeContext}}",
       "noReportScheduled": "Brak zaplanowanego raportu",
       "subtitle": "Miesięczne i tygodniowe podsumowania nauki",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -1950,6 +1950,7 @@
       "weeklySnapshot": "Resumo semanal",
       "monthlyReport": "Relatório mensal",
       "newBadge": "Novo",
+      "backToLatest": "Voltar ao relatório mais recente",
       "nextReportIn": "Próximo relatório em {{timeContext}}",
       "noReportScheduled": "Nenhum relatório agendado",
       "subtitle": "Resumos de aprendizado mensais e semanais",


### PR DESCRIPTION
## Summary
- show the latest child weekly report inline at the top of the reports screen
- let older weekly reports open inline and return to the latest report
- keep monthly report navigation on the existing detail route
- add localized "Back to latest report" copy and coverage for the inline history flow

## Verification
- pnpm run check:i18n
- pnpm exec tsc --build
- pnpm --dir apps/mobile exec jest --runTestsByPath apps/mobile/src/app/(app)/child/[profileId]/reports.test.tsx --no-coverage
- Git-for-Windows bash scripts/record-test-receipt.sh mobile
- normal git push accepted the fresh mobile receipt for 2 affected files
