### PR TITLE
fix(mobile): open progress reports by default

### DIFF
--- a/apps/mobile/e2e/flows/progress/progress-analytics.yaml
+++ b/apps/mobile/e2e/flows/progress/progress-analytics.yaml
@@ -1,7 +1,7 @@
-# Progress analytics - index, subject detail, milestones empty state
+# Progress analytics - index, subject detail, recent sessions expansion
 # Tags: nightly, progress
 # Seed: learning-active
-# Covers: progress index rendering, subject drill-down, milestones empty state
+# Covers: progress index rendering, subject drill-down, recent sessions list
 # Usage: ./scripts/seed-and-run.sh learning-active flows/progress/progress-analytics.yaml
 appId: com.mentomate.app
 tags:
@@ -37,30 +37,32 @@ tags:
 - tapOn:
     id: "progress-subject-back"
 
+- scrollUntilVisible:
+    element:
+      id: "progress-show-all-sessions"
+    direction: DOWN
+    timeout: 10000
+
 - extendedWaitUntil:
     visible:
-      id: "progress-milestones-see-all"
+      id: "progress-show-all-sessions"
     timeout: 10000
 
 - tapOn:
-    id: "progress-milestones-see-all"
+    id: "progress-show-all-sessions"
+
+- scrollUntilVisible:
+    element:
+      id: "recent-sessions-list"
+    direction: DOWN
+    timeout: 10000
 
 - extendedWaitUntil:
     visible:
-      id: "milestones-back"
+      id: "recent-sessions-list"
     timeout: 10000
 
 - assertVisible:
-    id: "milestones-empty"
+    id: "recent-sessions-list"
 
-- takeScreenshot: 03-milestones-empty
-
-- tapOn:
-    id: "milestones-back"
-
-- extendedWaitUntil:
-    visible:
-      id: "journey-subject-${SUBJECT_ID}"
-    timeout: 10000
-
-- takeScreenshot: 04-back-to-index
+- takeScreenshot: 03-recent-sessions-expanded

