### PR TITLE
Fix persona copy and draft store compliance package

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -41,6 +41,7 @@ Two production dead-code branches removed 2026-04-19 in commit `970a82a5`: `AgeB
 - [project_archon_spike_merge_rule.md](project_archon_spike_merge_rule.md) — During the Archon spike, `.archon/`-only changes can be direct-merged to main. Verify delta is `.archon/`-only first.
 - [feedback_never_switch_branch.md](feedback_never_switch_branch.md) — NEVER switch branches unless user explicitly asks.
 - [feedback_parallel_agents.md](feedback_parallel_agents.md) — Parallel agents in same tree, no worktrees. Coordinator commits sequentially.
+- [feedback_agent_checkpoint_cadence.md](feedback_agent_checkpoint_cadence.md) — Long-running agents save durable checkpoints every 4 minutes; no git from subagents.
 - [feedback_fast_iteration.md](feedback_fast_iteration.md) — 60-min feedback loops unacceptable. CI gates, but optimize speed.
 - [feedback_fix_verification_rules.md](feedback_fix_verification_rules.md) — Changed ≠ verified. Break tests, finding IDs, no silent recovery.
 - [feedback_sweep_for_same_bug.md](feedback_sweep_for_same_bug.md) — When a bug could be pattern-shaped, sweep the codebase for sibling instances before declaring done. **Direct precursor of CLAUDE.md `Sweep when you fix` rule (added 2026-05-03); strengthened 2026-05-12.**

--- a/.claude/memory/feedback_agent_checkpoint_cadence.md
+++ b/.claude/memory/feedback_agent_checkpoint_cadence.md
@@ -1,0 +1,16 @@
+---
+name: Agent checkpoint cadence
+description: Parallel/subagents should save durable progress checkpoints every four minutes so investigation and implementation work does not live only in chat.
+type: feedback
+---
+
+When dispatching any long-running agent or subagent, explicitly instruct it to save a durable checkpoint at least every 4 minutes.
+
+**Why:** A 2026-05-15 investigation lost practical momentum because two read-only subagents returned useful findings only in chat. The repo stayed clean, so there was no file artifact to resume from if the thread/context failed or the user wanted the work preserved.
+
+**How to apply:**
+- Do not make subagents commit, stage, or push by default. The no-git rule in `feedback_agents_commit_push.md` still wins.
+- For implementation agents, "save" means write actual code/test/docs changes to their assigned files as they work, plus report modified paths.
+- For research/review/explorer agents, "save" means write a short checkpoint note to a coordinator-approved durable file, such as a task-specific doc under `docs/audit/`, `docs/plans/`, or a scratch checkpoint path provided in the prompt.
+- If no checkpoint file is appropriate, the coordinator should create or name one before dispatching agents.
+- For work expected to finish in under 4 minutes, a final report is enough. For anything longer, agents should checkpoint partial findings every 4 minutes and include the latest checkpoint path in their final message.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S1-rung1-teach-new.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S1-rung1-teach-new.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S10-first-encounter-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S10-first-encounter-topic-turn0.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S11-first-encounter-topic-turn1.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S11-first-encounter-topic-turn1.md
@@ -95,7 +95,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S12-first-encounter-topic-turn3.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S12-first-encounter-topic-turn3.md
@@ -103,7 +103,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -122,7 +122,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S13-first-session-subject-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S13-first-session-subject-turn0.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S14-returning-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S14-returning-topic-turn0.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S15-review-mode-opener.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S15-review-mode-opener.md
@@ -86,7 +86,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -105,7 +105,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S16-app-help-notes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S16-app-help-notes.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S17-app-help-preferences.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S17-app-help-preferences.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S18-app-help-modes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S18-app-help-modes.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S19-app-help-memory.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S19-app-help-memory.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S2-rung2-revisit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S2-rung2-revisit.md
@@ -95,7 +95,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S3-rung3-evaluate.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S3-rung3-evaluate.md
@@ -98,7 +98,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -117,7 +117,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S4-rung4-teach-back.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S4-rung4-teach-back.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S5-rung5-exit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S5-rung5-exit.md
@@ -105,7 +105,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -124,7 +124,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S6-homework-help.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S6-homework-help.md
@@ -94,7 +94,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S8-casual-freeform.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S8-casual-freeform.md
@@ -85,7 +85,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -104,7 +104,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S9-correct-streak.md
+++ b/apps/api/eval-llm/snapshots/exchanges/11yo-czech-animals__S9-correct-streak.md
@@ -115,7 +115,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -134,7 +134,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S1-rung1-teach-new.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S1-rung1-teach-new.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S10-first-encounter-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S10-first-encounter-topic-turn0.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S11-first-encounter-topic-turn1.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S11-first-encounter-topic-turn1.md
@@ -95,7 +95,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S12-first-encounter-topic-turn3.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S12-first-encounter-topic-turn3.md
@@ -103,7 +103,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -122,7 +122,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S13-first-session-subject-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S13-first-session-subject-turn0.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S14-returning-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S14-returning-topic-turn0.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S15-review-mode-opener.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S15-review-mode-opener.md
@@ -86,7 +86,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -105,7 +105,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S16-app-help-notes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S16-app-help-notes.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S17-app-help-preferences.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S17-app-help-preferences.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S18-app-help-modes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S18-app-help-modes.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S19-app-help-memory.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S19-app-help-memory.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S2-rung2-revisit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S2-rung2-revisit.md
@@ -95,7 +95,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S3-rung3-evaluate.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S3-rung3-evaluate.md
@@ -98,7 +98,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -117,7 +117,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S4-rung4-teach-back.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S4-rung4-teach-back.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S5-rung5-exit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S5-rung5-exit.md
@@ -105,7 +105,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -124,7 +124,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S6-homework-help.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S6-homework-help.md
@@ -94,7 +94,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S8-casual-freeform.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S8-casual-freeform.md
@@ -85,7 +85,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -104,7 +104,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S9-correct-streak.md
+++ b/apps/api/eval-llm/snapshots/exchanges/12yo-dinosaurs__S9-correct-streak.md
@@ -115,7 +115,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -134,7 +134,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S1-rung1-teach-new.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S1-rung1-teach-new.md
@@ -90,7 +90,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S10-first-encounter-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S10-first-encounter-topic-turn0.md
@@ -90,7 +90,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S11-first-encounter-topic-turn1.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S11-first-encounter-topic-turn1.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S12-first-encounter-topic-turn3.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S12-first-encounter-topic-turn3.md
@@ -109,7 +109,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -128,7 +128,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S13-first-session-subject-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S13-first-session-subject-turn0.md
@@ -90,7 +90,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S14-returning-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S14-returning-topic-turn0.md
@@ -90,7 +90,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S15-review-mode-opener.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S15-review-mode-opener.md
@@ -92,7 +92,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -111,7 +111,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S16-app-help-notes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S16-app-help-notes.md
@@ -99,7 +99,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S17-app-help-preferences.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S17-app-help-preferences.md
@@ -99,7 +99,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S18-app-help-modes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S18-app-help-modes.md
@@ -99,7 +99,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S19-app-help-memory.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S19-app-help-memory.md
@@ -99,7 +99,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S2-rung2-revisit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S2-rung2-revisit.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S3-rung3-evaluate.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S3-rung3-evaluate.md
@@ -104,7 +104,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -123,7 +123,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S4-rung4-teach-back.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S4-rung4-teach-back.md
@@ -107,7 +107,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -126,7 +126,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S5-rung5-exit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S5-rung5-exit.md
@@ -111,7 +111,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -130,7 +130,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S6-homework-help.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S6-homework-help.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S7-language-fluency.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S7-language-fluency.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S8-casual-freeform.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S8-casual-freeform.md
@@ -91,7 +91,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -110,7 +110,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S9-correct-streak.md
+++ b/apps/api/eval-llm/snapshots/exchanges/13yo-spanish-beginner__S9-correct-streak.md
@@ -121,7 +121,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -140,7 +140,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S1-rung1-teach-new.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S1-rung1-teach-new.md
@@ -84,7 +84,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S10-first-encounter-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S10-first-encounter-topic-turn0.md
@@ -84,7 +84,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S11-first-encounter-topic-turn1.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S11-first-encounter-topic-turn1.md
@@ -95,7 +95,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S12-first-encounter-topic-turn3.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S12-first-encounter-topic-turn3.md
@@ -103,7 +103,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -122,7 +122,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S13-first-session-subject-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S13-first-session-subject-turn0.md
@@ -84,7 +84,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S14-returning-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S14-returning-topic-turn0.md
@@ -84,7 +84,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S15-review-mode-opener.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S15-review-mode-opener.md
@@ -86,7 +86,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -105,7 +105,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S16-app-help-notes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S16-app-help-notes.md
@@ -93,7 +93,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S17-app-help-preferences.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S17-app-help-preferences.md
@@ -93,7 +93,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S18-app-help-modes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S18-app-help-modes.md
@@ -93,7 +93,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S19-app-help-memory.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S19-app-help-memory.md
@@ -93,7 +93,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S2-rung2-revisit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S2-rung2-revisit.md
@@ -95,7 +95,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S3-rung3-evaluate.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S3-rung3-evaluate.md
@@ -98,7 +98,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -117,7 +117,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S4-rung4-teach-back.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S4-rung4-teach-back.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S5-rung5-exit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S5-rung5-exit.md
@@ -105,7 +105,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -124,7 +124,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S6-homework-help.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S6-homework-help.md
@@ -94,7 +94,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S8-casual-freeform.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S8-casual-freeform.md
@@ -85,7 +85,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -104,7 +104,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S9-correct-streak.md
+++ b/apps/api/eval-llm/snapshots/exchanges/15yo-football-gaming__S9-correct-streak.md
@@ -115,7 +115,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -134,7 +134,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S1-rung1-teach-new.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S1-rung1-teach-new.md
@@ -90,7 +90,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S10-first-encounter-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S10-first-encounter-topic-turn0.md
@@ -90,7 +90,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S11-first-encounter-topic-turn1.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S11-first-encounter-topic-turn1.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S12-first-encounter-topic-turn3.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S12-first-encounter-topic-turn3.md
@@ -109,7 +109,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -128,7 +128,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S13-first-session-subject-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S13-first-session-subject-turn0.md
@@ -90,7 +90,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S14-returning-topic-turn0.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S14-returning-topic-turn0.md
@@ -90,7 +90,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -109,7 +109,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S15-review-mode-opener.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S15-review-mode-opener.md
@@ -92,7 +92,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -111,7 +111,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S16-app-help-notes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S16-app-help-notes.md
@@ -99,7 +99,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S17-app-help-preferences.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S17-app-help-preferences.md
@@ -99,7 +99,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S18-app-help-modes.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S18-app-help-modes.md
@@ -99,7 +99,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S19-app-help-memory.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S19-app-help-memory.md
@@ -99,7 +99,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S2-rung2-revisit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S2-rung2-revisit.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S3-rung3-evaluate.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S3-rung3-evaluate.md
@@ -104,7 +104,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -123,7 +123,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S4-rung4-teach-back.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S4-rung4-teach-back.md
@@ -107,7 +107,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -126,7 +126,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S5-rung5-exit.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S5-rung5-exit.md
@@ -111,7 +111,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -130,7 +130,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S6-homework-help.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S6-homework-help.md
@@ -100,7 +100,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S7-language-fluency.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S7-language-fluency.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S8-casual-freeform.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S8-casual-freeform.md
@@ -91,7 +91,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -110,7 +110,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S9-correct-streak.md
+++ b/apps/api/eval-llm/snapshots/exchanges/17yo-french-advanced__S9-correct-streak.md
@@ -121,7 +121,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -140,7 +140,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A01.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A01.md
@@ -92,7 +92,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -111,7 +111,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A02.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A02.md
@@ -116,7 +116,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -135,7 +135,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A03.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A03.md
@@ -94,7 +94,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A06.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__A06.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P01.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P01.md
@@ -84,7 +84,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P11.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P11.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P14.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P14.md
@@ -95,7 +95,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P15.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P15.md
@@ -116,7 +116,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -135,7 +135,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P16.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P16.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P21.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P21.md
@@ -94,7 +94,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P22.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P22.md
@@ -118,7 +118,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -137,7 +137,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P23.md
+++ b/apps/api/eval-llm/snapshots/probes/11yo-czech-animals__P23.md
@@ -85,7 +85,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -104,7 +104,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__A01.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__A01.md
@@ -92,7 +92,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -111,7 +111,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__A02.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__A02.md
@@ -116,7 +116,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -135,7 +135,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__A05.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__A05.md
@@ -92,7 +92,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -111,7 +111,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P05.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P05.md
@@ -83,7 +83,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -102,7 +102,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P09.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P09.md
@@ -83,7 +83,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -102,7 +102,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P11.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P11.md
@@ -93,7 +93,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P14.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P14.md
@@ -95,7 +95,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P15.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P15.md
@@ -116,7 +116,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -135,7 +135,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P16.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P16.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P17.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P17.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P18.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P18.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P21.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P21.md
@@ -94,7 +94,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P22.md
+++ b/apps/api/eval-llm/snapshots/probes/12yo-dinosaurs__P22.md
@@ -118,7 +118,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -137,7 +137,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__A01.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__A01.md
@@ -98,7 +98,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -117,7 +117,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__A02.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__A02.md
@@ -122,7 +122,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -141,7 +141,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P02.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P02.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P06.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P06.md
@@ -107,7 +107,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -126,7 +126,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P07.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P07.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P11.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P11.md
@@ -99,7 +99,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P13.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P13.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P14.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P14.md
@@ -101,7 +101,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P15.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P15.md
@@ -122,7 +122,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -141,7 +141,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P16.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P16.md
@@ -107,7 +107,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -126,7 +126,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P21.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P21.md
@@ -100,7 +100,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P22.md
+++ b/apps/api/eval-llm/snapshots/probes/13yo-spanish-beginner__P22.md
@@ -124,7 +124,7 @@ Avoid abstract jargon; when a technical term is unavoidable, define it once in p
 Keep the tone warm but calm — no performative enthusiasm, no baby talk.
 When they get something right, a brief "yes, that's it" is plenty.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -143,7 +143,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__A01.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__A01.md
@@ -92,7 +92,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -111,7 +111,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__A02.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__A02.md
@@ -116,7 +116,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -135,7 +135,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__A04.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__A04.md
@@ -100,7 +100,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P03.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P03.md
@@ -100,7 +100,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P08.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P08.md
@@ -102,7 +102,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -121,7 +121,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P10.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P10.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P11.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P11.md
@@ -93,7 +93,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P12.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P12.md
@@ -93,7 +93,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -112,7 +112,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P14.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P14.md
@@ -95,7 +95,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -114,7 +114,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P15.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P15.md
@@ -116,7 +116,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -135,7 +135,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P16.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P16.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P20.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P20.md
@@ -84,7 +84,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -103,7 +103,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P21.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P21.md
@@ -94,7 +94,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -113,7 +113,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P22.md
+++ b/apps/api/eval-llm/snapshots/probes/15yo-football-gaming__P22.md
@@ -118,7 +118,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -137,7 +137,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__A01.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__A01.md
@@ -98,7 +98,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -117,7 +117,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__A02.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__A02.md
@@ -122,7 +122,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -141,7 +141,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P04.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P04.md
@@ -108,7 +108,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -127,7 +127,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P11.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P11.md
@@ -99,7 +99,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -118,7 +118,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P14.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P14.md
@@ -101,7 +101,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -120,7 +120,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P15.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P15.md
@@ -122,7 +122,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -141,7 +141,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P16.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P16.md
@@ -107,7 +107,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -126,7 +126,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P19.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P19.md
@@ -108,7 +108,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -127,7 +127,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P21.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P21.md
@@ -100,7 +100,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -119,7 +119,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P22.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P22.md
@@ -124,7 +124,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -143,7 +143,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P24.md
+++ b/apps/api/eval-llm/snapshots/probes/17yo-french-advanced__P24.md
@@ -109,7 +109,7 @@ Keep it short. Use everyday analogies. Skip the pep talks.
 Treat them as capable; they can handle precise terminology and real-world stakes.
 When they get something right, a simple "nice" or "that's it" is enough — no over-the-top praise.
 
-APP HELP (map version 2026-05-13):
+APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -128,7 +128,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.

--- a/apps/api/src/services/app-help-map.test.ts
+++ b/apps/api/src/services/app-help-map.test.ts
@@ -17,7 +17,7 @@ interface EnglishLocale {
     };
   };
   more: {
-    accommodation: { sectionHeader: string };
+    accommodation: { childScreenTitle: string; sectionHeader: string };
     help: { helpAndFeedback: string };
     learningPreferences: { rowLabel: string };
     mentorMemory: { sectionHeader: string };
@@ -87,7 +87,10 @@ describe('buildAppHelpPromptBlock', () => {
 
   it('contains parent-specific destinations', () => {
     expect(block).toMatch(/child/i);
-    expect(block).toMatch(/profile selector/i);
+    expect(block).toMatch(/child's card/i);
+    expect(block).toMatch(/learning preferences/i);
+    expect(block).not.toMatch(/profile selector/i);
+    expect(block).not.toMatch(/Switch to the child's profile/i);
   });
 
   it('does not contain Expo route strings', () => {
@@ -110,6 +113,9 @@ describe('buildAppHelpPromptBlock', () => {
     expect(en.more.accommodation.sectionHeader).toBe(
       'Your learning accommodation',
     );
+    expect(en.more.accommodation.childScreenTitle).toBe(
+      "{{name}}'s learning preferences",
+    );
     expect(en.more.account.profile).toBe('Profile');
 
     expect(block).toContain(en.more.learningPreferences.rowLabel);
@@ -118,6 +124,12 @@ describe('buildAppHelpPromptBlock', () => {
     expect(block).toContain(en.more.privacy.privacyAndData);
     expect(block).toContain(en.more.notifications.sectionHeader);
     expect(block).toContain(en.more.accommodation.sectionHeader);
+    expect(block).toContain(
+      en.more.accommodation.childScreenTitle.replace(
+        '{{name}}',
+        '<child name>',
+      ),
+    );
     expect(block).toContain(en.more.account.profile);
   });
 

--- a/apps/api/src/services/app-help-map.ts
+++ b/apps/api/src/services/app-help-map.ts
@@ -4,9 +4,9 @@
 // app-help-map.test.ts read the mobile en.json source and assert exact matches.
 // If a screen is renamed, update the map and the tests together.
 //
-// Map version: 2026-05-13
+// Map version: 2026-05-15
 
-const APP_HELP_MAP = `APP HELP (map version 2026-05-13):
+const APP_HELP_MAP = `APP HELP (map version 2026-05-15):
 If the learner asks how to find, change, or understand something in the app, answer from this map in plain chat text. Do not invent screens, buttons, routes, links, or capabilities. Use visible labels only. Keep the answer to one or two sentences, then return to the learning thread if one was active. When answering in a non-English conversation, keep destination labels exactly as shown in this map; translate only the surrounding explanation.
 
 Destinations:
@@ -25,7 +25,7 @@ Destinations:
 - Homework: Home > Help with an assignment.
 - Practice / reviews: Home > Test yourself.
 - Viewing a child's progress (parent): Home > tap the child's card.
-- Changing a child's preferences (parent): Switch to the child's profile using the profile selector, then use More > Preferences as normal.
+- Changing a child's preferences (parent): Home > tap the child's card > the "<child name>'s learning preferences" row.
 
 If you do not know a destination, say so and suggest "More > Help & feedback".
 Do not output internal route paths, Expo routes, markdown links, or URLs.`;

