### PR TITLE
Fix library shelves and child report flows

### DIFF
--- a/apps/mobile/src/app/(app)/child/[profileId]/index.test.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/index.test.tsx
@@ -18,6 +18,9 @@ jest.mock('react-i18next', () => ({
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
 const mockGoBackOrReplace = jest.fn();
+let mockLocalSearchParams: { profileId: string; mode?: string } = {
+  profileId: 'child-001',
+};
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({
@@ -26,7 +29,7 @@ jest.mock('expo-router', () => ({
     replace: mockReplace,
     push: mockPush,
   }),
-  useLocalSearchParams: () => ({ profileId: 'child-001' }),
+  useLocalSearchParams: () => mockLocalSearchParams,
 }));
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -153,6 +156,8 @@ const { default: ChildDetailScreen } = require('./index') as {
 // ---------------------------------------------------------------------------
 
 function setupDefaultMocks() {
+  mockLocalSearchParams = { profileId: 'child-001' };
+
   mockUseDashboard.mockReturnValue({
     data: undefined,
     isLoading: false,
@@ -375,6 +380,38 @@ describe('ChildDetailScreen — profile overview', () => {
     expect(screen.queryByTestId('child-reports-button')).toBeNull();
     expect(screen.queryByTestId('growth-teaser')).toBeNull();
     screen.getByTestId('consent-section');
+  });
+
+  it('shows only child settings when opened from the child avatar card', () => {
+    mockLocalSearchParams = { profileId: 'child-001', mode: 'settings' };
+
+    render(<ChildDetailScreen />);
+
+    expect(screen.queryByTestId('child-reports-link')).toBeNull();
+    expect(screen.queryByTestId('child-subjects-section')).toBeNull();
+    expect(
+      screen.queryByTestId('session-card-22222222-2222-7222-8222-222222222222'),
+    ).toBeNull();
+    screen.getByTestId('child-accommodation-row-child-001');
+    screen.getByTestId('mentor-memory-link');
+    screen.getByTestId('child-profile-details');
+    screen.getByTestId('consent-section');
+  });
+
+  it('shows only child progress when opened from the Progress action', () => {
+    mockLocalSearchParams = { profileId: 'child-001', mode: 'progress' };
+
+    render(<ChildDetailScreen />);
+
+    expect(screen.queryByTestId('child-reports-link')).toBeNull();
+    screen.getByTestId('child-subjects-section');
+    screen.getByTestId('session-card-22222222-2222-7222-8222-222222222222');
+    expect(
+      screen.queryByTestId('child-accommodation-row-child-001'),
+    ).toBeNull();
+    expect(screen.queryByTestId('mentor-memory-link')).toBeNull();
+    expect(screen.queryByTestId('child-profile-details')).toBeNull();
+    expect(screen.queryByTestId('consent-section')).toBeNull();
   });
 
   it('keeps the child progress surface open when the detail query fails but dashboard data has the child', () => {

--- a/apps/mobile/src/app/(app)/child/[profileId]/index.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/index.tsx
@@ -419,12 +419,16 @@ export default function ChildDetailScreen(): React.ReactElement {
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
   const { profiles } = useProfile();
-  const { profileId: rawProfileId } = useLocalSearchParams<{
+  const { profileId: rawProfileId, mode: rawMode } = useLocalSearchParams<{
     profileId: string;
+    mode?: string;
   }>();
   const profileId = Array.isArray(rawProfileId)
     ? rawProfileId[0]
     : rawProfileId;
+  const mode = Array.isArray(rawMode) ? rawMode[0] : rawMode;
+  const showSettingsOnly = mode === 'settings';
+  const showProgressOnly = mode === 'progress';
 
   const ownedProfile = useMemo(
     () => profiles.find((profile) => profile.id === profileId),
@@ -589,25 +593,27 @@ export default function ChildDetailScreen(): React.ReactElement {
         contentContainerStyle={{ paddingBottom: insets.bottom + 24 }}
         testID="child-detail-scroll"
       >
-        <RowLink
-          icon="document-text-outline"
-          title={t('parentView.reports.title', {
-            defaultValue: 'Reports',
-          })}
-          subtitle={t('parentView.index.reportsSubtitle', {
-            name: childName,
-            defaultValue: `Weekly and monthly updates for ${childName}`,
-          })}
-          onPress={() =>
-            router.push({
-              pathname: '/(app)/child/[profileId]/reports',
-              params: { profileId },
-            } as Href)
-          }
-          testID="child-reports-link"
-        />
+        {!showSettingsOnly && !showProgressOnly ? (
+          <RowLink
+            icon="document-text-outline"
+            title={t('parentView.reports.title', {
+              defaultValue: 'Reports',
+            })}
+            subtitle={t('parentView.index.reportsSubtitle', {
+              name: childName,
+              defaultValue: `Weekly and monthly updates for ${childName}`,
+            })}
+            onPress={() =>
+              router.push({
+                pathname: '/(app)/child/[profileId]/reports',
+                params: { profileId },
+              } as Href)
+            }
+            testID="child-reports-link"
+          />
+        ) : null}
 
-        {child?.subjects && child.subjects.length > 0 ? (
+        {!showSettingsOnly && child?.subjects && child.subjects.length > 0 ? (
           <View className="mt-6" testID="child-subjects-section">
             <Text className="text-h3 font-semibold text-text-primary mb-1">
               {t('parentView.index.subjects', {
@@ -624,82 +630,88 @@ export default function ChildDetailScreen(): React.ReactElement {
           </View>
         ) : null}
 
-        <RecentSessionsList
-          profileId={profileId}
-          sessionsQuery={sessionsQuery}
-        />
-
-        {profileId && child?.displayName ? (
-          <RowLink
-            icon="options-outline"
-            title={t('more.accommodation.childScreenTitle', {
-              name: child.displayName,
-            })}
-            subtitle={
-              activeAccommodation
-                ? `${activeAccommodation.title} - ${activeAccommodation.description}`
-                : t('parentView.index.noLearningPreferenceSet', {
-                    defaultValue: 'No learning preference set',
-                  })
-            }
-            onPress={() =>
-              router.push(
-                `/(app)/more/accommodation?childProfileId=${profileId}` as Href,
-              )
-            }
-            testID={`child-accommodation-row-${profileId}`}
+        {!showSettingsOnly ? (
+          <RecentSessionsList
+            profileId={profileId}
+            sessionsQuery={sessionsQuery}
           />
         ) : null}
 
-        <RowLink
-          icon="sparkles-outline"
-          title={t('parentView.index.mentorMemoryTitleFallback')}
-          subtitle={t('parentView.index.manageMentorMemoryForChild', {
-            name: childName,
-            defaultValue: `Manage what the mentor remembers about ${childName}`,
-          })}
-          onPress={() =>
-            router.push({
-              pathname: '/(app)/child/[profileId]/mentor-memory',
-              params: { profileId },
-            } as Href)
-          }
-          testID="mentor-memory-link"
-        />
+        {!showProgressOnly ? (
+          <>
+            {profileId && child?.displayName ? (
+              <RowLink
+                icon="options-outline"
+                title={t('more.accommodation.childScreenTitle', {
+                  name: child.displayName,
+                })}
+                subtitle={
+                  activeAccommodation
+                    ? `${activeAccommodation.title} - ${activeAccommodation.description}`
+                    : t('parentView.index.noLearningPreferenceSet', {
+                        defaultValue: 'No learning preference set',
+                      })
+                }
+                onPress={() =>
+                  router.push(
+                    `/(app)/more/accommodation?childProfileId=${profileId}` as Href,
+                  )
+                }
+                testID={`child-accommodation-row-${profileId}`}
+              />
+            ) : null}
 
-        {joinedLabel ? (
-          <InfoRow
-            label={t('parentView.index.profileDetails', {
-              defaultValue: 'Profile details',
-            })}
-            value={t('parentView.index.childProfileJoined', {
-              date: joinedLabel,
-              defaultValue: `Added ${joinedLabel}`,
-            })}
-            testID="child-profile-details"
-          />
-        ) : null}
-
-        <ConsentManagementSection
-          childProfileId={profileId}
-          childName={childName}
-        />
-
-        <View className="mt-5 rounded-card bg-primary-soft px-4 py-3">
-          <View className="flex-row items-start">
-            <Ionicons
-              name="information-circle-outline"
-              size={18}
-              color={colors.primary}
-            />
-            <Text className="text-caption text-text-secondary ms-2 flex-1">
-              {t('parentView.index.childProfileScopeHint', {
-                defaultValue:
-                  'Progress and reports live in their own tabs, so this page only keeps child-specific settings.',
+            <RowLink
+              icon="sparkles-outline"
+              title={t('parentView.index.mentorMemoryTitleFallback')}
+              subtitle={t('parentView.index.manageMentorMemoryForChild', {
+                name: childName,
+                defaultValue: `Manage what the mentor remembers about ${childName}`,
               })}
-            </Text>
-          </View>
-        </View>
+              onPress={() =>
+                router.push({
+                  pathname: '/(app)/child/[profileId]/mentor-memory',
+                  params: { profileId },
+                } as Href)
+              }
+              testID="mentor-memory-link"
+            />
+
+            {joinedLabel ? (
+              <InfoRow
+                label={t('parentView.index.profileDetails', {
+                  defaultValue: 'Profile details',
+                })}
+                value={t('parentView.index.childProfileJoined', {
+                  date: joinedLabel,
+                  defaultValue: `Added ${joinedLabel}`,
+                })}
+                testID="child-profile-details"
+              />
+            ) : null}
+
+            <ConsentManagementSection
+              childProfileId={profileId}
+              childName={childName}
+            />
+
+            <View className="mt-5 rounded-card bg-primary-soft px-4 py-3">
+              <View className="flex-row items-start">
+                <Ionicons
+                  name="information-circle-outline"
+                  size={18}
+                  color={colors.primary}
+                />
+                <Text className="text-caption text-text-secondary ms-2 flex-1">
+                  {t('parentView.index.childProfileScopeHint', {
+                    defaultValue:
+                      'Progress and reports live in their own tabs, so this page only keeps child-specific settings.',
+                  })}
+                </Text>
+              </View>
+            </View>
+          </>
+        ) : null}
       </ScrollView>
     </View>
   );

--- a/apps/mobile/src/app/(app)/child/[profileId]/reports.test.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/reports.test.tsx
@@ -256,6 +256,72 @@ describe('ChildReportsScreen', () => {
       expect(screen.getAllByText('+2 vs last week').length).toBeGreaterThan(0);
     });
 
+    it('opens older weekly reports inline and can return to the latest report', () => {
+      mockUseChildWeeklyReports.mockReturnValue({
+        data: [
+          {
+            id: 'wr-latest',
+            reportWeek: '2026-05-11',
+            viewedAt: '2026-05-12T03:00:00Z',
+            createdAt: '2026-05-18T03:00:00Z',
+            headlineStat: {
+              label: 'Topics mastered',
+              value: '4',
+              comparison: '+2 vs last week',
+            },
+            thisWeek: {
+              totalSessions: 5,
+              totalActiveMinutes: 120,
+              topicsMastered: 4,
+              topicsExplored: 8,
+              vocabularyTotal: 50,
+              streakBest: 3,
+            },
+          },
+          {
+            id: 'wr-older',
+            reportWeek: '2026-05-04',
+            viewedAt: null,
+            createdAt: '2026-05-11T03:00:00Z',
+            headlineStat: {
+              label: 'Topics mastered',
+              value: '1',
+              comparison: '+1 vs last week',
+            },
+            thisWeek: {
+              totalSessions: 2,
+              totalActiveMinutes: 30,
+              topicsMastered: 1,
+              topicsExplored: 2,
+              vocabularyTotal: 10,
+              streakBest: 1,
+            },
+          },
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      });
+      mockUseChildReports.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      });
+
+      render(<ChildReportsScreen />);
+
+      screen.getByText('Topics mastered: 4');
+      fireEvent.press(screen.getByTestId('weekly-report-card-wr-older'));
+
+      screen.getByText('Topics mastered: 1');
+      screen.getByTestId('child-reports-back-to-latest');
+      expect(mockPush).not.toHaveBeenCalled();
+
+      fireEvent.press(screen.getByTestId('child-reports-back-to-latest'));
+      screen.getByText('Topics mastered: 4');
+    });
+
     it('renders report cards when reports exist', () => {
       mockUseChildReports.mockReturnValue({
         data: [

--- a/apps/mobile/src/app/(app)/child/[profileId]/reports.tsx
+++ b/apps/mobile/src/app/(app)/child/[profileId]/reports.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter, type Href } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -69,6 +70,7 @@ function ReportsHeaderSummary({
 }: {
   latestReport: WeeklyReportSummary | undefined;
 }): React.ReactElement | null {
+  const { t } = useTranslation();
   if (!latestReport?.headlineStat) return null;
   const { headlineStat, thisWeek } = latestReport;
   return (
@@ -88,9 +90,40 @@ function ReportsHeaderSummary({
         </Text>
       ) : null}
       {thisWeek ? (
-        <Text className="text-caption text-text-secondary mt-2">
-          {thisWeek.totalSessions} sessions · {thisWeek.totalActiveMinutes} min
-        </Text>
+        <View className="flex-row flex-wrap mt-3" style={{ gap: 18 }}>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.sessionsThisWeek')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.totalSessions}
+            </Text>
+          </View>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.timeOnApp')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.totalActiveMinutes} min
+            </Text>
+          </View>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.topicsMastered')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.topicsMastered}
+            </Text>
+          </View>
+          <View>
+            <Text className="text-caption text-text-secondary">
+              {t('parentView.weeklyReport.totalWordsKnown')}
+            </Text>
+            <Text className="text-body font-semibold text-text-primary mt-1">
+              {thisWeek.vocabularyTotal}
+            </Text>
+          </View>
+        </View>
       ) : null}
     </View>
   );
@@ -121,6 +154,9 @@ export default function ChildReportsScreen(): React.ReactElement {
     refetch: weeklyRefetch,
   } = useChildWeeklyReports(profileId);
   const childName = child?.displayName ?? t('parentView.index.yourChild');
+  const [selectedWeeklyReportId, setSelectedWeeklyReportId] = useState<
+    string | null
+  >(null);
 
   const combinedLoading = isLoading || weeklyLoading;
   const hasAnyData =
@@ -130,6 +166,26 @@ export default function ChildReportsScreen(): React.ReactElement {
   // showed neither an error banner nor a retry path. The retry handler
   // already calls both refetches, so widening this condition is sufficient.
   const combinedError = !hasAnyData && (isError || weeklyError);
+  const latestWeeklyReport = weeklyReports?.[0];
+  const selectedWeeklyReport = useMemo(() => {
+    if (!weeklyReports?.length) return undefined;
+    return (
+      weeklyReports.find((report) => report.id === selectedWeeklyReportId) ??
+      latestWeeklyReport
+    );
+  }, [latestWeeklyReport, selectedWeeklyReportId, weeklyReports]);
+  const remainingWeeklyReports = useMemo(
+    () =>
+      (weeklyReports ?? []).filter(
+        (report) => report.id !== selectedWeeklyReport?.id,
+      ),
+    [selectedWeeklyReport?.id, weeklyReports],
+  );
+  const hasOtherReports =
+    remainingWeeklyReports.length > 0 || (reports?.length ?? 0) > 0;
+  const isViewingLatestWeeklyReport =
+    !!selectedWeeklyReport &&
+    selectedWeeklyReport.id === latestWeeklyReport?.id;
 
   return (
     <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
@@ -164,7 +220,22 @@ export default function ChildReportsScreen(): React.ReactElement {
           </View>
         </View>
 
-        <ReportsHeaderSummary latestReport={weeklyReports?.[0]} />
+        <ReportsHeaderSummary latestReport={selectedWeeklyReport} />
+        {selectedWeeklyReport && !isViewingLatestWeeklyReport ? (
+          <Pressable
+            onPress={() =>
+              setSelectedWeeklyReportId(latestWeeklyReport?.id ?? null)
+            }
+            className="self-start mt-3 px-1 py-2"
+            accessibilityRole="button"
+            accessibilityLabel={t('parentView.reports.backToLatest')}
+            testID="child-reports-back-to-latest"
+          >
+            <Text className="text-body-sm font-semibold text-primary">
+              {t('parentView.reports.backToLatest')}
+            </Text>
+          </Pressable>
+        ) : null}
 
         {combinedLoading ? (
           <View className="bg-surface rounded-card p-4 mt-4">
@@ -222,11 +293,11 @@ export default function ChildReportsScreen(): React.ReactElement {
               </Pressable>
             </View>
           </View>
-        ) : hasAnyData ? (
+        ) : hasAnyData && hasOtherReports ? (
           <View className="mt-4">
             <ReportsList
               monthlyReports={reports ?? []}
-              weeklyReports={weeklyReports ?? []}
+              weeklyReports={remainingWeeklyReports}
               onPressMonthly={(reportId) => {
                 if (!profileId) return;
                 router.push({
@@ -235,12 +306,7 @@ export default function ChildReportsScreen(): React.ReactElement {
                 } as Href);
               }}
               onPressWeekly={(reportId) => {
-                if (!profileId) return;
-                router.push({
-                  pathname:
-                    '/(app)/child/[profileId]/weekly-report/[weeklyReportId]',
-                  params: { profileId, weeklyReportId: reportId },
-                } as Href);
+                setSelectedWeeklyReportId(reportId);
               }}
               showNewBadge
             />

--- a/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.test.tsx
@@ -225,7 +225,7 @@ describe('ParentHomeScreen', () => {
     fireEvent.press(screen.getByTestId('parent-home-check-child-child-a'));
     expect(mockPush).toHaveBeenLastCalledWith({
       pathname: '/(app)/child/[profileId]',
-      params: { profileId: 'child-a' },
+      params: { profileId: 'child-a', mode: 'settings' },
     });
   });
 
@@ -238,7 +238,7 @@ describe('ParentHomeScreen', () => {
     fireEvent.press(screen.getByTestId('parent-home-child-progress-child-a'));
     expect(mockPush).toHaveBeenLastCalledWith({
       pathname: '/(app)/child/[profileId]',
-      params: { profileId: 'child-a' },
+      params: { profileId: 'child-a', mode: 'progress' },
     });
   });
 
@@ -331,7 +331,7 @@ describe('ParentHomeScreen', () => {
     fireEvent.press(screen.getByTestId('parent-home-tonight-child-a-primary'));
     expect(mockPush).toHaveBeenLastCalledWith({
       pathname: '/(app)/child/[profileId]',
-      params: { profileId: 'child-a' },
+      params: { profileId: 'child-a', mode: 'progress' },
     });
   });
 

--- a/apps/mobile/src/components/home/ParentHomeScreen.tsx
+++ b/apps/mobile/src/components/home/ParentHomeScreen.tsx
@@ -879,7 +879,7 @@ export function ParentHomeScreen({
     (childProfileId: string): void => {
       router.push({
         pathname: '/(app)/child/[profileId]',
-        params: { profileId: childProfileId },
+        params: { profileId: childProfileId, mode: 'settings' },
       } as Href);
     },
     [router],
@@ -889,7 +889,7 @@ export function ParentHomeScreen({
     (childProfileId: string): void => {
       router.push({
         pathname: '/(app)/child/[profileId]',
-        params: { profileId: childProfileId },
+        params: { profileId: childProfileId, mode: 'progress' },
       } as Href);
     },
     [router],

--- a/apps/mobile/src/components/library/ShelfRow.test.tsx
+++ b/apps/mobile/src/components/library/ShelfRow.test.tsx
@@ -59,6 +59,20 @@ describe('ShelfRow', () => {
     screen.getByTestId('shelf-row-bookshelf-sub-math');
   });
 
+  it('keeps each shelf as a compact horizontal row', () => {
+    render(<ShelfRow {...defaultProps} />);
+
+    const header = screen.getByTestId('shelf-row-header-sub-math');
+    expect(header.props.style).toEqual(
+      expect.objectContaining({
+        alignItems: 'center',
+        flexDirection: 'row',
+        paddingVertical: 12,
+      }),
+    );
+    expect(header.props.style).not.toHaveProperty('minHeight');
+  });
+
   it('opens the subject shelf when header is pressed', () => {
     const onPress = jest.fn();
     render(<ShelfRow {...defaultProps} onPress={onPress} />);

--- a/apps/mobile/src/components/library/ShelfRow.tsx
+++ b/apps/mobile/src/components/library/ShelfRow.tsx
@@ -76,7 +76,7 @@ export function ShelfRow({
   const showFinished = isFinished && !needsReview;
 
   return (
-    <View style={{ marginBottom: 12, opacity: isInactive ? 0.65 : 1 }}>
+    <View style={{ opacity: isInactive ? 0.65 : 1 }}>
       <Pressable
         testID={testID ?? `shelf-row-header-${subjectId}`}
         onPress={() => onPress(subjectId)}
@@ -92,29 +92,24 @@ export function ShelfRow({
               : '',
           action: t('library.row.shelfActionOpen'),
         })}
-        style={({ pressed }) => ({
-          backgroundColor: tint.soft,
-          borderColor: tint.solid + '33',
-          borderRadius: 16,
-          borderWidth: 1,
+        style={{
           flexDirection: 'row',
-          alignItems: 'flex-start',
-          minHeight: 108,
+          alignItems: 'center',
+          paddingVertical: 12,
           paddingHorizontal: 16,
-          paddingVertical: 18,
-          opacity: pressed ? 0.76 : 1,
-        })}
+          gap: 12,
+        }}
       >
         <SubjectBookshelfMotif
           testID={`shelf-row-bookshelf-${subjectId}`}
           tint={tint}
         />
 
-        <View style={{ flex: 1, marginLeft: 14, minWidth: 0 }}>
+        <View style={{ flex: 1 }}>
           <Text
             style={{
-              fontSize: 19,
-              fontWeight: '700',
+              fontSize: 15,
+              fontWeight: 'bold',
               color: colors.textPrimary,
             }}
             numberOfLines={1}
@@ -123,113 +118,103 @@ export function ShelfRow({
           </Text>
           <Text
             style={{
-              fontSize: 15,
+              fontSize: 12,
               color: isUnstarted ? tint.solid : colors.textSecondary,
-              fontWeight: isUnstarted ? '600' : '400',
-              marginTop: 4,
+              fontWeight: isUnstarted ? '500' : 'normal',
+              marginTop: 1,
             }}
             numberOfLines={1}
           >
             {subtitle}
           </Text>
-
-          <View
-            style={{
-              alignItems: 'center',
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              gap: 8,
-              marginTop: 10,
-            }}
-          >
-            {statusChip ? (
-              <View
-                testID={statusChip.testID}
-                style={{
-                  paddingHorizontal: 10,
-                  paddingVertical: 4,
-                  borderRadius: 999,
-                  backgroundColor: statusChip.backgroundColor,
-                }}
-              >
-                <Text
-                  style={{
-                    fontSize: 12,
-                    fontWeight: '700',
-                    color: statusChip.color,
-                  }}
-                >
-                  {statusChip.label}
-                </Text>
-              </View>
-            ) : null}
-
-            {needsReview ? (
-              <View
-                testID={`shelf-row-review-${subjectId}`}
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 4,
-                  paddingHorizontal: 10,
-                  paddingVertical: 4,
-                  borderRadius: 999,
-                  backgroundColor: colors.retentionWeak + '22',
-                }}
-              >
-                <Ionicons
-                  name="refresh-circle"
-                  size={13}
-                  color={colors.retentionWeak}
-                />
-                <Text
-                  style={{
-                    fontSize: 12,
-                    fontWeight: '700',
-                    color: colors.retentionWeak,
-                  }}
-                >
-                  {t('library.row.review')}
-                </Text>
-              </View>
-            ) : null}
-
-            {showFinished ? (
-              <View
-                testID={`shelf-row-finished-${subjectId}`}
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 4,
-                  paddingHorizontal: 10,
-                  paddingVertical: 4,
-                  borderRadius: 999,
-                  backgroundColor: colors.success + '22',
-                }}
-              >
-                <Ionicons
-                  name="checkmark-circle"
-                  size={13}
-                  color={colors.success}
-                />
-                <Text
-                  style={{
-                    fontSize: 12,
-                    fontWeight: '700',
-                    color: colors.success,
-                  }}
-                >
-                  {t('library.row.finished')}
-                </Text>
-              </View>
-            ) : null}
-          </View>
         </View>
 
-        <View style={{ paddingTop: 8 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+          {statusChip ? (
+            <View
+              testID={statusChip.testID}
+              style={{
+                paddingHorizontal: 8,
+                paddingVertical: 2,
+                borderRadius: 10,
+                backgroundColor: statusChip.backgroundColor,
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 11,
+                  fontWeight: '500',
+                  color: statusChip.color,
+                }}
+              >
+                {statusChip.label}
+              </Text>
+            </View>
+          ) : null}
+
+          {needsReview ? (
+            <View
+              testID={`shelf-row-review-${subjectId}`}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 3,
+                paddingHorizontal: 8,
+                paddingVertical: 2,
+                borderRadius: 10,
+                backgroundColor: colors.retentionWeak + '22',
+              }}
+            >
+              <Ionicons
+                name="refresh-circle"
+                size={12}
+                color={colors.retentionWeak}
+              />
+              <Text
+                style={{
+                  fontSize: 11,
+                  fontWeight: '600',
+                  color: colors.retentionWeak,
+                }}
+              >
+                {t('library.row.review')}
+              </Text>
+            </View>
+          ) : null}
+
+          {showFinished ? (
+            <View
+              testID={`shelf-row-finished-${subjectId}`}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 3,
+                paddingHorizontal: 8,
+                paddingVertical: 2,
+                borderRadius: 10,
+                backgroundColor: colors.success + '22',
+              }}
+            >
+              <Ionicons
+                name="checkmark-circle"
+                size={12}
+                color={colors.success}
+              />
+              <Text
+                style={{
+                  fontSize: 11,
+                  fontWeight: '600',
+                  color: colors.success,
+                }}
+              >
+                {t('library.row.finished')}
+              </Text>
+            </View>
+          ) : null}
+
           <Ionicons
             name="chevron-forward"
-            size={22}
+            size={16}
             color={colors.textSecondary}
             accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "Wöchentliche Momentaufnahme",
       "monthlyReport": "Monatsbericht",
       "newBadge": "Neu",
+      "backToLatest": "Zurück zum neuesten Bericht",
       "nextReportIn": "Nächster Bericht in {{timeContext}}",
       "noReportScheduled": "Kein Bericht geplant",
       "subtitle": "Monatliche und wöchentliche Lernzusammenfassungen",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -1995,6 +1995,7 @@
       "weeklySnapshot": "Weekly snapshot",
       "monthlyReport": "Monthly report",
       "newBadge": "New",
+      "backToLatest": "Back to latest report",
       "nextReportIn": "Next report in {{timeContext}}",
       "noReportScheduled": "No report scheduled",
       "subtitle": "Monthly and weekly learning summaries",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "Resumen semanal",
       "monthlyReport": "Informe mensual",
       "newBadge": "Nuevo",
+      "backToLatest": "Volver al informe más reciente",
       "nextReportIn": "Próximo informe en {{timeContext}}",
       "noReportScheduled": "No hay informe programado",
       "subtitle": "Resúmenes de aprendizaje mensuales y semanales",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "週次スナップショット",
       "monthlyReport": "月次レポート",
       "newBadge": "新規",
+      "backToLatest": "最新のレポートに戻る",
       "nextReportIn": "次のレポートまで{{timeContext}}",
       "noReportScheduled": "レポートの予定はありません",
       "subtitle": "月次および週次の学習要約",

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -1925,6 +1925,7 @@
       "weeklySnapshot": "Ukentlig øyeblikksbilde",
       "monthlyReport": "Månedsrapport",
       "newBadge": "Ny",
+      "backToLatest": "Tilbake til nyeste rapport",
       "nextReportIn": "Neste rapport om {{timeContext}}",
       "noReportScheduled": "Ingen rapport planlagt",
       "subtitle": "Månedlige og ukentlige læringssammendrag",

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -1950,6 +1950,7 @@
       "weeklySnapshot": "Migawka tygodniowa",
       "monthlyReport": "Raport miesięczny",
       "newBadge": "Nowy",
+      "backToLatest": "Wróć do najnowszego raportu",
       "nextReportIn": "Następny raport za {{timeContext}}",
       "noReportScheduled": "Brak zaplanowanego raportu",
       "subtitle": "Miesięczne i tygodniowe podsumowania nauki",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -1950,6 +1950,7 @@
       "weeklySnapshot": "Resumo semanal",
       "monthlyReport": "Relatório mensal",
       "newBadge": "Novo",
+      "backToLatest": "Voltar ao relatório mais recente",
       "nextReportIn": "Próximo relatório em {{timeContext}}",
       "noReportScheduled": "Nenhum relatório agendado",
       "subtitle": "Resumos de aprendizado mensais e semanais",


### PR DESCRIPTION
## Summary

Fixes the parent/library regressions from the recent UI work: library subject shelves are compact rows again, the parent child card routes split settings vs progress instead of opening the same combined screen, and the child Reports tab now opens the latest weekly report inline while keeping older reports selectable underneath with a Back to latest report action.

## Verified-By

- [x] `pnpm exec tsc --build` - pass via pre-commit hook
- [x] lint-staged eslint/prettier - pass on affected staged files
- [x] Tests:
    - `pnpm exec jest --runTestsByPath "C:/Dev/Projects/Products/Apps/eduagent-build/apps/mobile/src/components/library/ShelfRow.test.tsx" "C:/Dev/Projects/Products/Apps/eduagent-build/apps/mobile/src/components/home/ParentHomeScreen.test.tsx" "C:/Dev/Projects/Products/Apps/eduagent-build/apps/mobile/src/app/(app)/child/[profileId]/index.test.tsx" "C:/Dev/Projects/Products/Apps/eduagent-build/apps/mobile/src/app/(app)/child/[profileId]/reports.test.tsx" --no-coverage` - 69 passed, 0 failed
    - `bash scripts/record-test-receipt.sh mobile` - 145 passed, 0 failed; receipt written
    - pre-commit related mobile tests - 124 passed, 0 failed
- [x] If mobile TS/TSX files changed: `.test-receipts/mobile.json` committed in this PR and fresh within 24h

## Failure modes considered

- Parent child avatar/card and Progress action previously landed on the same combined child screen. They now carry explicit `settings` and `progress` modes, with tests asserting each mode hides the other surface.
- Weekly report cards previously navigated away from the reports list. They now swap the selected report inline, and older selections expose a direct Back to latest report action.
- Library shelf rows previously expanded into large card-like blocks. The compact horizontal row shape is restored and covered by a regression test.

## Sweep audit (if claiming a sweep)

N/A - no sweep claimed.

## Notes for reviewers

Known local test noise remains: duplicate Stripe manual mock warning from `.worktrees/next-phase-2026-05-14`, Expo native module warnings, baseline-browser-mapping staleness, and an existing LibraryScreen act warning. Tests passed despite those warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mode-based navigation for child profiles: access settings or progress views from different entry points.
  * Enabled in-screen weekly report selection with a "back to latest" control for easy report browsing.

* **Tests**
  * Updated test coverage for conditional rendering and navigation modes.
  * Added verification for weekly report selection behavior.

* **Chores**
  * Updated localization for new "back to latest report" feature across supported languages.
  * Refined shelf component styling for improved layout consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/294)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->