### PR TITLE
fix(observability): harden transient error reporting

### DIFF
--- a/apps/api/src/routes/maintenance.test.ts
+++ b/apps/api/src/routes/maintenance.test.ts
@@ -2,6 +2,7 @@ const { createInngestTransportCapture } =
   require('../test-utils/inngest-transport-capture') as typeof import('../test-utils/inngest-transport-capture');
 
 const mockInngestTransport = createInngestTransportCapture();
+const mockCaptureException = jest.fn();
 
 jest.mock('../inngest/client' /* gc1-allow: pattern-a conversion */, () => {
   const actual = jest.requireActual(
@@ -10,6 +11,13 @@ jest.mock('../inngest/client' /* gc1-allow: pattern-a conversion */, () => {
   return { ...actual, ...mockInngestTransport.module };
 });
 
+jest.mock(
+  '../services/sentry' /* gc1-allow: Sentry service is the external observability boundary for this route test */,
+  () => ({
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+  }),
+);
+
 import { Hono } from 'hono';
 import { maintenanceRoutes } from './maintenance';
 
@@ -17,6 +25,7 @@ type TestEnv = {
   Bindings: {
     ENVIRONMENT?: string;
     MAINTENANCE_SECRET?: string;
+    SENTRY_DSN?: string;
   };
 };
 
@@ -33,6 +42,52 @@ function createTestApp(bindings: TestEnv['Bindings']) {
 describe('maintenanceRoutes', () => {
   beforeEach(() => {
     mockInngestTransport.clear();
+    mockCaptureException.mockClear();
+  });
+
+  it('rejects sentry smoke without the maintenance secret', async () => {
+    const app = createTestApp({ MAINTENANCE_SECRET: 'secret' });
+
+    const res = await app.request('/maintenance/sentry-smoke', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('captures a sentry smoke exception with a valid secret', async () => {
+    const app = createTestApp({
+      ENVIRONMENT: 'production',
+      MAINTENANCE_SECRET: 'secret',
+      SENTRY_DSN: 'https://example@sentry.io/123',
+    });
+
+    const res = await app.request('/maintenance/sentry-smoke', {
+      method: 'POST',
+      headers: { 'X-Maintenance-Secret': 'secret' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      captured: boolean;
+      smokeId: string;
+      sentryConfigured: boolean;
+    };
+    expect(body).toEqual({
+      captured: true,
+      smokeId: expect.any(String),
+      sentryConfigured: true,
+    });
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      requestPath: '/maintenance/sentry-smoke',
+      extra: {
+        surface: 'maintenance.sentry-smoke',
+        smokeId: body.smokeId,
+        environment: 'production',
+        sentryConfigured: true,
+      },
+    });
   });
 
   it('rejects memory facts backfill without the maintenance secret', async () => {

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -2,11 +2,13 @@ import { Hono } from 'hono';
 import { ERROR_CODES } from '@eduagent/schemas';
 import { inngest } from '../inngest/client';
 import { safeSend } from '../services/safe-non-core';
+import { captureException } from '../services/sentry';
 
 type MaintenanceEnv = {
   Bindings: {
     ENVIRONMENT?: string;
     MAINTENANCE_SECRET?: string;
+    SENTRY_DSN?: string;
   };
 };
 
@@ -39,6 +41,34 @@ async function verifyMaintenanceSecret(c: {
 }
 
 export const maintenanceRoutes = new Hono<MaintenanceEnv>()
+  .post('/maintenance/sentry-smoke', async (c) => {
+    if (!(await verifyMaintenanceSecret(c))) {
+      return c.json(
+        {
+          code: ERROR_CODES.FORBIDDEN,
+          message: 'Maintenance secret required',
+        },
+        403,
+      );
+    }
+
+    const smokeId = crypto.randomUUID();
+    captureException(new Error('Sentry smoke test'), {
+      requestPath: c.req.path,
+      extra: {
+        surface: 'maintenance.sentry-smoke',
+        smokeId,
+        environment: c.env.ENVIRONMENT ?? 'unknown',
+        sentryConfigured: Boolean(c.env.SENTRY_DSN),
+      },
+    });
+
+    return c.json({
+      captured: true,
+      smokeId,
+      sentryConfigured: Boolean(c.env.SENTRY_DSN),
+    });
+  })
   .post('/maintenance/memory-facts-backfill', async (c) => {
     if (!(await verifyMaintenanceSecret(c))) {
       return c.json(

--- a/apps/api/src/services/snapshot-aggregation.test.ts
+++ b/apps/api/src/services/snapshot-aggregation.test.ts
@@ -41,6 +41,7 @@ jest.mock('./sentry' /* gc1-allow: pattern-a conversion */, () => {
   return {
     ...actual,
     captureException: jest.fn(),
+    addBreadcrumb: jest.fn(),
   };
 });
 
@@ -69,7 +70,7 @@ import {
 } from './snapshot-aggregation';
 import { detectMilestones, storeMilestones } from './milestone-detection';
 import { queueCelebration } from './celebrations';
-import { captureException } from './sentry';
+import { addBreadcrumb } from './sentry';
 import type {
   ProgressMetrics,
   SubjectProgressMetrics,
@@ -721,6 +722,26 @@ describe('buildKnowledgeInventory', () => {
     });
   });
 
+  it('recomputes when cached snapshot contains a subject missing from live state', async () => {
+    const staleSubjectId = '550e8400-e29b-41d4-a716-446655440099';
+    const latest = makeSnapshotRow({
+      snapshotDate: TODAY,
+      metrics: makeMetrics({
+        totalSessions: 3,
+        subjects: [makeSubjectMetric(staleSubjectId)],
+      }),
+    });
+    const db = createSnapshotDb({ findFirst: latest, findMany: [latest] });
+
+    await expect(buildKnowledgeInventory(db, profileId)).resolves.toEqual(
+      expect.objectContaining({
+        global: expect.objectContaining({ totalSessions: 0 }),
+        subjects: [],
+      }),
+    );
+    expect(db.query.subjects.findMany).toHaveBeenCalledTimes(2);
+  });
+
   it('includes currently working on entries from the learning profile', async () => {
     const latest = makeSnapshotRow({
       snapshotDate: TODAY,
@@ -939,13 +960,14 @@ describe('refreshProgressSnapshot', () => {
 
     expect(result.snapshotDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(vocabularyCardsFindMany).toHaveBeenCalledTimes(2);
-    expect(captureException).toHaveBeenCalledWith(
-      connectionError,
+    expect(addBreadcrumb).toHaveBeenCalledWith(
+      'Transient database error; retrying',
+      'database',
+      'warning',
       expect.objectContaining({
-        extra: expect.objectContaining({
-          operation: 'load_progress_state',
-          retryable: true,
-        }),
+        error: connectionError.message,
+        operation: 'load_progress_state',
+        retryable: true,
       }),
     );
   });

--- a/apps/api/src/services/snapshot-aggregation.ts
+++ b/apps/api/src/services/snapshot-aggregation.ts
@@ -693,10 +693,14 @@ export async function buildKnowledgeInventory(
   // — the next session-completed pipeline tick will refresh the snapshot.
   if (latestSnapshot) {
     const cachedSubjectIds = new Set(metrics.subjects.map((s) => s.subjectId));
+    const liveSubjectIds = new Set(state.subjects.map((s) => s.id));
     const hasMissingLiveSubject = state.subjects.some(
       (s) => !cachedSubjectIds.has(s.id),
     );
-    if (hasMissingLiveSubject) {
+    const hasStaleCachedSubject = metrics.subjects.some(
+      (s) => !liveSubjectIds.has(s.subjectId),
+    );
+    if (hasMissingLiveSubject || hasStaleCachedSubject) {
       metrics = await computeProgressMetrics(db, profileId);
     }
   }

--- a/apps/api/src/services/subject.test.ts
+++ b/apps/api/src/services/subject.test.ts
@@ -90,16 +90,19 @@ function createMockDb({
   insertReturning = [] as ReturnType<typeof mockSubjectRow>[],
   updateReturning = [] as ReturnType<typeof mockSubjectRow>[],
   readyBook = null as ReturnType<typeof mockBookRow> | null,
+  readyBooks = [] as Array<Pick<ReturnType<typeof mockBookRow>, 'subjectId'>>,
   bookSuggestion = null as { id: string } | null,
+  bookSuggestions = [] as Array<{ subjectId: string }>,
 } = {}): Database {
   return {
     query: {
       curriculumBooks: {
         findFirst: jest.fn().mockResolvedValue(readyBook),
-        findMany: jest.fn().mockResolvedValue([]),
+        findMany: jest.fn().mockResolvedValue(readyBooks),
       },
       bookSuggestions: {
         findFirst: jest.fn().mockResolvedValue(bookSuggestion),
+        findMany: jest.fn().mockResolvedValue(bookSuggestions),
       },
     },
     insert: jest.fn().mockReturnValue({
@@ -143,7 +146,9 @@ describe('listSubjects', () => {
       mockSubjectRow({ id: 's2', name: 'Science' }),
     ];
     setupScopedRepo({ findManyResult: rows });
-    const db = createMockDb({ readyBook: mockBookRow() });
+    const db = createMockDb({
+      readyBooks: [{ subjectId: 's1' }, { subjectId: 's2' }],
+    });
     const result = await listSubjects(db, profileId);
 
     expect(result).toHaveLength(2);
@@ -172,7 +177,9 @@ describe('listSubjects', () => {
     setupScopedRepo({
       findManyResult: [mockSubjectRow({ id: 'subject-broad' })],
     });
-    const db = createMockDb({ bookSuggestion: { id: 'suggestion-1' } });
+    const db = createMockDb({
+      bookSuggestions: [{ subjectId: 'subject-broad' }],
+    });
 
     const result = await listSubjects(db, profileId);
 
@@ -222,6 +229,45 @@ describe('listSubjects', () => {
     const db = createMockDb();
     const result = await listSubjects(db, profileId);
     expect(result[0]!.id).toBe('newer');
+  });
+
+  it('batches curriculum status lookups across active subjects', async () => {
+    const rows = [
+      mockSubjectRow({ id: 'ready-book', name: 'Math' }),
+      mockSubjectRow({ id: 'ready-suggestion', name: 'Science' }),
+      mockSubjectRow({ id: 'preparing', name: 'History' }),
+      mockSubjectRow({
+        id: 'archived',
+        name: 'Old class',
+        status: 'archived',
+      }),
+    ];
+    setupScopedRepo({ findManyResult: rows });
+    const db = createMockDb({
+      readyBooks: [{ subjectId: 'ready-book' }],
+      bookSuggestions: [{ subjectId: 'ready-suggestion' }],
+    });
+
+    const result = await listSubjects(db, profileId, { includeInactive: true });
+
+    expect(db.query.curriculumBooks.findMany).toHaveBeenCalledTimes(1);
+    expect(db.query.bookSuggestions.findMany).toHaveBeenCalledTimes(1);
+    expect(result.find((subject) => subject.id === 'ready-book')).toMatchObject(
+      {
+        curriculumStatus: 'ready',
+      },
+    );
+    expect(
+      result.find((subject) => subject.id === 'ready-suggestion'),
+    ).toMatchObject({
+      curriculumStatus: 'ready',
+    });
+    expect(result.find((subject) => subject.id === 'preparing')).toMatchObject({
+      curriculumStatus: 'preparing',
+    });
+    expect(
+      result.find((subject) => subject.id === 'archived'),
+    ).not.toHaveProperty('curriculumStatus');
   });
 });
 

--- a/apps/api/src/services/subject.ts
+++ b/apps/api/src/services/subject.ts
@@ -3,7 +3,7 @@
 // Pure business logic, no Hono imports
 // ---------------------------------------------------------------------------
 
-import { eq, and, gte, notInArray, sql } from 'drizzle-orm';
+import { eq, and, gte, inArray, notInArray, sql } from 'drizzle-orm';
 import {
   subjects,
   curriculumBooks,
@@ -80,24 +80,40 @@ function mapSubjectRow(
   };
 }
 
-async function getSubjectCurriculumStatus(
+async function getSubjectCurriculumStatuses(
   db: Database,
-  subjectId: string,
-): Promise<SubjectCurriculumStatus> {
-  const readyBook = await db.query.curriculumBooks.findFirst({
-    where: and(
-      eq(curriculumBooks.subjectId, subjectId),
-      eq(curriculumBooks.topicsGenerated, true),
-    ),
-  });
-  if (readyBook) return 'ready';
+  subjectIds: string[],
+): Promise<Map<string, SubjectCurriculumStatus>> {
+  if (subjectIds.length === 0) return new Map();
 
-  const bookSuggestion = await db.query.bookSuggestions.findFirst({
-    where: eq(bookSuggestions.subjectId, subjectId),
-  });
-  if (bookSuggestion) return 'ready';
+  const [readyBooks, suggestions] = await Promise.all([
+    db.query.curriculumBooks.findMany({
+      where: and(
+        inArray(curriculumBooks.subjectId, subjectIds),
+        eq(curriculumBooks.topicsGenerated, true),
+      ),
+      columns: { subjectId: true },
+    }),
+    db.query.bookSuggestions.findMany({
+      where: inArray(bookSuggestions.subjectId, subjectIds),
+      columns: { subjectId: true },
+    }),
+  ]);
 
-  return 'preparing';
+  const readySubjectIds = new Set<string>();
+  for (const book of readyBooks) {
+    readySubjectIds.add(book.subjectId);
+  }
+  for (const suggestion of suggestions) {
+    readySubjectIds.add(suggestion.subjectId);
+  }
+
+  return new Map(
+    subjectIds.map((subjectId) => [
+      subjectId,
+      readySubjectIds.has(subjectId) ? 'ready' : 'preparing',
+    ]),
+  );
 }
 
 async function dispatchCurriculumPrewarm(args: {
@@ -193,14 +209,16 @@ export async function listSubjects(
   // Sort by most recently updated first — prevents arbitrary subject[0] picks
   // in freeform classifier fallback and Learn New "Continue with X" card
   rows.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-  return Promise.all(
-    rows.map(async (row) =>
-      mapSubjectRow(
-        row,
-        row.status === 'active'
-          ? await getSubjectCurriculumStatus(db, row.id)
-          : undefined,
-      ),
+  const curriculumStatuses = await getSubjectCurriculumStatuses(
+    db,
+    rows.filter((row) => row.status === 'active').map((row) => row.id),
+  );
+  return rows.map((row) =>
+    mapSubjectRow(
+      row,
+      row.status === 'active'
+        ? (curriculumStatuses.get(row.id) ?? 'preparing')
+        : undefined,
     ),
   );
 }

--- a/apps/api/src/services/transient-db-retry.test.ts
+++ b/apps/api/src/services/transient-db-retry.test.ts
@@ -5,11 +5,11 @@ import {
 
 jest.mock(
   './sentry' /* gc1-allow: transient-retry unit test suppresses Sentry */,
-  () => ({ captureException: jest.fn() }),
+  () => ({ addBreadcrumb: jest.fn() }),
 );
 
-const { captureException } = jest.requireMock('./sentry') as {
-  captureException: jest.Mock;
+const { addBreadcrumb } = jest.requireMock('./sentry') as {
+  addBreadcrumb: jest.Mock;
 };
 
 beforeEach(() => {
@@ -20,6 +20,7 @@ describe('isTransientDatabaseError', () => {
   it.each([
     ['Connection terminated unexpectedly', true],
     ['Connection closed', true],
+    ['timeout exceeded when trying to connect', true],
     ['socket hang up', true],
     [Object.assign(new Error('fail'), { code: 'ECONNRESET' }), true],
     [Object.assign(new Error('fail'), { code: 'ECONNREFUSED' }), true],
@@ -40,7 +41,7 @@ describe('withTransientDatabaseRetry', () => {
       Promise.resolve('ok'),
     );
     expect(result).toBe('ok');
-    expect(captureException).not.toHaveBeenCalled();
+    expect(addBreadcrumb).not.toHaveBeenCalled();
   });
 
   it('retries on transient error and succeeds', async () => {
@@ -56,15 +57,15 @@ describe('withTransientDatabaseRetry', () => {
 
     expect(result).toBe('recovered');
     expect(op).toHaveBeenCalledTimes(2);
-    expect(captureException).toHaveBeenCalledTimes(1);
-    expect(captureException).toHaveBeenCalledWith(
-      expect.any(Error),
+    expect(addBreadcrumb).toHaveBeenCalledTimes(1);
+    expect(addBreadcrumb).toHaveBeenCalledWith(
+      'Transient database error; retrying',
+      'database',
+      'warning',
       expect.objectContaining({
-        extra: expect.objectContaining({
-          retryable: true,
-          operation: 'test_op',
-          attempt: 1,
-        }),
+        retryable: true,
+        operation: 'test_op',
+        attempt: 1,
       }),
     );
   });
@@ -77,7 +78,7 @@ describe('withTransientDatabaseRetry', () => {
       nonTransient,
     );
     expect(op).toHaveBeenCalledTimes(1);
-    expect(captureException).not.toHaveBeenCalled();
+    expect(addBreadcrumb).not.toHaveBeenCalled();
   });
 
   it('throws after exhausting all retries', async () => {
@@ -88,6 +89,6 @@ describe('withTransientDatabaseRetry', () => {
       transient,
     );
     expect(op).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
-    expect(captureException).toHaveBeenCalledTimes(3);
+    expect(addBreadcrumb).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/api/src/services/transient-db-retry.ts
+++ b/apps/api/src/services/transient-db-retry.ts
@@ -1,4 +1,4 @@
-import { captureException } from './sentry';
+import { addBreadcrumb } from './sentry';
 
 const TRANSIENT_DB_RETRY_ATTEMPTS = 3;
 const TRANSIENT_DB_RETRY_DELAY_MS = 300;
@@ -25,6 +25,7 @@ export function isTransientDatabaseError(error: unknown): boolean {
     code === 'ETIMEDOUT' ||
     /connection terminated/i.test(message) ||
     /connection closed/i.test(message) ||
+    /timeout exceeded when trying to connect/i.test(message) ||
     /socket hang up/i.test(message)
   );
 }
@@ -47,14 +48,18 @@ export async function withTransientDatabaseRetry<T>(
         throw error;
       }
 
-      captureException(error, {
-        extra: {
+      addBreadcrumb(
+        'Transient database error; retrying',
+        'database',
+        'warning',
+        {
+          error: error instanceof Error ? error.message : String(error),
           retryable: true,
           operation: label,
           attempt: attempt + 1,
           maxAttempts: TRANSIENT_DB_RETRY_ATTEMPTS + 1,
         },
-      });
+      );
       await delay(TRANSIENT_DB_RETRY_DELAY_MS * (attempt + 1));
     }
   }

--- a/apps/mobile/e2e/scripts/seed-and-run.sh
+++ b/apps/mobile/e2e/scripts/seed-and-run.sh
@@ -288,8 +288,8 @@ METRO_PORT=$(echo "$METRO_URL" | sed -n 's#.*:\([0-9][0-9]*\)\(/.*\)\?$#\1#p')
 REVERSED_PORTS=""
 reverse_port() {
   local port="$1"
-  [ -z "$port" ] && return
-  case " $REVERSED_PORTS " in *" $port "*) return ;; esac
+  [ -z "$port" ] && return 0
+  case " $REVERSED_PORTS " in *" $port "*) return 0 ;; esac
   REVERSED_PORTS="$REVERSED_PORTS $port"
   $ADB $DEVICE_FLAG reverse tcp:"$port" tcp:"$port" 2>/dev/null || true
 }

--- a/apps/mobile/src/app/(app)/session/index.test.tsx
+++ b/apps/mobile/src/app/(app)/session/index.test.tsx
@@ -1016,6 +1016,29 @@ describe('SessionScreen homework flow', () => {
     });
   });
 
+  it('does not auto-resume over a local turn when the learner sends before lookup settles', async () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({
+      mode: 'learning',
+      subjectId: 'subject-1',
+      subjectName: 'Geography',
+      topicId: 'topic-1',
+      topicName: 'Continents',
+    });
+    mockFetch.setRoute('/progress/topic', { sessionId: 'session-resumed' });
+
+    const wrapper = createWrapper();
+    const testScreen = render(<SessionScreen />, { wrapper });
+
+    fireEvent.press(testScreen.getByTestId('manual-send-button'));
+    await flushAsyncWork();
+
+    await waitFor(() => {
+      expect(mockStartSession).toHaveBeenCalledTimes(1);
+      expect(testScreen.queryByText('Solve 2x + 5 = 17')).toBeTruthy();
+    });
+    expect(mockSetParams).not.toHaveBeenCalled();
+  });
+
   it('does not auto-resume when entering a topic in review mode', async () => {
     (useLocalSearchParams as jest.Mock).mockReturnValue({
       mode: 'review',

--- a/apps/mobile/src/app/(app)/session/index.tsx
+++ b/apps/mobile/src/app/(app)/session/index.tsx
@@ -265,6 +265,8 @@ function SessionScreenInner() {
   const [messages, setMessages] = useState<ChatMessage[]>([
     { id: 'opening', role: 'assistant', content: openingContent },
   ]);
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
   // [BUG-919] Hide the "Go to the Library" hint once the conversation
   // starts. See shouldShowBookLink for the full rationale.
   const showBookLink = shouldShowBookLink({
@@ -395,8 +397,16 @@ function SessionScreenInner() {
   // history loads everywhere instead of dropping the learner into a blank chat.
   // Scoped to learning mode only: review/homework/freeform intentionally start
   // fresh.
+  const hasLocalLearnerTurn = messages.some(
+    (message) => message.role === 'user' && !message.eventId,
+  );
   const shouldLookupActiveSession =
-    effectiveMode === 'learning' && !!topicId && !routeSessionId;
+    effectiveMode === 'learning' &&
+    !!topicId &&
+    !routeSessionId &&
+    !activeSessionId &&
+    !isStreaming &&
+    !hasLocalLearnerTurn;
   const activeSessionLookup = useActiveSessionForTopic(
     shouldLookupActiveSession ? topicId : undefined,
   );
@@ -607,6 +617,22 @@ function SessionScreenInner() {
         isSystemPrompt: entry.isSystemPrompt,
         escalationRung: entry.escalationRung,
       }));
+
+    const currentMessages = messagesRef.current;
+    const transcriptUserContents = new Set(
+      transcriptMessages
+        .filter((message) => message.role === 'user')
+        .map((message) => message.content),
+    );
+    const hasInFlightLocalTurn =
+      currentMessages.some((message) => message.streaming) ||
+      currentMessages.some(
+        (message) =>
+          message.role === 'user' &&
+          !message.eventId &&
+          !transcriptUserContents.has(message.content),
+      );
+    if (hasInFlightLocalTurn) return;
 
     setMessages(
       transcriptMessages.length > 0

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -48,10 +48,11 @@ import { sanitizeSecureStoreKey } from '../lib/secure-storage';
 import { ErrorBoundary, OfflineBanner } from '../components/common';
 import { OutboxDrainProvider } from '../providers/OutboxDrainProvider';
 import { useNetworkStatus } from '../hooks/use-network-status';
-import { Sentry } from '../lib/sentry';
+import { enableSentry, Sentry } from '../lib/sentry';
 import { configureRevenueCat } from '../lib/revenuecat';
 import { AnimatedSplash } from '../components/AnimatedSplash';
 import { asyncStoragePersister } from '../lib/query-persister';
+import { shouldReportQueryErrorToSentry } from '../lib/query-error-reporting';
 
 // BUG-417: Clerk's default tokenCache uses expo-secure-store directly,
 // which crashes on web. Use our secure-storage wrapper instead.
@@ -81,6 +82,9 @@ if (!clerkPublishableKey) {
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
+      if (!shouldReportQueryErrorToSentry(error)) {
+        return;
+      }
       // Global fallback: report query failures to Sentry so silent blank
       // screens become observable even when a screen forgets to handle
       // isError, but ensures no failure goes unnoticed.
@@ -462,6 +466,10 @@ export default function RootLayout() {
   const [clerkReady, setClerkReady] = useState(false);
   const [clerkTimedOut, setClerkTimedOut] = useState(false);
   const showSplash = !animDone;
+
+  useEffect(() => {
+    enableSentry();
+  }, []);
 
   const onAnimComplete = useCallback(() => {
     if (__DEV__) console.log('[Splash] Animation complete');

--- a/apps/mobile/src/components/session/MessageBubble.test.tsx
+++ b/apps/mobile/src/components/session/MessageBubble.test.tsx
@@ -141,6 +141,9 @@ describe('MessageBubble collapse affordance', () => {
 
     const toggle = getByTestId('message-collapse-toggle');
     expect(toggle.props.className).toContain('min-h-[32px]');
+    expect(getByTestId('message-ai-content').props.style).toEqual(
+      expect.objectContaining({ maxHeight: 150, overflow: 'hidden' }),
+    );
     expect(queryByText('Show less')).toBeNull();
     expect(queryByText('Show more')).toBeNull();
   });

--- a/apps/mobile/src/components/session/MessageBubble.tsx
+++ b/apps/mobile/src/components/session/MessageBubble.tsx
@@ -301,9 +301,12 @@ export function MessageBubble({
       if (!isExpanded) return; // don't re-measure constrained height
       if (event.nativeEvent.layout.height > COLLAPSE_THRESHOLD) {
         setIsCollapsible(true);
+        if (!isCollapsible) {
+          setIsExpanded(false);
+        }
       }
     },
-    [isExpanded],
+    [isCollapsible, isExpanded],
   );
 
   const showCollapseToggle = isAI && isCollapsible && !streaming;

--- a/apps/mobile/src/components/session/use-session-streaming.test.ts
+++ b/apps/mobile/src/components/session/use-session-streaming.test.ts
@@ -4,6 +4,18 @@ import {
   useSessionStreaming,
 } from './use-session-streaming';
 import { QuotaExceededError } from '../../lib/api-client';
+import { UpstreamError } from '../../lib/api-errors';
+
+const mockCaptureException = jest.fn();
+
+jest.mock(
+  '../../lib/sentry' /* gc1-allow: Sentry SDK loads native module config in Jest */,
+  () => ({
+    Sentry: {
+      captureException: (...args: unknown[]) => mockCaptureException(...args),
+    },
+  }),
+);
 
 // Mock ChatShell directly so the hook can avoid the session barrel cycle.
 // prettier-ignore
@@ -247,6 +259,7 @@ describe('useSessionStreaming', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCaptureException.mockClear();
   });
 
   afterEach(() => {
@@ -593,6 +606,7 @@ describe('useSessionStreaming', () => {
 
       expect(opts.setQuotaError).toHaveBeenCalledWith(quotaDetails);
       expect(opts.setIsStreaming).toHaveBeenCalledWith(false);
+      expect(mockCaptureException).not.toHaveBeenCalled();
     });
 
     it('handles reconnectable errors with reconnect prompt', async () => {
@@ -609,6 +623,44 @@ describe('useSessionStreaming', () => {
       expect(opts.setIsStreaming).toHaveBeenCalledWith(false);
       // setMessages should have been called to show the error
       expect(opts.setMessages).toHaveBeenCalled();
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('captures upstream LLM stream errors before showing reconnect prompt', async () => {
+      const llmError = new UpstreamError(
+        'Something went wrong while generating a reply. Please try again.',
+        'LLM_UNAVAILABLE',
+        502,
+      );
+      const opts = makeOpts({
+        activeSessionId: 'session-1',
+        effectiveMode: 'learning',
+        topicId: 'topic-1',
+        inputMode: 'voice',
+        streamMessage: jest.fn().mockRejectedValue(llmError),
+      });
+      const { result } = renderHook(() => useSessionStreaming(opts as any));
+
+      await act(async () => {
+        await result.current.continueWithMessage('test');
+      });
+
+      expect(mockCaptureException).toHaveBeenCalledWith(llmError, {
+        tags: {
+          surface: 'session_stream',
+          feature: 'llm',
+          mode: 'learning',
+          reconnectable: 'true',
+          code: 'LLM_UNAVAILABLE',
+        },
+        extra: {
+          sessionId: 'session-1',
+          profileId: 'profile-1',
+          subjectId: 'subject-1',
+          topicId: 'topic-1',
+          inputMode: 'voice',
+        },
+      });
     });
 
     it('writes session recovery marker after successful stream', async () => {

--- a/apps/mobile/src/components/session/use-session-streaming.ts
+++ b/apps/mobile/src/components/session/use-session-streaming.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../hooks/use-sessions';
 import { useApiClient, type QuotaExceededDetails } from '../../lib/api-client';
 import { formatApiError } from '../../lib/format-api-error';
+import { Sentry } from '../../lib/sentry';
 import { writeSessionRecoveryMarker } from '../../lib/session-recovery';
 import {
   buildHomeworkSessionMetadata,
@@ -40,6 +41,20 @@ import {
 
 const FIRST_TOPIC_ACK_PATTERN =
   /^(ok(?:ay)?|yes|yep|yeah|ready|start|go ahead|sure|sounds good|let'?s go)[.!?\s]*$/i;
+
+function getStreamErrorCode(error: unknown): string | undefined {
+  if (error == null || typeof error !== 'object' || !('code' in error)) {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function shouldCaptureLlmStreamError(error: unknown): boolean {
+  const code = getStreamErrorCode(error);
+  if (code === 'LLM_UNAVAILABLE' || code === 'UPSTREAM_ERROR') return true;
+  return error instanceof Error && error.name === 'UpstreamError';
+}
 
 export function buildSessionApiMessage(
   text: string,
@@ -502,6 +517,7 @@ export function useSessionStreaming(opts: UseSessionStreamingOptions) {
       activeContinueRef.current = currentTurn;
 
       let streamId: string | null = null;
+      let resolvedSessionId: string | null = activeSessionId;
       // [H6] SSE freeze watchdog — hoisted so finally can always clear it.
       let sseWatchdogTimerId: ReturnType<typeof setInterval> | null = null;
       let doneCalled = false;
@@ -543,6 +559,7 @@ export function useSessionStreaming(opts: UseSessionStreamingOptions) {
         };
 
         const sid = await ensureSession(sessionSubjectId, text);
+        resolvedSessionId = sid;
         if (!sid) {
           const hasSubject = !!(
             subjectId ||
@@ -897,6 +914,25 @@ export function useSessionStreaming(opts: UseSessionStreamingOptions) {
         }
 
         const reconnectable = isReconnectableSessionError(err);
+        const streamErrorCode = getStreamErrorCode(err);
+        if (shouldCaptureLlmStreamError(err)) {
+          Sentry.captureException(err, {
+            tags: {
+              surface: 'session_stream',
+              feature: 'llm',
+              mode: effectiveMode,
+              reconnectable: String(reconnectable),
+              code: streamErrorCode ?? 'unknown',
+            },
+            extra: {
+              sessionId: resolvedSessionId,
+              profileId: activeProfileId,
+              subjectId: options?.sessionSubjectId ?? effectiveSubjectId,
+              topicId,
+              inputMode,
+            },
+          });
+        }
         const formattedError = formatApiError(err);
         // [3B.1] Classify: timeout → timeout msg, 5xx → server error, network → reconnect,
         // CORS/config → config error, fatal 4xx → formatted api error (non-reconnectable).
@@ -971,6 +1007,7 @@ export function useSessionStreaming(opts: UseSessionStreamingOptions) {
     },
     [
       activeHomeworkProblem,
+      activeSessionId,
       activeProfileId,
       animationCleanupRef,
       classifiedSubject,
@@ -984,6 +1021,7 @@ export function useSessionStreaming(opts: UseSessionStreamingOptions) {
       homeworkProblemsState,
       imageBase64Ref,
       imageMimeTypeRef,
+      inputMode,
       lastAiAtRef,
       lastExpectedMinutesRef,
       lastRetryPayloadRef,

--- a/apps/mobile/src/lib/query-error-reporting.test.ts
+++ b/apps/mobile/src/lib/query-error-reporting.test.ts
@@ -1,0 +1,35 @@
+import { UpstreamError } from './api-errors';
+import { shouldReportQueryErrorToSentry } from './query-error-reporting';
+
+describe('shouldReportQueryErrorToSentry', () => {
+  it('suppresses typed transient database 503 query errors', () => {
+    const error = new UpstreamError(
+      'Database temporarily unavailable — please retry',
+      'SERVICE_UNAVAILABLE',
+      503,
+    );
+
+    expect(shouldReportQueryErrorToSentry(error)).toBe(false);
+  });
+
+  it('suppresses service-unavailable shaped errors when class identity is lost', () => {
+    const error = {
+      name: 'UpstreamError',
+      message: 'Database temporarily unavailable — please retry',
+      code: 'SERVICE_UNAVAILABLE',
+      status: 503,
+    };
+
+    expect(shouldReportQueryErrorToSentry(error)).toBe(false);
+  });
+
+  it('keeps reporting other upstream errors', () => {
+    const error = new UpstreamError('Server exploded', 'INTERNAL_ERROR', 500);
+
+    expect(shouldReportQueryErrorToSentry(error)).toBe(true);
+  });
+
+  it('keeps reporting unknown errors', () => {
+    expect(shouldReportQueryErrorToSentry(new Error('Boom'))).toBe(true);
+  });
+});

--- a/apps/mobile/src/lib/query-error-reporting.ts
+++ b/apps/mobile/src/lib/query-error-reporting.ts
@@ -1,0 +1,20 @@
+function isServiceUnavailableError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    'code' in error &&
+    'status' in error &&
+    (error as { name?: unknown }).name === 'UpstreamError' &&
+    (error as { code?: unknown }).code === 'SERVICE_UNAVAILABLE' &&
+    (error as { status?: unknown }).status === 503
+  );
+}
+
+export function shouldReportQueryErrorToSentry(error: unknown): boolean {
+  if (isServiceUnavailableError(error)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- reduce `/v1/subjects` DB fan-out by batching curriculum status lookups
- recover from stale progress snapshots when cached and live subjects diverge
- classify Neon connection timeouts as transient and record recovered retries as breadcrumbs instead of Sentry exceptions
- suppress expected mobile Sentry noise for typed temporary DB outages
- add a protected Sentry smoke endpoint plus LLM stream capture context
- protect active learner turns from being overwritten by delayed session auto-resume

## Validation
- `pnpm exec jest --config apps/api/jest.config.cjs --runTestsByPath apps/api/src/routes/maintenance.test.ts apps/api/src/services/subject.test.ts apps/api/src/services/snapshot-aggregation.test.ts apps/api/src/services/transient-db-retry.test.ts --runInBand --no-coverage`
- `pnpm exec jest --runTestsByPath src/components/session/use-session-streaming.test.ts --runInBand --no-coverage --detectOpenHandles`
- `pnpm exec jest --runTestsByPath src/components/session/MessageBubble.test.tsx src/lib/query-error-reporting.test.ts --runInBand --no-coverage`
- `pnpm exec jest --runTestsByPath "src/app/(app)/session/index.test.tsx" -t "does not auto-resume over a local turn when the learner sends before lookup settles" --runInBand --no-coverage --detectOpenHandles`
- `pnpm exec tsc --noEmit -p apps/api/tsconfig.app.json`
- `cd apps/mobile && pnpm exec tsc --noEmit`
- pre-commit hook passed: lint-staged, `tsc --build`, related API/mobile tests
- pre-push hook passed for the 18-file push delta

## Notes
- Jest still prints existing local `.worktrees` duplicate Stripe mock warnings in this checkout.
- The full mobile session-screen suite was slow when run directly, but the pre-commit/pre-push related mobile test set passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added maintenance endpoint for Sentry smoke testing functionality.
  * Selective error suppression for service unavailability errors in query handling.

* **Bug Fixes**
  * Fixed session auto-resume overwriting in-progress local messages.
  * Added height constraints to collapsible message UI.

* **Performance Improvements**
  * Batch curriculum status lookups to reduce database round-trips.

* **Improvements**
  * Enhanced error telemetry for LLM stream failures with structured metadata.
  * Better transient database retry tracking via breadcrumb logging.
  * Expanded cache divergence detection for snapshot aggregation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->