### PR TITLE
fix(mobile): apply progress and stream resilience fixes

### DIFF
--- a/apps/api/src/services/streaming/sse-utf8.test.ts
+++ b/apps/api/src/services/streaming/sse-utf8.test.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono';
+import { streamSSEUtf8 } from './sse-utf8';
+
+describe('streamSSEUtf8', () => {
+  it('sets the UTF-8 SSE content type', async () => {
+    const app = new Hono();
+    app.get('/stream', (c) =>
+      streamSSEUtf8(c, async (stream) => {
+        await stream.writeSSE({
+          data: JSON.stringify({ type: 'done', exchangeCount: 1 }),
+        });
+      }),
+    );
+
+    const res = await app.request('/stream');
+
+    expect(res.headers.get('content-type')).toBe(
+      'text/event-stream; charset=utf-8',
+    );
+  });
+
+  it('emits a JSON error frame when the stream callback throws before writing frames', async () => {
+    const app = new Hono();
+    app.get('/stream', (c) =>
+      streamSSEUtf8(c, async () => {
+        throw new Error('provider socket closed');
+      }),
+    );
+
+    const res = await app.request('/stream');
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).toContain(
+      'data: {"type":"error","message":"Something went wrong while generating a reply. Please try again.","code":"STREAM_CALLBACK_ERROR"}',
+    );
+    expect(body).not.toContain('provider socket closed');
+  });
+});

--- a/apps/api/src/services/streaming/sse-utf8.ts
+++ b/apps/api/src/services/streaming/sse-utf8.ts
@@ -1,5 +1,21 @@
 import type { Context } from 'hono';
 import { streamSSE, type SSEStreamingApi } from 'hono/streaming';