--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -136,7 +136,7 @@ jest.mock('react-i18next', () => ({
         const count = opts?.count as number;
         return `${count} practice point${count === 1 ? '' : 's'}`;
       }
-      if (key === 'progress.recentFocus.title') return 'Recent focus';
+      if (key === 'progress.recentFocus.title') return 'Recent sessions';
       if (key === 'progress.recentFocus.showAll') return 'Show all sessions';
       if (key === 'progress.recentFocus.empty')
         return 'Recent sessions will appear here once learning gets going.';
@@ -557,7 +557,7 @@ describe('ProgressScreen — progressive disclosure', () => {
     expect(refs.refreshSnapshot).toHaveBeenCalled();
     expect(refs.monthlyReportsRefetch).toHaveBeenCalled();
     expect(refs.weeklyReportsRefetch).toHaveBeenCalled();
-    expect(refs.milestonesRefetch).toHaveBeenCalled();
+    expect(refs.milestonesRefetch).not.toHaveBeenCalled();
   });
 
   it('keeps the focus refresh callback stable across render updates', () => {
@@ -652,6 +652,35 @@ describe('ProgressScreen — progressive disclosure', () => {
     screen.getByText('45 practice points');
   });
 
+  it('opens the latest report card even when a legacy summary has no metrics', () => {
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 5, topicsMastered: 2 },
+        subjects: [fullSubject],
+      },
+      weeklyReports: [
+        {
+          id: 'weekly-legacy',
+          reportWeek: '2026-05-11',
+          viewedAt: null,
+          createdAt: '2026-05-17T00:00:00Z',
+          headlineStat: {
+            label: 'sessions this week',
+            value: 4,
+            comparison: 'steady rhythm',
+          },
+        },
+      ],
+    });
+
+    render(<ProgressScreen />);
+
+    screen.getByTestId('progress-latest-report-card');
+    screen.getByText('4 sessions this week');
+    expect(screen.getAllByText('steady rhythm').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('progress-latest-report-empty')).toBeNull();
+  });
+
   it('falls back to monthly report summary when no weekly report exists', () => {
     mockHooks({
       inventory: {
@@ -690,7 +719,7 @@ describe('ProgressScreen — progressive disclosure', () => {
     expect(screen.getAllByText('+3 from last month').length).toBeGreaterThan(0);
   });
 
-  it('shows recent focus from recent sessions and expands to the reused session list', () => {
+  it('shows recent sessions and expands to the reused session list', () => {
     mockHooks({
       inventory: {
         global: { ...baseGlobal, totalSessions: 5, topicsMastered: 2 },
@@ -744,7 +773,7 @@ describe('ProgressScreen — progressive disclosure', () => {
 
     render(<ProgressScreen />);
 
-    screen.getByText('Recent focus');
+    screen.getByText('Recent sessions');
     screen.getByText('Fractions');
     screen.getByText('Practiced comparing fractions.');
     screen.getByText('Biology');
@@ -982,7 +1011,7 @@ describe('ProgressScreen — progressive disclosure', () => {
     screen.getByText('My progress');
     screen.getByText('You learned 3 topics. Steady wins.');
     screen.getByText('Latest report');
-    screen.getByText('Recent focus');
+    screen.getByText('Recent sessions');
     expect(screen.queryByText('Your growth')).toBeNull();
     expect(screen.queryByText('Weekly report')).toBeNull();
   });
@@ -1001,8 +1030,23 @@ describe('ProgressScreen — progressive disclosure', () => {
     screen.getByText('My progress');
     screen.getByText('4 practice lessons');
     screen.getByText('Latest report');
-    screen.getByText('Recent focus');
+    screen.getByText('Recent sessions');
     expect(screen.queryByText('Your week')).toBeNull();
+  });
+
+  it('does not render the recent milestones block on the progress overview', () => {
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 5, topicsMastered: 1 },
+        subjects: [fullSubject],
+      },
+    });
+
+    render(<ProgressScreen />);
+
+    screen.getByText('Recent sessions');
+    expect(screen.queryByTestId('progress-milestones-see-all')).toBeNull();
+    expect(screen.queryByTestId('milestones-teaser')).toBeNull();
   });
 
   it('uses current focus areas as recent focus fallback when sessions are absent', () => {

--- a/apps/mobile/src/app/(app)/progress/index.tsx
+++ b/apps/mobile/src/app/(app)/progress/index.tsx
@@ -32,7 +32,6 @@ import {
 import { NudgeActionSheet } from '../../../components/nudge/NudgeActionSheet';
 import {
   MetricCard,
-  MilestoneCard,
   RecentSessionsList,
   ReportsList,
   SubjectProgressRow,
@@ -45,7 +44,6 @@ import {
   useLearningResumeTarget,
   useOverallProgress,
   useProgressInventory,
-  useProgressMilestones,
   useProfileReports,
   useProfileSessions,
   useProfileWeeklyReports,
@@ -136,22 +134,6 @@ function heroCopy(
   };
 }
 
-const MILESTONE_THRESHOLDS = [1, 3, 5, 10, 25, 50, 100];
-
-export function getNextMilestoneLabel(
-  totalSessions: number,
-  t: Translate,
-): string {
-  const next = MILESTONE_THRESHOLDS.find(
-    (threshold) => threshold > totalSessions,
-  );
-  if (next === undefined) {
-    return t('progress.milestones.allReached');
-  }
-  const remaining = next - totalSessions;
-  return t('progress.milestones.nextMilestone', { count: remaining });
-}
-
 function LoadingBlock(): React.ReactElement {
   return (
     <>
@@ -220,9 +202,10 @@ type LatestReport =
 
 function formatReportDate(report: LatestReport): string {
   if (report.kind === 'monthly') {
-    return new Date(
-      `${report.report.reportMonth}-01T00:00:00Z`,
-    ).toLocaleDateString(undefined, {
+    const reportMonth = /^\d{4}-\d{2}$/.test(report.report.reportMonth)
+      ? `${report.report.reportMonth}-01`
+      : report.report.reportMonth;
+    return new Date(`${reportMonth}T00:00:00Z`).toLocaleDateString(undefined, {
       month: 'long',
       timeZone: 'UTC',
       year: 'numeric',
@@ -319,7 +302,7 @@ function LatestReportCard({
               </Text>
             </Pressable>
           </View>
-        ) : latestReport && metrics ? (
+        ) : latestReport ? (
           <Pressable
             onPress={onOpen}
             accessibilityRole="button"
@@ -338,26 +321,30 @@ function LatestReportCard({
             <Text className="text-body-sm text-text-secondary mt-1">
               {latestReport.report.headlineStat.comparison}
             </Text>
-            <View className="flex-row gap-3 mt-4">
-              <MetricCard
-                label={t('progress.latestReport.sessions')}
-                value={String(metrics.totalSessions)}
-              />
-              <MetricCard
-                label={t('progress.latestReport.time')}
-                value={formatMinutes(metrics.totalActiveMinutes)}
-              />
-            </View>
-            <View className="flex-row gap-3 mt-3">
-              <MetricCard
-                label={t('progress.latestReport.topics')}
-                value={String(metrics.topicsMastered)}
-              />
-              <MetricCard
-                label={t('progress.latestReport.words')}
-                value={String(metrics.vocabularyTotal)}
-              />
-            </View>
+            {metrics ? (
+              <>
+                <View className="flex-row gap-3 mt-4">
+                  <MetricCard
+                    label={t('progress.latestReport.sessions')}
+                    value={String(metrics.totalSessions)}
+                  />
+                  <MetricCard
+                    label={t('progress.latestReport.time')}
+                    value={formatMinutes(metrics.totalActiveMinutes)}
+                  />
+                </View>
+                <View className="flex-row gap-3 mt-3">
+                  <MetricCard
+                    label={t('progress.latestReport.topics')}
+                    value={String(metrics.topicsMastered)}
+                  />
+                  <MetricCard
+                    label={t('progress.latestReport.words')}
+                    value={String(metrics.vocabularyTotal)}
+                  />
+                </View>
+              </>
+            ) : null}
             {practiceTotals &&
             (practiceTotals.activitiesCompleted > 0 ||
               practiceTotals.pointsEarned > 0) ? (
@@ -577,7 +564,6 @@ export default function ProgressScreen(): React.ReactElement {
     selectedProfileId || activeProfile?.id,
   );
   const resumeTargetQuery = useLearningResumeTarget();
-  const milestonesQuery = useProgressMilestones(5);
   const subjectsQuery = useSubjects();
   const {
     mutateAsync: refreshProgressSnapshot,
@@ -597,7 +583,6 @@ export default function ProgressScreen(): React.ReactElement {
   );
 
   const refetchInventory = inventoryQuery.refetch;
-  const refetchMilestones = milestonesQuery.refetch;
   const refetchMonthlyReports = monthlyReportsQuery.refetch;
   const refetchWeeklyReports = weeklyReportsQuery.refetch;
   const refetchChildSummary = childSummaryQuery.refetch;
@@ -621,13 +606,11 @@ export default function ProgressScreen(): React.ReactElement {
         refetchMonthlyReports(),
         refetchWeeklyReports(),
         ...(!isViewingSelf ? [refetchChildSummary()] : []),
-        ...(isViewingSelf ? [refetchMilestones()] : []),
       ]);
     },
     [
       isViewingSelf,
       refetchInventory,
-      refetchMilestones,
       refetchMonthlyReports,
       refetchWeeklyReports,
       refetchChildSummary,
@@ -1016,6 +999,42 @@ export default function ProgressScreen(): React.ReactElement {
               }}
             />
 
+            {selectedProfileId && hasAnyReports ? (
+              <View
+                className="bg-surface rounded-card p-4 mt-6"
+                testID="reports-list-card"
+              >
+                <View className="flex-row items-center justify-between mb-1">
+                  <Text className="text-body font-semibold text-text-primary">
+                    {t('progress.previousReports.title')}
+                  </Text>
+                  <Pressable
+                    onPress={() =>
+                      router.push(
+                        isViewingSelf
+                          ? ('/(app)/progress/reports' as Href)
+                          : (`/(app)/child/${selectedProfileId}/reports` as Href),
+                      )
+                    }
+                    accessibilityRole="button"
+                    accessibilityLabel={t('progress.previousReports.viewAll')}
+                    testID="progress-reports-link"
+                  >
+                    <Text className="text-body-sm text-primary font-semibold">
+                      {t('progress.previousReports.viewAll')}
+                    </Text>
+                  </Pressable>
+                </View>
+                <ReportsList
+                  monthlyReports={monthlyReportsQuery.data ?? []}
+                  weeklyReports={weeklyReportsQuery.data ?? []}
+                  limit={2}
+                  onPressMonthly={handleOpenMonthlyReport}
+                  onPressWeekly={handleOpenWeeklyReport}
+                />
+              </View>
+            ) : null}
+
             {!isViewingSelf ? (
               <>
                 {childSummaryQuery.data ? (
@@ -1039,7 +1058,7 @@ export default function ProgressScreen(): React.ReactElement {
                     </Text>
                   </Pressable>
                 ) : null}
-                {selectedProfileId ? (
+                {selectedProfileId && !hasAnyReports ? (
                   <Pressable
                     testID="progress-view-all-reports"
                     onPress={() =>
@@ -1090,118 +1109,30 @@ export default function ProgressScreen(): React.ReactElement {
               />
             ) : null}
 
-            {selectedProfileId && hasAnyReports ? (
-              <View
-                className="bg-surface rounded-card p-4 mt-6"
-                testID="reports-list-card"
-              >
-                <View className="flex-row items-center justify-between mb-1">
-                  <Text className="text-body font-semibold text-text-primary">
-                    {t('progress.previousReports.title')}
-                  </Text>
-                  <Pressable
-                    onPress={() =>
-                      router.push(
-                        isViewingSelf
-                          ? ('/(app)/progress/reports' as Href)
-                          : (`/(app)/child/${selectedProfileId}/reports` as Href),
-                      )
-                    }
-                    accessibilityRole="button"
-                    accessibilityLabel={t('progress.previousReports.viewAll')}
-                    testID="progress-reports-link"
-                  >
-                    <Text className="text-body-sm text-primary font-semibold">
-                      {t('progress.previousReports.viewAll')}
-                    </Text>
-                  </Pressable>
-                </View>
-                <ReportsList
-                  monthlyReports={monthlyReportsQuery.data ?? []}
-                  weeklyReports={weeklyReportsQuery.data ?? []}
-                  limit={2}
-                  onPressMonthly={handleOpenMonthlyReport}
-                  onPressWeekly={handleOpenWeeklyReport}
-                />
-              </View>
-            ) : null}
-
             {isViewingSelf ? (
-              <>
-                <View className="flex-row items-center justify-between mt-6 mb-2">
-                  <Text className="text-h3 font-semibold text-text-primary">
-                    {t('progress.milestones.recentTitle')}
-                  </Text>
-                  {milestonesQuery.data ? (
-                    <Pressable
-                      onPress={() =>
-                        router.push('/(app)/progress/milestones' as Href)
-                      }
-                      accessibilityRole="button"
-                      accessibilityLabel={t('progress.milestones.seeAll')}
-                      testID="progress-milestones-see-all"
-                    >
-                      <Text className="text-body-sm text-primary font-medium">
-                        {t('progress.milestones.seeAllLink')}
-                      </Text>
-                    </Pressable>
-                  ) : null}
-                </View>
-                {milestonesQuery.isError && !milestonesQuery.data ? (
-                  <ErrorFallback
-                    variant="card"
-                    message={classifyApiError(milestonesQuery.error).message}
-                    primaryAction={{
-                      label: t('common.tryAgain'),
-                      onPress: () => void milestonesQuery.refetch(),
-                      testID: 'progress-milestones-error-retry',
-                    }}
-                    testID="progress-milestones-error"
-                  />
-                ) : milestonesQuery.data && milestonesQuery.data.length > 0 ? (
-                  milestonesQuery.data.map((milestone) => (
-                    <View key={milestone.id} className="mt-3">
-                      <MilestoneCard milestone={milestone} />
-                    </View>
-                  ))
-                ) : (
-                  <View
-                    className="bg-surface rounded-card px-4 py-3"
-                    testID="milestones-teaser"
-                  >
-                    <Text className="text-caption text-text-secondary text-center">
-                      {getNextMilestoneLabel(
-                        inventory?.global.totalSessions ?? 0,
-                        t,
-                      )}
-                    </Text>
-                  </View>
-                )}
-
-                <Pressable
-                  onPress={() => router.push('/(app)/progress/saved' as Href)}
-                  className="bg-surface rounded-card p-4 mt-6 flex-row items-center justify-between"
-                  accessibilityRole="button"
-                  accessibilityLabel={t('progress.saved.viewLabel')}
-                  testID="progress-saved-link"
-                >
-                  <View className="flex-row items-center gap-3">
-                    <Ionicons
-                      name="bookmark"
-                      size={20}
-                      className="text-primary"
-                    />
-                    <Text className="text-body font-medium text-text-primary">
-                      {t('progress.saved.title')}
-                    </Text>
-                  </View>
+              <Pressable
+                onPress={() => router.push('/(app)/progress/saved' as Href)}
+                className="bg-surface rounded-card p-4 mt-6 flex-row items-center justify-between"
+                accessibilityRole="button"
+                accessibilityLabel={t('progress.saved.viewLabel')}
+                testID="progress-saved-link"
+              >
+                <View className="flex-row items-center gap-3">
                   <Ionicons
-                    name="chevron-forward"
-                    size={18}
-                    className="text-text-tertiary"
+                    name="bookmark"
+                    size={20}
+                    className="text-primary"
                   />
-                </Pressable>
-              </>
+                  <Text className="text-body font-medium text-text-primary">
+                    {t('progress.saved.title')}
+                  </Text>
+                </View>
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  className="text-text-tertiary"
+                />
+              </Pressable>
             ) : null}
 
             {isViewingSelf ? (

--- a/apps/mobile/src/components/progress/ReportsList.tsx
+++ b/apps/mobile/src/components/progress/ReportsList.tsx
@@ -31,7 +31,8 @@ function formatDateOnly(
   isoDate: string,
   options: Intl.DateTimeFormatOptions,
 ): string {
-  return new Date(`${isoDate}T00:00:00Z`).toLocaleDateString(undefined, {
+  const dateOnly = /^\d{4}-\d{2}$/.test(isoDate) ? `${isoDate}-01` : isoDate;
+  return new Date(`${dateOnly}T00:00:00Z`).toLocaleDateString(undefined, {
     ...options,
     timeZone: 'UTC',
   });

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -1502,7 +1502,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -1650,7 +1650,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -1650,7 +1650,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent focus",
+      "title": "Recent sessions",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",


### PR DESCRIPTION
## Summary
- Render existing weekly/monthly report summaries on Progress even when legacy rows do not include embedded metric details.
- Move previous reports directly under the latest report preview and keep report navigation on the self-view routes.
- Replace the Progress overview milestone block with the recent sessions surface and “Show all sessions”.
- Handle monthly report dates in both YYYY-MM and YYYY-MM-DD forms.

## Validation
- pnpm exec jest --runTestsByPath "apps/mobile/src/app/(app)/progress.test.tsx" "apps/mobile/src/components/progress/ReportsList.test.tsx" --no-coverage --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.claude/worktrees"
- pnpm exec tsc --noEmit (from apps/mobile)
- pnpm exec eslint "src/app/(app)/progress/index.tsx" "src/app/(app)/progress.test.tsx" "src/components/progress/ReportsList.tsx" (warnings only: existing internal mock warnings in progress.test.tsx)
- Pre-commit hook: check:i18n, tsc --build, related mobile Jest tests (13 suites / 176 tests)

## Notes
- The documented `scripts/record-test-receipt.sh mobile` command is not present in this checkout. The current pre-push advisory says mobile affected tests no longer block on receipts, and related tests passed in the pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a previous reports card displaying recent reports on the Progress screen
  * Added a view all reports button when no reports are available
  * Added a saved bookmark link to the Progress overview

* **Bug Fixes**
  * Fixed date formatting for partial ISO date strings

* **Changes**
  * Renamed "Recent focus" to "Recent sessions" across all languages
  * Removed milestones feature from the Progress screen

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->