--- a/apps/mobile/src/app/delete-account.test.tsx
+++ b/apps/mobile/src/app/delete-account.test.tsx
@@ -8,6 +8,8 @@ import {
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import type { Profile, ProfileContextValue } from '../lib/profile';
+
 const mockBack = jest.fn();
 const mockReplace = jest.fn();
 const mockCanGoBack = jest.fn();
@@ -75,9 +77,60 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, gcTime: 0 } },
 });
 
+const ownerProfile: Profile = {
+  id: '00000000-0000-7000-8000-000000000001',
+  accountId: '00000000-0000-7000-8000-000000000010',
+  displayName: 'Zuzka',
+  avatarUrl: null,
+  birthYear: 1990,
+  location: null,
+  isOwner: true,
+  hasPremiumLlm: false,
+  conversationLanguage: 'en',
+  pronouns: null,
+  consentStatus: null,
+  linkCreatedAt: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const childProfile: Profile = {
+  ...ownerProfile,
+  id: '00000000-0000-7000-8000-000000000002',
+  displayName: 'Mia',
+  birthYear: 2013,
+  isOwner: false,
+  linkCreatedAt: '2026-01-02T00:00:00Z',
+  createdAt: '2026-01-02T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+};
+
+function createProfileContext(
+  profiles: Profile[] = [ownerProfile],
+  activeProfile: Profile | null = profiles[0] ?? null,
+): ProfileContextValue {
+  return {
+    profiles,
+    activeProfile,
+    switchProfile: jest.fn(async () => ({ success: true })),
+    isLoading: false,
+    profileLoadError: null,
+    profileWasRemoved: false,
+    acknowledgeProfileRemoval: jest.fn(),
+  };
+}
+
+let mockProfileContext = createProfileContext();
+const { ProfileContext } =
+  require('../lib/profile') as typeof import('../lib/profile');
+
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ProfileContext.Provider value={mockProfileContext}>
+        {children}
+      </ProfileContext.Provider>
+    </QueryClientProvider>
   );
 }
 