+import { streamErrorFrameSchema } from '@eduagent/schemas';
+
+const DEFAULT_STREAM_ERROR_MESSAGE =
+  'Something went wrong while generating a reply. Please try again.';
+
+async function emitJsonErrorFrame(stream: SSEStreamingApi): Promise<void> {
+  await stream.writeSSE({
+    data: JSON.stringify(
+      streamErrorFrameSchema.parse({
+        type: 'error',
+        code: 'STREAM_CALLBACK_ERROR',
+        message: DEFAULT_STREAM_ERROR_MESSAGE,
+      }),
+    ),
+  });
+}
 
 /**
  * [BUG-881] Wrapper around Hono's `streamSSE` that ensures the response
@@ -31,9 +47,26 @@ import { streamSSE, type SSEStreamingApi } from 'hono/streaming';
 export function streamSSEUtf8(
   c: Context,
   cb: (stream: SSEStreamingApi) => Promise<void>,
-  onError?: (e: Error, stream: SSEStreamingApi) => Promise<void>
+  onError?: (e: Error, stream: SSEStreamingApi) => Promise<void>,
 ): Response {
-  const res = streamSSE(c, cb, onError);
+  const guardedCallback = async (stream: SSEStreamingApi): Promise<void> => {
+    try {
+      await cb(stream);
+    } catch (caught) {
+      const error =
+        caught instanceof Error ? caught : new Error(String(caught));
+      if (onError) {
+        try {
+          await onError(error, stream);
+        } catch (onErrorCaught) {
+          console.error(onErrorCaught);
+        }
+      }
+      await emitJsonErrorFrame(stream);
+    }
+  };
+
+  const res = streamSSE(c, guardedCallback);
   res.headers.set('Content-Type', 'text/event-stream; charset=utf-8');
   return res;
 }

--- a/apps/mobile/src/app/(app)/progress.test.tsx
+++ b/apps/mobile/src/app/(app)/progress.test.tsx
@@ -412,6 +412,7 @@ function mockHooks(
   const milestonesRefetch = jest.fn();
   const refreshSnapshot = jest.fn().mockResolvedValue(undefined);
   const monthlyReportsRefetch = jest.fn();
+  const profileSessionsRefetch = jest.fn();
   const weeklyReportsRefetch = jest.fn();
   (useProgressInventory as jest.Mock).mockReturnValue({
     data: inventory,
@@ -470,7 +471,7 @@ function mockHooks(
         : []),
     isLoading: false,
     isError: false,
-    refetch: jest.fn(),
+    refetch: profileSessionsRefetch,
   });
   (useProfileReports as jest.Mock).mockReturnValue({
     data: monthlyReports,
@@ -506,6 +507,7 @@ function mockHooks(
     inventoryRefetch,
     milestonesRefetch,
     monthlyReportsRefetch,
+    profileSessionsRefetch,
     refreshSnapshot,
     weeklyReportsRefetch,
   };
@@ -556,6 +558,7 @@ describe('ProgressScreen — progressive disclosure', () => {
     });
     expect(refs.refreshSnapshot).toHaveBeenCalled();
     expect(refs.monthlyReportsRefetch).toHaveBeenCalled();
+    expect(refs.profileSessionsRefetch).toHaveBeenCalled();
     expect(refs.weeklyReportsRefetch).toHaveBeenCalled();
     expect(refs.milestonesRefetch).not.toHaveBeenCalled();
   });
@@ -816,6 +819,21 @@ describe('ProgressScreen — progressive disclosure', () => {
       screen.queryByTestId('progress-weekly-delta-topicsMastered'),
     ).toBeNull();
     expect(screen.queryByTestId('progress-currently-working-on')).toBeNull();
+  });
+
+  it('keeps the reports dashboard reachable when no reports exist', () => {
+    mockHooks({
+      inventory: {
+        global: { ...baseGlobal, totalSessions: 5, topicsMastered: 2 },
+        subjects: [fullSubject],
+      },
+    });
+    const push = jest.requireMock('expo-router').useRouter().push as jest.Mock;
+
+    render(<ProgressScreen />);
+
+    fireEvent.press(screen.getByTestId('progress-view-all-reports'));
+    expect(push).toHaveBeenCalledWith('/(app)/progress/reports');
   });
 
   it('shows full view when totalSessions is 3', () => {

--- a/apps/mobile/src/app/(app)/progress/index.tsx
+++ b/apps/mobile/src/app/(app)/progress/index.tsx
@@ -584,6 +584,7 @@ export default function ProgressScreen(): React.ReactElement {
 
   const refetchInventory = inventoryQuery.refetch;
   const refetchMonthlyReports = monthlyReportsQuery.refetch;
+  const refetchProfileSessions = profileSessionsQuery.refetch;
   const refetchWeeklyReports = weeklyReportsQuery.refetch;
   const refetchChildSummary = childSummaryQuery.refetch;
 
@@ -604,6 +605,7 @@ export default function ProgressScreen(): React.ReactElement {
       await Promise.all([
         refetchInventory(),
         refetchMonthlyReports(),
+        refetchProfileSessions(),
         refetchWeeklyReports(),
         ...(!isViewingSelf ? [refetchChildSummary()] : []),
       ]);
@@ -612,6 +614,7 @@ export default function ProgressScreen(): React.ReactElement {
       isViewingSelf,
       refetchInventory,
       refetchMonthlyReports,
+      refetchProfileSessions,
       refetchWeeklyReports,
       refetchChildSummary,
       refreshProgressSnapshot,
@@ -1035,6 +1038,26 @@ export default function ProgressScreen(): React.ReactElement {
               </View>
             ) : null}
 
+            {selectedProfileId && !hasAnyReports ? (
+              <Pressable
+                testID="progress-view-all-reports"
+                onPress={() =>
+                  router.push(
+                    isViewingSelf
+                      ? ('/(app)/progress/reports' as Href)
+                      : (`/(app)/child/${selectedProfileId}/reports` as Href),
+                  )
+                }
+                className="bg-surface rounded-button px-4 py-3 mt-4 items-center min-h-[48px] justify-center"
+                accessibilityRole="button"
+                accessibilityLabel={t('progress.guardian.viewAllReports')}
+              >
+                <Text className="text-body font-semibold text-primary">
+                  {t('progress.guardian.viewAllReports')}
+                </Text>
+              </Pressable>
+            ) : null}
+
             {!isViewingSelf ? (
               <>
                 {childSummaryQuery.data ? (
@@ -1055,23 +1078,6 @@ export default function ProgressScreen(): React.ReactElement {
                       {t('progress.guardian.nudgeCta', {
                         name: selectedChildName,
                       })}
-                    </Text>
-                  </Pressable>
-                ) : null}
-                {selectedProfileId && !hasAnyReports ? (
-                  <Pressable
-                    testID="progress-view-all-reports"
-                    onPress={() =>
-                      router.push(
-                        `/(app)/child/${selectedProfileId}/reports` as Href,
-                      )
-                    }
-                    className="bg-surface rounded-button px-4 py-3 mt-4 items-center min-h-[48px] justify-center"
-                    accessibilityRole="button"
-                    accessibilityLabel={t('progress.guardian.viewAllReports')}
-                  >
-                    <Text className="text-body font-semibold text-primary">
-                      {t('progress.guardian.viewAllReports')}
                     </Text>
                   </Pressable>
                 ) : null}

--- a/apps/mobile/src/hooks/use-sessions.test.ts
+++ b/apps/mobile/src/hooks/use-sessions.test.ts
@@ -1052,6 +1052,94 @@ describe('useStreamMessage', () => {
     });
   });
 
+  it('queues overlapping stream calls instead of completing the second silently', async () => {
+    const { streamSSEViaXHR } = require('../lib/sse') as {
+      streamSSEViaXHR: jest.Mock;
+    };
+
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    streamSSEViaXHR
+      .mockReturnValueOnce({
+        events: (async function* () {
+          yield { type: 'chunk', content: 'First' };
+          await firstGate;
+          yield { type: 'done', exchangeCount: 1, escalationRung: 1 };
+        })(),
+        abort: jest.fn(),
+      })
+      .mockReturnValueOnce({
+        events: (async function* () {
+          yield { type: 'chunk', content: 'Second' };
+          await secondGate;
+          yield { type: 'done', exchangeCount: 2, escalationRung: 1 };
+        })(),
+        abort: jest.fn(),
+      });
+
+    const { result } = renderHook(() => useStreamMessage('session-1'), {
+      wrapper: createWrapper(),
+    });
+
+    const firstDone = jest.fn();
+    const secondDone = jest.fn();
+    let firstPromise!: Promise<void>;
+    let secondPromise!: Promise<void>;
+
+    await act(async () => {
+      firstPromise = result.current.stream(
+        'first',
+        jest.fn(),
+        firstDone,
+        'session-1',
+      );
+      secondPromise = result.current.stream(
+        'second',
+        jest.fn(),
+        secondDone,
+        'session-1',
+      );
+    });
+
+    await waitFor(() => {
+      expect(streamSSEViaXHR).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      releaseFirst();
+      await firstPromise;
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(streamSSEViaXHR).toHaveBeenCalledTimes(2);
+    });
+    expect(secondDone).not.toHaveBeenCalled();
+
+    await act(async () => {
+      releaseSecond();
+      await secondPromise;
+    });
+
+    expect(firstDone).toHaveBeenCalledWith({
+      exchangeCount: 1,
+      escalationRung: 1,
+    });
+    expect(secondDone).toHaveBeenCalledWith({
+      exchangeCount: 2,
+      escalationRung: 1,
+    });
+  });
+
   it('classifies server SSE error events as retryable upstream errors', async () => {
     const { streamSSEViaXHR } = require('../lib/sse') as {
       streamSSEViaXHR: jest.Mock;

--- a/apps/mobile/src/hooks/use-sessions.ts
+++ b/apps/mobile/src/hooks/use-sessions.ts
@@ -358,6 +358,7 @@ export function useStreamMessage(sessionId: string): {
   const { activeProfile } = useProfile();
   const [isStreaming, setIsStreaming] = useState(false);
   const isStreamingRef = useRef(false);
+  const activeStreamRef = useRef<Promise<void> | null>(null);
   const abortRef = useRef<(() => void) | null>(null);
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
@@ -395,103 +396,120 @@ export function useStreamMessage(sessionId: string): {
         onReplay?: (result: IdempotencyReplayBody) => void;
       },
     ): Promise<void> => {
+      while (activeStreamRef.current) {
+        await activeStreamRef.current.catch(() => undefined);
+      }
+
       const effectiveSessionId = overrideSessionId ?? sessionIdRef.current;
-      if (isStreamingRef.current || !effectiveSessionId) return;
-      isStreamingRef.current = true;
-      setIsStreaming(true);
+      if (!effectiveSessionId) {
+        throw new Error('Cannot stream a message without an active session.');
+      }
+
+      const runStream = (async (): Promise<void> => {
+        isStreamingRef.current = true;
+        setIsStreaming(true);
+        try {
+          // Build URL and auth headers manually — React Native's fetch does NOT
+          // support ReadableStream on response.body (Hermes returns null), so we
+          // bypass the Hono RPC client and use XHR-based streaming instead.
+          // [I-1 / BUG-629] [I-3 / BUG-631] Snapshot BOTH proxyMode and
+          // profileId BEFORE the async getToken() call so a concurrent
+          // profile-switch can't produce a mismatched header pair.
+          const proxyMode = getProxyMode();
+          const snapshotProfileId = profileIdRef.current;
+          const token = await getTokenRef.current();
+          const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            Accept: 'text/event-stream',
+          };
+          if (token) headers['Authorization'] = `Bearer ${token}`;
+          if (snapshotProfileId) headers['X-Profile-Id'] = snapshotProfileId;
+          // [I-1] SSE path builds headers manually so X-Proxy-Mode must be
+          // injected here — customFetch is bypassed for the stream request.
+          if (proxyMode) headers['X-Proxy-Mode'] = 'true';
+          const finalHeaders = withIdempotencyKey(
+            headers,
+            options?.idempotencyKey,
+          );
+
+          const url = `${getApiUrl()}/v1/sessions/${effectiveSessionId}/stream`;
+          const body: SessionMessageInput = {
+            message,
+            ...(options?.homeworkMode
+              ? { homeworkMode: options.homeworkMode }
+              : {}),
+            ...(options?.imageBase64 && options?.imageMimeType
+              ? {
+                  imageBase64: options.imageBase64,
+                  imageMimeType: options.imageMimeType as
+                    | 'image/jpeg'
+                    | 'image/png'
+                    | 'image/webp',
+                }
+              : {}),
+          };
+          const { events, abort } = streamSSEViaXHR(url, {
+            method: 'POST',
+            headers: finalHeaders,
+            body: JSON.stringify(body),
+          });
+          abortRef.current = abort;
+
+          let accumulated = '';
+          let fallback:
+            | { reason: StreamFallbackReason; fallbackText: string }
+            | undefined;
+          for await (const event of events) {
+            if (event.type === 'chunk') {
+              accumulated += event.content;
+              onChunk(accumulated);
+            } else if (event.type === 'replace') {
+              accumulated = event.content;
+              onChunk(accumulated);
+            } else if (event.type === 'replay') {
+              options?.onReplay?.(event);
+              return;
+            } else if (event.type === 'fallback') {
+              fallback = {
+                reason: event.reason,
+                fallbackText: event.fallbackText,
+              };
+            } else if (event.type === 'done') {
+              await onDone({
+                exchangeCount: event.exchangeCount,
+                escalationRung: event.escalationRung ?? 0,
+                expectedResponseMinutes: event.expectedResponseMinutes,
+                aiEventId: (event as { aiEventId?: string }).aiEventId,
+                notePrompt: event.notePrompt,
+                notePromptPostSession: event.notePromptPostSession,
+                fluencyDrill: event.fluencyDrill,
+                confidence: event.confidence,
+                fallback,
+              });
+            } else if (event.type === 'error') {
+              throw new UpstreamError(
+                event.message,
+                event.code ?? 'UPSTREAM_ERROR',
+                502,
+              );
+            }
+          }
+        } finally {
+          // Abort any in-flight XHR — safe to call even after normal completion
+          abortRef.current?.();
+          abortRef.current = null;
+          isStreamingRef.current = false;
+          setIsStreaming(false);
+        }
+      })();
+      activeStreamRef.current = runStream;
 
       try {
-        // Build URL and auth headers manually — React Native's fetch does NOT
-        // support ReadableStream on response.body (Hermes returns null), so we
-        // bypass the Hono RPC client and use XHR-based streaming instead.
-        // [I-1 / BUG-629] [I-3 / BUG-631] Snapshot BOTH proxyMode and
-        // profileId BEFORE the async getToken() call so a concurrent
-        // profile-switch can't produce a mismatched header pair.
-        const proxyMode = getProxyMode();
-        const snapshotProfileId = profileIdRef.current;
-        const token = await getTokenRef.current();
-        const headers: Record<string, string> = {
-          'Content-Type': 'application/json',
-          Accept: 'text/event-stream',
-        };
-        if (token) headers['Authorization'] = `Bearer ${token}`;
-        if (snapshotProfileId) headers['X-Profile-Id'] = snapshotProfileId;
-        // [I-1] SSE path builds headers manually so X-Proxy-Mode must be
-        // injected here — customFetch is bypassed for the stream request.
-        if (proxyMode) headers['X-Proxy-Mode'] = 'true';
-        const finalHeaders = withIdempotencyKey(
-          headers,
-          options?.idempotencyKey,
-        );
-
-        const url = `${getApiUrl()}/v1/sessions/${effectiveSessionId}/stream`;
-        const body: SessionMessageInput = {
-          message,
-          ...(options?.homeworkMode
-            ? { homeworkMode: options.homeworkMode }
-            : {}),
-          ...(options?.imageBase64 && options?.imageMimeType
-            ? {
-                imageBase64: options.imageBase64,
-                imageMimeType: options.imageMimeType as
-                  | 'image/jpeg'
-                  | 'image/png'
-                  | 'image/webp',
-              }
-            : {}),
-        };
-        const { events, abort } = streamSSEViaXHR(url, {
-          method: 'POST',
-          headers: finalHeaders,
-          body: JSON.stringify(body),
-        });
-        abortRef.current = abort;
-
-        let accumulated = '';
-        let fallback:
-          | { reason: StreamFallbackReason; fallbackText: string }
-          | undefined;
-        for await (const event of events) {
-          if (event.type === 'chunk') {
-            accumulated += event.content;
-            onChunk(accumulated);
-          } else if (event.type === 'replace') {
-            accumulated = event.content;
-            onChunk(accumulated);
-          } else if (event.type === 'replay') {
-            options?.onReplay?.(event);
-            return;
-          } else if (event.type === 'fallback') {
-            fallback = {
-              reason: event.reason,
-              fallbackText: event.fallbackText,
-            };
-          } else if (event.type === 'done') {
-            await onDone({
-              exchangeCount: event.exchangeCount,
-              escalationRung: event.escalationRung ?? 0,
-              expectedResponseMinutes: event.expectedResponseMinutes,
-              aiEventId: (event as { aiEventId?: string }).aiEventId,
-              notePrompt: event.notePrompt,
-              notePromptPostSession: event.notePromptPostSession,
-              fluencyDrill: event.fluencyDrill,
-              confidence: event.confidence,
-              fallback,
-            });
-          } else if (event.type === 'error') {
-            throw new UpstreamError(
-              event.message,
-              event.code ?? 'UPSTREAM_ERROR',
-              502,
-            );
-          }
-        }
+        await runStream;
       } finally {
-        // Abort any in-flight XHR — safe to call even after normal completion
-        abortRef.current?.();
-        abortRef.current = null;
-        isStreamingRef.current = false;
-        setIsStreaming(false);
+        if (activeStreamRef.current === runStream) {
+          activeStreamRef.current = null;
+        }
       }
     },
 

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent sessions",
+      "title": "Letzte Sitzungen",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent sessions",
+      "title": "Sesiones recientes",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent sessions",
+      "title": "最近のセッション",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -1625,7 +1625,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent sessions",
+      "title": "Nylige økter",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -1650,7 +1650,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent sessions",
+      "title": "Ostatnie sesje",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -1650,7 +1650,7 @@
       "practicePoints_other": "{{count}} practice points"
     },
     "recentFocus": {
-      "title": "Recent sessions",
+      "title": "Sessões recentes",
       "showAll": "Show all sessions",
       "empty": "Recent sessions will appear here once learning gets going.",
       "error": "We couldn't load recent sessions right now.",


### PR DESCRIPTION
## Summary
- refresh recent sessions alongside progress report data
- keep the reports dashboard reachable when no reports exist yet
- localize the updated recent sessions title in non-English locales
- prevent silent session stream loss by surfacing API stream callback failures as typed SSE errors and queuing overlapping mobile stream sends

## Validation
- focused progress, reports list, and E2E selector integrity tests passed
- i18n staleness check passed
- mobile typecheck passed
- pre-commit related progress tests passed
- API streaming SSE regression test passed
- mobile `useStreamMessage` overlapping-stream regression test passed
- commit hooks passed: formatting/lint, `tsc --build`, related API/mobile Jest tests

## Notes
- The stream fix is commit `b2569a135`.
- This addresses the silent stream/request lifecycle path that produced the in-app `Connection lost - Try again` fallback; live-device confirmation still depends on the deployed build.