@@ -111,6 +164,7 @@ describe('DeleteAccountScreen', () => {
       isError: false,
       refetch: mockDeletionStatusRefetch,
     };
+    mockProfileContext = createProfileContext();
   });
 
   afterEach(() => {
@@ -417,7 +471,19 @@ describe('DeleteAccountScreen', () => {
       screen.getByTestId('delete-account-confirming');
     });
 
-    it('shows the family-pool warning in the confirming stage', () => {
+    it('hides the family-pool warning for a solo owner', () => {
+      mockProfileContext = createProfileContext([ownerProfile]);
+
+      render(<DeleteAccountScreen />, { wrapper: Wrapper });
+      fireEvent.press(screen.getByTestId('delete-account-confirm'));
+
+      expect(screen.queryByTestId('delete-account-family-warning')).toBeNull();
+      expect(screen.queryByText(/linked child profiles/i)).toBeNull();
+    });
+
+    it('shows the family-pool warning when the owner has a linked child', () => {
+      mockProfileContext = createProfileContext([ownerProfile, childProfile]);
+
       render(<DeleteAccountScreen />, { wrapper: Wrapper });
       fireEvent.press(screen.getByTestId('delete-account-confirm'));
 

--- a/apps/mobile/src/app/delete-account.tsx
+++ b/apps/mobile/src/app/delete-account.tsx
@@ -22,7 +22,7 @@ import { goBackOrReplace } from '../lib/navigation';
 import { formatApiError } from '../lib/format-api-error';
 import { platformAlert } from '../lib/platform-alert';
 import { signOutWithCleanup } from '../lib/sign-out';
-import { useProfile } from '../lib/profile';
+import { useHasLinkedChildren, useProfile } from '../lib/profile';
 
 // [BUG-910] The exact phrase a user must type to confirm. Kept as a constant
 // so tests and accessibility labels stay in sync.
@@ -38,6 +38,7 @@ export default function DeleteAccountScreen() {
   const { signOut } = useAuth();
   const queryClient = useQueryClient();
   const { profiles } = useProfile();
+  const hasLinkedChildren = useHasLinkedChildren();
   const deleteAccount = useDeleteAccount();
   const cancelDeletion = useCancelDeletion();
   const deletionStatus = useDeletionStatus();
@@ -288,19 +289,21 @@ export default function DeleteAccountScreen() {
           </View>
         ) : stage === 'confirming' ? (
           <View testID="delete-account-confirming">
-            {/* [BUG-910] Family pool consequences — parents need to know
-                that linked child profiles are deleted along with their account. */}
-            <View
-              className="bg-danger/10 rounded-card px-4 py-3 mb-4"
-              testID="delete-account-family-warning"
-            >
-              <Text className="text-body-sm font-semibold text-danger mb-1">
-                {t('account.familyWarningTitle')}
-              </Text>
-              <Text className="text-body-sm text-text-primary">
-                {t('account.familyWarningBody')}
-              </Text>
-            </View>
+            {hasLinkedChildren ? (
+              /* [BUG-910] Family pool consequences: parents need to know
+                 that linked child profiles are deleted along with their account. */
+              <View
+                className="bg-danger/10 rounded-card px-4 py-3 mb-4"
+                testID="delete-account-family-warning"
+              >
+                <Text className="text-body-sm font-semibold text-danger mb-1">
+                  {t('account.familyWarningTitle')}
+                </Text>
+                <Text className="text-body-sm text-text-primary">
+                  {t('account.familyWarningBody')}
+                </Text>
+              </View>
+            ) : null}
 
             {/* [BUG-910] Active subscription advisory — store-billed plans
                 continue to charge unless the user cancels with the platform. */}

--- a/docs/audit/2026-05-15-persona-copy-agent-checkpoint.md
+++ b/docs/audit/2026-05-15-persona-copy-agent-checkpoint.md
@@ -1,0 +1,12 @@
+# Persona Copy Agent Checkpoint
+
+Date: 2026-05-15
+
+Scope: follow-up for PC-1 and PC-3 from `docs/audit/2026-05-15-persona-store-compliance-triage.md`.
+
+Progress notes:
+
+- 2026-05-15 coordinator: Created checkpoint file before dispatch.
+- 2026-05-15 Codex: Confirmed PC-1 uses `delete-account-family-warning` unconditionally; investigating existing profile context and app-help child preference route before patching.
+- 2026-05-15 Codex: Patched PC-1 to gate the family warning on linked children and updated PC-3 app-help map to the child-card preferences route; installing dependencies to run focused tests and eval.
+- 2026-05-15 Codex: PC-1 and PC-3 validated with focused tests; full `pnpm eval:llm` refreshed prompt snapshots. PC-2 still intentionally unimplemented pending UX choice: show subscription warning only for paid/trial state, or keep an always-visible conditional compliance warning.

--- a/docs/audit/2026-05-15-persona-store-compliance-triage.md
+++ b/docs/audit/2026-05-15-persona-store-compliance-triage.md
@@ -1,0 +1,55 @@
+# Persona Copy And Store Compliance Triage
+
+Date: 2026-05-15
+
+Status: checkpoint for follow-up implementation. This file captures the two read-only subagent reports so the work is durable before new agents continue.
+
+## Persona And Copy Mismatches
+
+### Real Issues
+
+| ID | Status | Area | Evidence | Next action |
+| --- | --- | --- | --- | --- |
+| PC-1 | Addressed in code | Delete account | `apps/mobile/src/app/delete-account.tsx` always rendered `delete-account-family-warning`, even for solo owner/self-learner accounts. The copy says "If you have linked child profiles". | Gated on actual linked child profiles. Added tests for solo owner hidden and owner with child shown. |
+| PC-2 | Real UX/copy decision | Delete account | `apps/mobile/src/app/delete-account.tsx` always renders the store subscription warning. The current copy is technically conditional enough to be useful for paid users, but noisy for free solo users. | Product/UX decision needed: either show only when subscription state indicates paid/trial, or keep always-visible "If you have..." style compliance warning. |
+| PC-3 | Addressed in code/content | App help prompt map | `apps/api/src/services/app-help-map.ts` told parents to switch into a child's profile to edit child preferences. Current mobile IA has direct parent child-detail preferences access. | Updated app-help copy/tests and the app-help spec to the current child-card route. `pnpm eval:llm` refreshed snapshots. |
+
+### Stale Or Obsolete Reports
+
+| ID | Status | Area | Evidence | Decision |
+| --- | --- | --- | --- | --- |
+| PC-4 | Stale doc | Single learner privacy controls | Old audit says solo learner saw "When I withdraw consent for a child". Current `apps/mobile/src/app/(app)/more/privacy.tsx` gates withdrawal archive controls behind `role === 'owner' && linkedChildren.length > 0`. | No code fix for this exact issue. Add/keep regression coverage if touching the screen. |
+| PC-5 | Stale doc | Duplicate parent onboarding notices | Current parent home renders only `ParentTransitionNotice` when children exist; `FamilyOrientationCue` appears dead except for its own test/import. | No live UX fix. Optional cleanup later. |
+| PC-6 | Stale doc | Web subscription dead-end | Current web path computes `storePurchaseUnavailable` and renders `free-upgrade-unavailable` instead of the `Upgrade` button. | No web code fix. Native no-offerings edge still needs a UX call if we want to change it. |
+
+## Store Compliance Package
+
+### Real External/Admin Gaps
+
+| ID | Status | Area | Evidence | Next action |
+| --- | --- | --- | --- | --- |
+| SC-1 | Blocked external/admin | Privacy policy URL | `apps/mobile/app.json` has `privacyPolicyUrl: https://mentomate.app/privacy`, but DNS lookup failed on 2026-05-15. | Publish the policy at that URL, or choose a live URL and update config/store metadata. Need final legal entity and domain. |
+| SC-2 | Draft created; admin/legal review needed | App Privacy / Data Safety forms | No repo worksheet for Apple App Privacy or Google Data Safety existed. iOS privacy manifest exists, but that is not the store questionnaire. | Worksheet created at `docs/screenshots_and_store_info/app-privacy-data-safety-worksheet.md`. Complete forms in store consoles once accounts are available and legal/admin confirms answers. |
+| SC-3 | Draft created; product/admin input needed | Screenshots | `docs/screenshots_and_store_info/` only had store description copy. No current screenshot set. | Screenshot scene pool and guardrails added to `docs/screenshots_and_store_info/store-compliance-checklist.md`. Choose scenes/captions with product input, then capture current app screens. |
+| SC-4 | Draft created; product/legal input needed | Age rating | Existing docs mention likely age rating, but no rating questionnaire answers were stored. | Draft rating guidance added to `docs/screenshots_and_store_info/store-compliance-checklist.md`. Need product decision on exact 11+ / Education category posture. |
+| SC-5 | Draft created; admin input needed | Review notes | No review-notes file existed. Facts exist across RevenueCat, subscription UI, consent copy, and AI tutoring docs. | Review-notes draft created at `docs/screenshots_and_store_info/reviewer-notes-draft.md`. Finalize once test accounts/IAP products exist. |
+
+### Already Covered In Code
+
+| ID | Status | Area | Evidence |
+| --- | --- | --- | --- |
+| SC-6 | Covered | Account deletion flow | More -> Privacy & data -> Delete account exists, with typed `DELETE`, cancel path, API scheduling, and Inngest 7-day deletion. |
+| SC-7 | Covered | Camera/microphone permission copy | Native permission strings exist in `apps/mobile/app.json`; runtime camera and microphone permission states exist in mobile UI. |
+| SC-8 | Locally covered | Store description | `docs/screenshots_and_store_info/store description.md` contains name, short description, full description, category, and keywords. Needs product review and removal of editor marker glyphs before store entry. |
+
+## Checkpoint Rules For New Agents
+
+- Do not run `git add`, `git commit`, or `git push`.
+- Use this file as the shared durable checkpoint.
+- For any run longer than 4 minutes, append a short progress note under "Agent Progress Notes" before continuing.
+- Report changed file paths in the final response.
+
+## Agent Progress Notes
+
+- 2026-05-15 coordinator: Created durable checkpoint from the two read-only subagent reports before dispatching follow-up agents.
+- 2026-05-15 coordinator: PC-1 and PC-3 were patched and verified with focused tests plus `pnpm eval:llm`; SC-2 through SC-5 draft artifacts were created. PC-2 remains open for product/UX choice.

--- a/docs/audit/2026-05-15-store-compliance-agent-checkpoint.md
+++ b/docs/audit/2026-05-15-store-compliance-agent-checkpoint.md
@@ -1,0 +1,11 @@
+# Store Compliance Agent Checkpoint
+
+Date: 2026-05-15
+
+Scope: follow-up for SC-1 through SC-5 from `docs/audit/2026-05-15-persona-store-compliance-triage.md`.
+
+Progress notes:
+
+- 2026-05-15 coordinator: Created checkpoint file before dispatch.
+- 2026-05-15 Codex: Read AGENTS/project guidance, project-memory index, store-compliance triage, existing store description, app config, billing/IAP memory, and focused code/docs for privacy, consent, screenshots, age, reviewer, and IAP facts. Next step is drafting docs/screenshots_and_store_info artifacts without marking external/admin work complete.
+- 2026-05-15 Codex: Created store-compliance checklist, App Privacy/Data Safety worksheet, and reviewer-notes draft under `docs/screenshots_and_store_info/`. All external/admin dependencies are marked as blocked or NEEDS USER/ADMIN/STORE confirmation.

--- a/docs/screenshots_and_store_info/app-privacy-data-safety-worksheet.md
+++ b/docs/screenshots_and_store_info/app-privacy-data-safety-worksheet.md
@@ -1,0 +1,110 @@
+# App Privacy And Data Safety Worksheet
+
+Date: 2026-05-15
+
+Status: repo-evidence draft for Apple App Privacy and Google Play Data Safety. Do not paste this into store consoles without legal/admin review.
+
+## Submission Blockers
+
+- [ ] Live privacy URL and legal entity are not confirmed.
+- [ ] Store account access/status is not confirmed.
+- [ ] Final third-party processor list is not confirmed against production configuration.
+- [ ] Final tracking/advertising answers require legal/admin review.
+- [ ] Final retention/deletion language must match the live privacy policy.
+
+## App Facts From Repo
+
+| Fact | Repo evidence |
+| --- | --- |
+| App name | `MentoMate` in `apps/mobile/app.json` and store description draft. |
+| iOS bundle ID | `com.mentomate.app` in `apps/mobile/app.json`. |
+| Android package | `com.mentomate.app` in `apps/mobile/app.json`. |
+| Privacy URL configured | `https://mentomate.app/privacy` in `apps/mobile/app.json`; triage says DNS lookup failed on 2026-05-15. |
+| Store category draft | Education in `docs/screenshots_and_store_info/store description.md`. |
+| Minimum age | 11+ via `MINIMUM_AGE = 11` and create-profile copy. |
+| Parental consent | Consent required through age 16 using the GDPR-everywhere model in `apps/api/src/services/consent.ts`. |
+| Data export | More -> Privacy & Data -> Export my data; schema in `packages/schemas/src/account.ts`. |
+| Account deletion | More -> Privacy & Data -> Delete account; typed `DELETE` confirmation and 7-day grace period. |
+| Permissions | Camera, photo library, microphone, notifications; see `apps/mobile/app.json` and related hooks/screens. |
+| IAP | RevenueCat native IAP integration with webhook-backed entitlements; products need store/admin readiness. |
+| Diagnostics | Sentry mobile/API error telemetry; mobile has age/consent gating in `apps/mobile/src/lib/sentry.ts`. |
+
+## Data Categories
+
+Use this as a conservative mapping aid. "Draft disclosure posture" is not a final legal answer.
+
+| Data category | Repo evidence | Draft disclosure posture | Open questions |
+| --- | --- | --- | --- |
+| Email address | `accounts.email`, `consent_states.parent_email`, Clerk auth, email notifications. | Collected and linked to account/profile. Used for account management, consent, transactional email, and app functionality. | Final legal entity/privacy wording; whether parent and learner emails are both collected in production flows. |
+| Name/display name | `profiles.display_name`; profile creation asks for display name. | Collected and linked to profile. Used for app functionality and personalization. | Whether profile avatar/photo is enabled in production. |
+| Age / birth year | `profiles.birth_year`; create-profile birth date UI stores birth year; consent and age voice use it. | Collected and linked to profile. Used for age gating, consent, and age-appropriate tutoring. | Console category wording differs by Apple/Google; confirm exact entry. |
+| Parent/child relationship | `family_links`; parent views child progress. | Collected and linked. Used for family/account functionality and parental oversight. | Legal wording for child profiles and parent access. |
+| Consent records | `consent_states` with consent type/status, parent email, timestamps, token fields. | Collected and linked. Used for compliance and app access gating. | Retention/deletion wording. |
+| Learning content | Export schema includes subjects, curricula, curriculum topics, learning sessions, events, summaries, retention cards, assessments, XP, streaks, learning modes, teaching preferences, parking lot items, needs-deepening topics, learning profiles. | Collected and linked. Used for app functionality, progress tracking, personalization, and AI tutoring. | Confirm any retention purge policy and whether all exported tables are live in production. |
+| Chat messages and transcripts | Session message schemas and session routes persist learning exchanges; session transcript route exists. | Collected and linked. User content used for AI tutoring and learning history. | Final policy for transcript retention/purge. |
+| Homework images/photos | Homework OCR route accepts uploaded images; session message schema supports base64 homework image; dictation review accepts imageBase64. | Collected when user chooses camera/photo homework features. Used for app functionality and AI/OCR review. | Whether images are retained, transformed, or only processed transiently in each flow. |
+| Audio / voice | Microphone permission exists. Speech recognition hook creates transcripts; inspected hook does not upload raw audio files directly. | Microphone access is used. Disclose transcript collection as learning content. Raw audio collection needs confirmation before answering. | Platform speech-recognition service behavior and final privacy wording. |
+| Photos/photo library | Photo library permission copy exists for importing homework. | Accessed when user imports homework. Collected only when user selects an image for homework/dictation review. | Confirm exact current UI paths and retention. |
+| Push token and notification settings | `notification_preferences.expo_push_token`, push registration hook, notification settings screen. | Collected and linked to profile when notification permission is granted. Used for app notifications. | Confirm default notification states and opt-out wording. |
+| Purchase/subscription data | RevenueCat hooks, webhook payload, subscription/quota/top-up tables. | Collected and linked. Used for purchases, entitlement, quota, and account management. | Final product list and whether Apple/Google/RevenueCat are listed as processors/sharing recipients. |
+| Identifiers | Clerk user ID, account/profile IDs, RevenueCat app user ID, push token. | Collected and linked. Used for account, app functionality, purchases, notifications, and diagnostics. | Whether any device IDs are collected by SDKs beyond app code. |
+| Diagnostics | Sentry, crash/error captures, breadcrumbs, performance transactions. | Collected where Sentry is enabled. Used for diagnostics and app quality. | Confirm production DSN, age gating, sample rates, and whether diagnostics are linked. |
+| Product interaction / usage | Session events, usage/quota, analytics breadcrumbs in Sentry, app flow data. | Collected and linked or pseudonymized depending on implementation. Used for app functionality, analytics, and diagnostics. | Final Apple "Usage Data" and Google "App activity" answers. |
+| Location | DB schema has optional `profiles.location`, but current create-profile flow reviewed here does not send location. | Do not mark current collection without confirming production/legacy data. | Check production rows and legacy flow history before store answer. |
+| Advertising data | No ad SDK found in reviewed package files. | Likely not collected for ads, pending final SDK review. | Legal/admin must confirm. |
+| Contacts/address book | No address book contact access found in reviewed facts. | Likely not collected, pending final review. | Confirm package/permission scan before final. |
+| Financial payment details | Native stores and RevenueCat handle purchases; API stores subscription/product/transaction status. | Do not claim raw card/payment details are collected by MentoMate unless admin confirms. | Confirm store/RevenueCat billing data disclosures. |
+
+## Third-Party / Processor Review
+
+Production configuration and legal review must confirm the final list. Repo evidence points to these systems:
+
+| Processor/system | Evidence | Likely data involved |
+| --- | --- | --- |
+| Clerk | Auth packages and API auth config. | Authentication identifiers, email, sessions. |
+| RevenueCat | `react-native-purchases`, RevenueCat webhook route, RevenueCat memory. | App user ID, purchase/subscription/customer info. |
+| Apple App Store / Google Play | Native IAP and platform subscription management links. | Store purchase/subscription data. |
+| Sentry | Mobile and API Sentry packages/wrappers. | Crash/error diagnostics, breadcrumbs, possibly user/profile context depending on gate/scope. |
+| LLM providers | API config includes Gemini, OpenAI, Anthropic; architecture routes LLM calls through server. | Messages, learning context, homework text/images when used for tutoring/OCR/review. |
+| OCR/embedding providers | API config includes Gemini and Voyage. | Homework images/text for OCR; learning/session text for embeddings if enabled. |
+| Resend/email | API config and notification services. | Transactional email metadata, consent/digest emails. |
+| Expo push notifications | `expo-notifications` and Expo push token registration. | Push token and notification payloads. |
+| Neon/PostgreSQL/Cloudflare Workers/KV/Inngest | Architecture/deployment docs. | App database, cached subscription status, async job payloads. |
+
+## Apple App Privacy Mapping Aid
+
+| Apple category area | Draft mapping from repo evidence | Final answer owner |
+| --- | --- | --- |
+| Contact Info | Email address for account/parent consent and transactional messages. | Legal/admin |
+| User Content | Chat messages, homework text/images, dictation review images, learning transcripts/summaries. | Legal/admin |
+| Identifiers | User/account/profile IDs, RevenueCat app user ID, push token, possibly SDK-generated identifiers. | Legal/admin |
+| Purchases | Subscription/top-up status and purchase transaction identifiers through RevenueCat/webhooks. | Legal/admin |
+| Usage Data | Session events, quota usage, product interactions, app analytics breadcrumbs. | Legal/admin |
+| Diagnostics | Crash/error diagnostics and performance where Sentry is enabled. | Legal/admin |
+| Sensitive Info | Birth year/child data may need conservative disclosure even if not an Apple "Sensitive Info" category. | Legal/admin |
+| Location | Do not claim current collection from active flow without production/legacy confirmation. | Legal/admin |
+| Tracking | No ad SDK found in reviewed package files, but SDK/processors must be reviewed under Apple's tracking definition. | Legal/admin |
+
+## Google Data Safety Mapping Aid
+
+| Google section | Draft mapping from repo evidence | Final answer owner |
+| --- | --- | --- |
+| Data collected | Email, profile/display name, birth year, parent/child links, consent records, learning activity/content, images selected for homework, push token, purchase/subscription data, diagnostics. | Legal/admin |
+| Data shared | Likely shared with service providers/processors for auth, payments, AI/OCR, diagnostics, email/push, hosting. Final classification depends on Google Data Safety definitions. | Legal/admin |
+| Data processed ephemerally | Homework images/OCR and speech/audio behavior need implementation and provider confirmation before marking ephemeral or retained. | Engineering/legal/admin |
+| Data encrypted in transit | Confirm production HTTPS/TLS posture before answering. | Engineering/admin |
+| Users can request deletion | In-app account deletion exists with 7-day grace period; export exists for owner profiles. | Legal/admin |
+| Independent security review | No evidence reviewed in repo. | Admin |
+| Ads | No ad SDK found in reviewed packages. Final answer requires admin/legal review. | Legal/admin |
+
+## Copy-Ready Internal Notes
+
+Use these for drafting the store forms after legal review:
+
+- The app is an education app for learners aged 11+ and parents/adult learners.
+- Account owners can export data and schedule account deletion from More -> Privacy & Data.
+- The app collects learning data to provide tutoring, progress tracking, spaced repetition, and parent oversight.
+- Camera/photo access is used only when the user chooses to capture or import homework.
+- Microphone access is used for voice-based learning; confirm whether raw audio is collected by any production service before store submission.
+- Mobile purchases use native IAP through RevenueCat; Stripe is dormant for future web.
+

--- a/docs/screenshots_and_store_info/reviewer-notes-draft.md
+++ b/docs/screenshots_and_store_info/reviewer-notes-draft.md
@@ -1,0 +1,89 @@
+# Reviewer Notes Draft
+
+Date: 2026-05-15
+
+Status: draft for App Store / Google Play reviewer notes. This cannot be final until a reviewer account, sandbox testers, IAP products, and store account access are confirmed.
+
+## Required Admin Inputs
+
+- Reviewer test account email: NEEDS USER/ADMIN INPUT
+- Reviewer test account password: NEEDS USER/ADMIN INPUT
+- Reviewer profile setup: NEEDS USER/ADMIN INPUT
+- Whether reviewer should use a parent account, learner account, or both: NEEDS PRODUCT INPUT
+- Sandbox tester account(s): NEEDS STORE ADMIN INPUT
+- Apple/Google IAP product readiness: NEEDS STORE ADMIN INPUT
+- Live privacy URL and legal entity: NEEDS USER/ADMIN INPUT
+
+Do not submit placeholder credentials.
+
+## Draft Review Notes
+
+MentoMate is an education app for learners aged 11+ and for parents/adult learners. The app provides AI-guided tutoring, homework help, practice, spaced repetition, progress tracking, and parent oversight.
+
+The core learning flow is private to the signed-in account. There is no public social feed. Learners can type questions, use voice transcription, or choose camera/photo homework capture to send learning content to the tutor. The AI tutoring and OCR/review features are processed through the app's backend services.
+
+Account deletion and data export are available in the app:
+
+- More -> Privacy & Data -> Export my data
+- More -> Privacy & Data -> Delete account
+
+The delete-account flow uses an in-screen warning, exact `DELETE` typed confirmation, and a 7-day grace period before deletion is processed. The app also includes parental-consent flows for younger learners according to the current 11+ / consent-through-age-16 product posture.
+
+Camera access is used for photographing homework. Photo library access is used to import homework images. Microphone access is used for voice-based learning. Push notifications are optional and are used for learning reminders/progress notifications.
+
+Mobile purchases use native in-app purchases through RevenueCat. Stripe code exists for future web billing but is dormant for mobile store launch.
+
+## Reviewer Test Flow Draft
+
+Use the final reviewer account once provided:
+
+1. Sign in with the reviewer account.
+2. Confirm the profile shown after sign-in matches the intended reviewer scenario.
+3. Open Home and start a simple tutoring prompt, for example a safe school topic.
+4. Open Library or Progress to view learning history and retention/progress features.
+5. Open More -> Privacy & Data to see export and delete-account controls.
+6. Open More -> Account/Profile -> Subscription to view the subscription screen.
+7. If IAP products are ready in the store sandbox, test purchase or restore using the sandbox tester account.
+
+## IAP Readiness Notes
+
+Repo evidence shows RevenueCat/native IAP integration and these product IDs in the API webhook mapping:
+
+| Product ID | Type/tier in repo | Readiness |
+| --- | --- | --- |
+| `com.eduagent.plus.monthly` | Plus subscription, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.plus.yearly` | Plus subscription, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.family.monthly` | Family subscription, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.family.yearly` | Family subscription, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.pro.monthly` | Pro subscription, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.pro.yearly` | Pro subscription, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.plus.monthly.android` | Plus subscription, Android | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.plus.yearly.android` | Plus subscription, Android | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.family.monthly.android` | Family subscription, Android | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.family.yearly.android` | Family subscription, Android | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.pro.monthly.android` | Pro subscription, Android | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.pro.yearly.android` | Pro subscription, Android | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.topup.500` | 500-credit consumable, iOS | NEEDS STORE ADMIN CONFIRMATION |
+| `com.eduagent.topup.500.android` | 500-credit consumable, Android | NEEDS STORE ADMIN CONFIRMATION |
+
+Important: `apps/mobile/src/app/(app)/subscription.tsx` currently surfaces Free and Plus in the public static comparison, while Family/Pro cards are read-only for existing Family/Pro customers. Product/admin must confirm the final public product set before store submission.
+
+## Reviewer Account Matrix
+
+Choose one or more scenarios before submission:
+
+| Scenario | Purpose | Status |
+| --- | --- | --- |
+| Adult owner / solo learner | Fastest review path through Home, Library, Progress, Privacy & Data, Subscription. | NEEDS USER/ADMIN INPUT |
+| Parent with linked child | Demonstrates parent oversight and child progress. | NEEDS USER/ADMIN INPUT |
+| Learner requiring consent | Demonstrates consent gate, but can slow review if not explained. | NEEDS PRODUCT DECISION |
+| Paid/sandbox subscriber | Demonstrates IAP and entitlements. | NEEDS STORE ADMIN INPUT |
+
+## Notes To Avoid Unsupported Claims
+
+- Do not say the privacy policy is live until the URL is verified.
+- Do not say IAP products are ready until the products are available in the relevant store sandbox/console.
+- Do not say the app is COPPA/GDPR compliant in reviewer notes unless legal signs off.
+- Do not claim raw audio is or is not collected until production speech-recognition behavior is reviewed.
+- Do not claim Family/Pro are public purchase options unless product/admin confirms store listing.
+

--- a/docs/screenshots_and_store_info/store-compliance-checklist.md
+++ b/docs/screenshots_and_store_info/store-compliance-checklist.md
@@ -1,0 +1,154 @@
+# Store Compliance Checklist
+
+Date: 2026-05-15
+
+Status: working checklist for SC-1 through SC-5 from `docs/audit/2026-05-15-persona-store-compliance-triage.md`. This is not a record of completed App Store Connect or Google Play Console work.
+
+## Source Snapshot
+
+Repo evidence reviewed for this checklist:
+
+- `apps/mobile/app.json` - app identifiers, permissions, iOS privacy manifest, privacy URL.
+- `docs/screenshots_and_store_info/store description.md` - current store description draft.
+- `docs/flows/mobile-app-flow-inventory.md` - current mobile flow inventory as of 2026-05-14.
+- `packages/schemas/src/account.ts` and `apps/api/src/services/export.ts` - exportable data shape.
+- `apps/mobile/src/app/(app)/more/privacy.tsx` and `apps/mobile/src/app/delete-account.tsx` - Privacy & Data, export, and delete-account flows.
+- `apps/api/src/services/consent.ts` - 11+ minimum and parental-consent gating.
+- `apps/mobile/src/hooks/use-revenuecat.ts`, `apps/mobile/src/app/(app)/subscription.tsx`, and `apps/api/src/routes/revenuecat-webhook.ts` - mobile IAP and product ID evidence.
+- `.claude/memory/project_revenuecat_setup.md`, `.claude/memory/project_apple_enrollment.md`, `.claude/memory/google_play_publishing.md`, and `.claude/memory/billing-payments.md` - historical store/admin blockers and billing decisions. Treat these as context, not current admin truth.
+
+## Open Admin Inputs
+
+Do not mark the store package ready until these are answered by the user or store admin:
+
+- [ ] Live privacy policy URL and final legal entity.
+- [ ] App Store Connect and Google Play Console access/status.
+- [ ] Screenshot scene list, captions, target locales, and final device requirements from the current consoles.
+- [ ] Age-rating questionnaire answers and final Education vs Kids category posture.
+- [ ] Reviewer test account, reviewer-safe seed data, sandbox testers, and IAP product readiness.
+
+## SC-1 Privacy Policy URL
+
+Current repo fact:
+
+- `apps/mobile/app.json` sets `privacyPolicyUrl` to `https://mentomate.app/privacy`.
+- The mobile Privacy & Data screen opens in-app `/privacy` and `/terms` routes.
+- The triage doc records that DNS lookup for `https://mentomate.app/privacy` failed on 2026-05-15.
+
+Checklist:
+
+- [ ] Confirm final legal entity name, physical/contact address if required, support email, privacy contact, and data controller/processor language.
+- [ ] Publish the policy at `https://mentomate.app/privacy`, or choose a different live URL.
+- [ ] If the URL changes, update `apps/mobile/app.json` and both store metadata entries.
+- [ ] Confirm Terms of Service URL and in-app `/terms` content are live and consistent.
+- [ ] Verify the URL from a clean browser/device before store submission.
+
+Status: blocked on user/admin input. Do not claim complete from repo-only evidence.
+
+## SC-2 App Privacy And Google Data Safety
+
+Artifact:
+
+- `docs/screenshots_and_store_info/app-privacy-data-safety-worksheet.md`
+
+Current repo fact:
+
+- The app stores account email, profile data, consent records, learning/session data, notification preferences, subscription/quota data, and exportable learning data.
+- Camera/photo flows support homework capture and OCR. Microphone is used for voice-based learning through speech recognition; inspected code sends transcripts/messages, not raw audio files from the speech hook.
+- RevenueCat handles native IAP identity/offering/customer-info flows; the API processes RevenueCat webhooks.
+- Sentry is used for crash/error telemetry and analytics breadcrumbs, with age/consent gating on mobile.
+- No ad SDK or ad network package was found in the package files reviewed, but final "tracking" answers need legal/admin review.
+
+Checklist:
+
+- [ ] Legal/admin review of the worksheet before copying any answers into Apple or Google forms.
+- [ ] Confirm all third-party processors for production: Clerk, RevenueCat, Sentry, LLM/OCR providers, Resend/email, Expo push, Apple/Google stores, database/hosting.
+- [ ] Confirm whether any production telemetry or third-party SDK behavior counts as tracking under Apple/Google rules.
+- [ ] Confirm whether legacy optional `profiles.location` data exists in production exports and needs disclosure, even though the current create-profile flow does not collect location.
+- [ ] Confirm data deletion and retention wording with the live privacy policy.
+
+Status: draftable from repo evidence, but store-console submission is blocked on admin/legal input.
+
+## SC-3 Screenshots
+
+Current repo fact:
+
+- `docs/screenshots_and_store_info/` had store description copy but no screenshot set before this pass.
+- The current app flow inventory lists the modern Home, Library, Session, Homework, Progress, Parent, More, Privacy & Data, and Subscription flows.
+
+Suggested scene pool for product selection:
+
+| Scene | Why it may belong | Needs input |
+| --- | --- | --- |
+| Learner home with subject carousel / Ask Anything | Shows the first useful screen, not marketing copy. | Choose seeded subject and caption. |
+| Library or subject shelf | Shows structured learning content and retention/library value. | Choose subject/book data. |
+| AI tutoring session | Core product value. | Use a safe educational prompt and avoid unsupported outcome claims. |
+| Homework capture / OCR flow | Explains camera/photo permission and homework use case. | Decide whether to show camera UI or post-capture review. |
+| Progress overview / subject progress | Shows retention, streaks, milestones, or reports. | Choose learner progress seed and exact caption. |
+| Parent child-progress view | Shows parent oversight if store positioning includes parents. | Choose parent/child seed and privacy-safe data. |
+| Privacy & Data screen | Useful for review notes but usually not a marketing screenshot. | Product decision only. |
+
+Caption guardrails:
+
+- Avoid "COPPA/GDPR compliant" unless legal signs off.
+- Avoid "learn any subject instantly", "guaranteed grades", or other outcome guarantees.
+- Use "AI-guided", "practice", "review", "progress", and "parent oversight" only where the screenshot visibly supports the claim.
+- Use synthetic learner names and synthetic schoolwork. Never use real child data.
+
+Checklist:
+
+- [ ] Confirm current Apple and Google screenshot device/size requirements in the consoles or current official docs.
+- [ ] Pick final scene list and captions.
+- [ ] Capture screenshots from a production-like build with reviewer-safe seeded data.
+- [ ] Review each screenshot for private data, unsupported claims, stale UI, missing permissions, and text overflow.
+- [ ] Store final exported images under a clear subfolder once captured.
+
+Status: blocked on screenshot scene/caption choices and store account/device requirements.
+
+## SC-4 Age Rating
+
+Current repo fact:
+
+- Product posture in memory and docs is strictly 11+.
+- `apps/api/src/services/consent.ts` defines `MINIMUM_AGE = 11`.
+- The current consent check rejects under-11 users and requires parental consent through age 16 using the GDPR-everywhere model.
+- `apps/mobile/src/app/create-profile.tsx` tells users the minimum age is 11.
+- The store description draft uses category `Education`.
+
+Draft questionnaire guidance, pending final console wording:
+
+| Area | Draft posture from repo evidence | Needs product/legal confirmation |
+| --- | --- | --- |
+| Intended audience | Learners aged 11+ and parents/adult learners. | Exact age band to enter in Apple/Google. |
+| Kids category / Designed for Families | Do not mark as complete without explicit product/legal decision. The app serves teens and adults and uses AI, Sentry, Clerk, RevenueCat, and LLM providers. | Final category posture. |
+| User-generated content | No public social feed found. Learners send private prompts, homework text/images, and transcripts to the AI tutor. | How the console classifies private AI chat/input. |
+| Unrestricted web access | No unrestricted browser feature found in the reviewed app facts. | Confirm before answering. |
+| Purchases | Yes. Native IAP subscriptions/top-ups are implemented via RevenueCat, with store products still needing admin readiness. | Exact product set and availability. |
+| Ads/tracking | No ad SDK found in reviewed package files. Tracking answer still requires legal/admin review of third-party SDK use. | Final Apple tracking/Data Safety answer. |
+| Mature content | Product is educational; LLM router has a safety preamble to refuse prohibited content. Learners can type arbitrary text, so answer carefully. | Exact age-rating questionnaire responses. |
+| Camera/microphone | Yes. Camera/photo for homework; microphone for voice-based learning. | Confirm disclosure wording. |
+
+Status: draft guidance only. Final age rating is blocked on store-console questionnaire answers and product/legal sign-off.
+
+## SC-5 Reviewer Notes
+
+Artifact:
+
+- `docs/screenshots_and_store_info/reviewer-notes-draft.md`
+
+Current repo fact:
+
+- App Review should be told where account deletion and data export live: More -> Privacy & Data.
+- AI tutoring, camera/photo homework capture, microphone voice mode, push notifications, parental consent, and IAP all need concise reviewer context.
+- RevenueCat products and store account connections are not proven ready by repo evidence.
+
+Checklist:
+
+- [ ] Create or confirm reviewer test account credentials.
+- [ ] Decide reviewer seed profile: adult owner, teen learner, parent with child, or multiple accounts.
+- [ ] Confirm whether reviewer should test consent flow, IAP purchase, restore purchase, subscription management, homework capture, and notifications.
+- [ ] Confirm sandbox tester accounts and that App Store/Play products are approved/available.
+- [ ] Paste final reviewer notes into each console only after credentials and products are live.
+
+Status: draft exists, but cannot be final until reviewer account and IAP readiness are confirmed.
+

--- a/docs/specs/2026-05-13-chat-only-app-help.md
+++ b/docs/specs/2026-05-13-chat-only-app-help.md
@@ -1,7 +1,7 @@
 # Chat-Only App Help In Mentor Chat
 
 **Date:** 2026-05-13
-**Status:** Spec - not yet implemented
+**Status:** Implemented; map refreshed 2026-05-15
 **Size:** S
 **Source:** Product discussion 2026-05-13
 
@@ -78,7 +78,7 @@ Initial map:
 | Homework | "Home > Help with an assignment." |
 | Practice / reviews | "Home > Test yourself." (An action card on the Home screen, not a separate tab.) |
 | Viewing a child's progress (parent) | "Home > tap the child's card" to see their progress overview. |
-| Changing a child's preferences (parent) | Switch to the child's profile using the profile selector, then use "More > Preferences" as normal. |
+| Changing a child's preferences (parent) | "Home > tap the child's card > the child's learning preferences row." |
 
 The map should be easy to edit as IA changes. If a destination moves, updating this single map should update prompt behavior.
 


### PR DESCRIPTION
## Summary
- Gate delete-account family warning on actual linked child profiles so solo learners do not see parent/child privacy copy.
- Refresh app-help parent preference copy to the current child-card route and update prompt snapshots.
- Add durable store-compliance working docs for checklist, App Privacy/Data Safety, reviewer notes, and agent checkpointing.

## Open / Deferred
- PC-2 subscription warning remains open for product/UX choice. Recommendation: hide it for known-free users and show it for paid/trial/unknown billing states.
- Store-console completion remains blocked on admin/legal inputs: live privacy URL, store account access, screenshot choices, reviewer account, and IAP readiness.

## Validation
- `pnpm exec jest --config apps/mobile/jest.config.cjs --runTestsByPath apps/mobile/src/app/delete-account.test.tsx --runInBand --no-coverage --forceExit`
- `pnpm exec jest --config apps/api/jest.config.cjs --testMatch "**/apps/api/src/services/app-help-map.test.ts" --runInBand --no-coverage --passWithNoTests=false`
- `pnpm eval:llm`
- `pnpm exec prettier --check ...`
- `pnpm exec eslint ...`
- `pnpm exec tsc --build --pretty false`
- `pnpm exec nx run mobile:test` via `scripts/record-test-receipt.sh mobile`