### PR TITLE
Harden mobile capture and session wrap-up

### DIFF
--- a/apps/api/src/services/notes.integration.test.ts
+++ b/apps/api/src/services/notes.integration.test.ts
@@ -8,12 +8,13 @@ import {
   curriculumBooks,
   curriculumTopics,
   generateUUIDv7,
+  learningSessions,
   profiles,
   subjects,
   topicNotes,
   type Database,
 } from '@eduagent/database';
-import { listAllNotes } from './notes';
+import { createNote, createNoteForSession, listAllNotes } from './notes';
 
 loadDatabaseEnv(resolve(__dirname, '../../../..'));
 
@@ -78,6 +79,19 @@ async function seedTopic(
     .returning({ id: curriculumTopics.id });
 
   return { subjectId: subject!.id, topicId: topic!.id };
+}
+
+async function seedSession(
+  profileId: string,
+  subjectId: string,
+  topicId: string,
+): Promise<string> {
+  const [session] = await db
+    .insert(learningSessions)
+    .values({ profileId, subjectId, topicId })
+    .returning({ id: learningSessions.id });
+
+  return session!.id;
 }
 
 describeIfDb('listAllNotes (integration)', () => {
@@ -167,5 +181,82 @@ describeIfDb('listAllNotes (integration)', () => {
     expect(page2.notes[0]!.subjectName).toBe('Chemistry');
     expect(page2.notes[0]!.id).not.toBe(page1.notes[0]!.id);
     expect(page2.nextCursor).toBeNull();
+  });
+
+  it('lists multiple manually written chat notes from the same session', async () => {
+    const { profileId } = await seedProfile();
+    const { subjectId, topicId } = await seedTopic(
+      profileId,
+      'Chemistry',
+      'Reaction Rates',
+    );
+    const sessionId = await seedSession(profileId, subjectId, topicId);
+
+    await createNote(
+      db,
+      profileId,
+      subjectId,
+      topicId,
+      'First chat note from today.',
+      sessionId,
+    );
+    await createNote(
+      db,
+      profileId,
+      subjectId,
+      topicId,
+      'Second chat note from today.',
+      sessionId,
+    );
+
+    const result = await listAllNotes(db, profileId);
+
+    expect(result.notes.map((note) => note.content)).toEqual(
+      expect.arrayContaining([
+        'First chat note from today.',
+        'Second chat note from today.',
+      ]),
+    );
+    expect(result.notes).toHaveLength(2);
+  });
+
+  it('dedupes exact auto-summary retries without hiding different session notes', async () => {
+    const { profileId } = await seedProfile();
+    const { subjectId, topicId } = await seedTopic(
+      profileId,
+      'History',
+      'The Silk Road',
+    );
+    const sessionId = await seedSession(profileId, subjectId, topicId);
+
+    const first = await createNoteForSession(db, {
+      profileId,
+      topicId,
+      sessionId,
+      content: 'Auto summary reflection.',
+    });
+    const retry = await createNoteForSession(db, {
+      profileId,
+      topicId,
+      sessionId,
+      content: 'Auto summary reflection.',
+    });
+    await createNoteForSession(db, {
+      profileId,
+      topicId,
+      sessionId,
+      content: 'A different note from the same session.',
+    });
+
+    const result = await listAllNotes(db, profileId);
+
+    expect(retry.id).toBe(first.id);
+    expect(result.notes.map((note) => note.content)).toEqual(
+      expect.arrayContaining([
+        'Auto summary reflection.',
+        'A different note from the same session.',
+      ]),
+    );
+    expect(result.notes).toHaveLength(2);
   });
 });

--- a/apps/api/src/services/notes.ts
+++ b/apps/api/src/services/notes.ts
@@ -53,6 +53,7 @@ async function insertNoteWithCap(
     sessionId: string | null;
     content: string;
   },
+  options: { dedupeExactSessionContent?: boolean } = {},
 ): Promise<NoteRow> {
   return db.transaction(async (tx) => {
     const lockKey = `notes:${values.profileId}:${values.topicId}`;
@@ -60,14 +61,10 @@ async function insertNoteWithCap(
       sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`,
     );
 
-    // Idempotency for retries: if a note for this sessionId already exists,
-    // return it instead of inserting a duplicate. submitSummary can be
-    // retried (mobile network timeout, double-tap) and without this check the
-    // 50-note cap would be the only backstop — poor UX.
-    // Filter by topicId as well: callers today validate session.topicId === topicId
-    // upstream, but the function signature accepts arbitrary topicId so a future
-    // caller mismatching the pair must not get a note bound to the wrong topic.
-    if (values.sessionId) {
+    // Idempotency for retries: submitSummary can be retried with the same
+    // payload. Only dedupe the exact same session+topic+content; users can
+    // write multiple different notes during the same chat.
+    if (options.dedupeExactSessionContent && values.sessionId) {
       const [existingForSession] = await tx
         .select({
           id: topicNotes.id,
@@ -83,6 +80,7 @@ async function insertNoteWithCap(
             eq(topicNotes.profileId, values.profileId),
             eq(topicNotes.sessionId, values.sessionId),
             eq(topicNotes.topicId, values.topicId),
+            eq(topicNotes.content, values.content),
           ),
         )
         .limit(1);
@@ -136,12 +134,18 @@ export async function createNoteForSession(
     content: string;
   },
 ): Promise<NoteRow> {
-  return insertNoteWithCap(db, {
-    topicId: params.topicId,
-    profileId: params.profileId,
-    sessionId: params.sessionId,
-    content: params.content,
-  });
+  return insertNoteWithCap(
+    db,
+    {
+      topicId: params.topicId,
+      profileId: params.profileId,
+      sessionId: params.sessionId,
+      content: params.content,
+    },
+    {
+      dedupeExactSessionContent: true,
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/app/(app)/homework/camera.test.tsx
+++ b/apps/mobile/src/app/(app)/homework/camera.test.tsx
@@ -357,6 +357,67 @@ describe('CameraScreen', () => {
     expect(queryByText(/photograph homework problems so your/i)).toBeNull();
   });
 
+  it('allows type-or-record entry without granting camera permission', async () => {
+    const requestPermission = jest.fn();
+    useCameraPermissions.mockReturnValue([
+      { granted: false, canAskAgain: true },
+      requestPermission,
+      jest.fn().mockResolvedValue({ granted: false, canAskAgain: true }),
+    ]);
+
+    const { getByTestId, getByText, queryByTestId } = render(<CameraScreen />, {
+      wrapper: createWrapper(),
+    });
+
+    fireEvent.press(getByTestId('manual-entry-button'));
+
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(queryByTestId('camera-view')).toBeNull();
+    getByText(/type or say the homework problem/i);
+    fireEvent.press(getByTestId('problem-mic-0'));
+    expect(mockClearTranscript).toHaveBeenCalled();
+    expect(mockStartListening).toHaveBeenCalled();
+
+    fireEvent.changeText(getByTestId('result-text-input'), 'Explain gravity');
+    fireEvent.press(getByTestId('confirm-button'));
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: '/(app)/session',
+          params: expect.objectContaining({
+            mode: 'homework',
+            subjectId: 'sub-123',
+            subjectName: 'Mathematics',
+            problemText: 'Explain gravity',
+          }),
+        }),
+      );
+    });
+    const callArgs = mockRouter.replace.mock.calls[0][0];
+    expect(callArgs.params.imageUri).toBeUndefined();
+  });
+
+  it('returns to the permission choice after manual entry when camera is still denied', async () => {
+    useCameraPermissions.mockReturnValue([
+      { granted: false, canAskAgain: true },
+      jest.fn(),
+      jest.fn().mockResolvedValue({ granted: false, canAskAgain: true }),
+    ]);
+
+    const { getByTestId, getByText, queryByTestId } = render(<CameraScreen />, {
+      wrapper: createWrapper(),
+    });
+
+    fireEvent.press(getByTestId('manual-entry-button'));
+    getByText(/type or say the homework problem/i);
+
+    fireEvent.press(getByTestId('camera-back-button'));
+
+    getByText(/camera access/i);
+    expect(queryByTestId('camera-view')).toBeNull();
+  });
+
   it('shows Settings link when permission denied and cannot ask again', () => {
     useCameraPermissions.mockReturnValue([
       { granted: false, canAskAgain: false },
@@ -369,6 +430,23 @@ describe('CameraScreen', () => {
     });
     getByTestId('open-settings-button');
     getByText(/device settings/i);
+  });
+
+  it('allows type-or-record entry when camera permission is permanently denied', () => {
+    useCameraPermissions.mockReturnValue([
+      { granted: false, canAskAgain: false },
+      jest.fn(),
+      jest.fn().mockResolvedValue({ granted: false, canAskAgain: false }),
+    ]);
+
+    const { getByTestId, getByText } = render(<CameraScreen />, {
+      wrapper: createWrapper(),
+    });
+
+    fireEvent.press(getByTestId('manual-entry-button'));
+
+    getByText(/type or say the homework problem/i);
+    getByTestId('problem-mic-0');
   });
 
   it('re-checks permission when app returns from background (e.g. after Settings)', async () => {

--- a/apps/mobile/src/app/(app)/homework/camera.tsx
+++ b/apps/mobile/src/app/(app)/homework/camera.tsx
@@ -395,8 +395,8 @@ export default function CameraScreen(): React.ReactNode {
     setShowSubjectPicker(false);
     setShowCelebration(true);
     classifyTriggeredRef.current = false;
-    dispatch({ type: 'RETAKE' });
-  }, [speech]);
+    dispatch({ type: 'RESET', hasPermission: permission?.granted ?? false });
+  }, [permission?.granted, speech]);
 
   const handleStartManualEntry = useCallback(() => {
     if (speech.isListening) {
@@ -806,6 +806,17 @@ export default function CameraScreen(): React.ReactNode {
             </Text>
           </Pressable>
         )}
+        <Pressable
+          testID="manual-entry-button"
+          onPress={handleStartManualEntry}
+          className="mt-4 py-3 px-6 min-h-[48px] items-center justify-center"
+          accessibilityLabel={t('homework.typeOrRecordInstead')}
+          accessibilityRole="button"
+        >
+          <Text className="text-body font-semibold text-primary text-center">
+            {t('homework.typeOrRecordInstead')}
+          </Text>
+        </Pressable>
         <Pressable
           testID="close-button"
           onPress={handleClose}

--- a/apps/mobile/src/app/(app)/library.test.tsx
+++ b/apps/mobile/src/app/(app)/library.test.tsx
@@ -488,7 +488,7 @@ describe('LibraryScreen', () => {
     ]);
   });
 
-  it('has no top-level tabs — library opens subject shelves as the next level', () => {
+  it('has no top-level tabs — library opens subject detail as the next level', () => {
     // Library v3 redesign replaced Shelves/Books/Topics tabs with a subject
     // shelf list. There are no tab controls at the library level.
     mockUseSubjects.mockReturnValue({
@@ -505,10 +505,11 @@ describe('LibraryScreen', () => {
     expect(screen.queryByTestId('library-tab-shelves')).toBeNull();
     expect(screen.queryByTestId('library-tab-books')).toBeNull();
     expect(screen.queryByTestId('library-tab-topics')).toBeNull();
-    // Instead, the subject shelf list is the root navigation.
+    // Instead, the subject list is the root navigation.
     screen.getByTestId('shelves-list');
-    screen.getByTestId('shelf-grid-row-active-0');
-    screen.getByTestId('shelf-grid-plank-active-0');
+    screen.getByTestId('shelf-row-header-sub-1');
+    expect(screen.queryByTestId('shelf-grid-row-active-0')).toBeNull();
+    expect(screen.queryByTestId('shelf-grid-plank-active-0')).toBeNull();
   });
 
   it('opens the subject shelf when a subject row is pressed', () => {

--- a/apps/mobile/src/app/(app)/library.tsx
+++ b/apps/mobile/src/app/(app)/library.tsx
@@ -96,14 +96,6 @@ function sortSubjectsByStatus<T extends { status: Subject['status'] }>(
     .map(({ subject }) => subject);
 }
 
-function chunkIntoRows<T>(items: readonly T[], rowSize: number): T[][] {
-  const rows: T[][] = [];
-  for (let index = 0; index < items.length; index += rowSize) {
-    rows.push(items.slice(index, index + rowSize));
-  }
-  return rows;
-}
-
 // ---------------------------------------------------------------------------
 // SubjectStatusPill
 // ---------------------------------------------------------------------------
@@ -685,7 +677,7 @@ export default function LibraryScreen() {
           </>
         )}
 
-        {/* Subject shelf list (hidden when searching) */}
+        {/* Subject list (hidden when searching) */}
         {!isSearching && (
           <View testID="shelves-list">
             {nextLearningSubject ? (
@@ -720,83 +712,33 @@ export default function LibraryScreen() {
                     {t(`library.sections.${group.status}`)}
                   </Text>
                 ) : null}
-                {chunkIntoRows(group.subjects, 2).map((row, rowIndex) => (
-                  <View
-                    key={`${group.status}-${rowIndex}`}
-                    testID={`shelf-grid-row-${group.status}-${rowIndex}`}
-                    style={{
-                      position: 'relative',
-                      paddingBottom: 12,
-                      marginBottom: 14,
-                    }}
-                  >
-                    <View
-                      pointerEvents="none"
-                      testID={`shelf-grid-plank-${group.status}-${rowIndex}`}
-                      style={{
-                        position: 'absolute',
-                        left: 2,
-                        right: 2,
-                        bottom: 0,
-                        height: 16,
-                        borderRadius: 999,
-                        backgroundColor: themeColors.surface,
-                        borderColor: themeColors.border,
-                        borderWidth: 1,
-                        shadowColor: themeColors.textPrimary,
-                        shadowOffset: { width: 0, height: 2 },
-                        shadowOpacity: 0.04,
-                        shadowRadius: 4,
-                        elevation: 1,
-                      }}
-                    />
-                    <View
-                      style={{
-                        flexDirection: 'row',
-                        justifyContent: 'space-between',
-                        alignItems: 'flex-end',
-                      }}
-                    >
-                      {row.map((subject) => {
-                        const retData = retentionDataBySubjectId.get(
-                          subject.id,
-                        );
-                        const books = booksBySubjectId.get(subject.id) ?? [];
-                        const bookCount = books.length;
-                        const progress = progressBySubjectId.get(subject.id);
-                        const topicsTotal = progress?.topicsTotal ?? 0;
-                        const topicsCompleted = progress?.topicsCompleted ?? 0;
-                        const topicProgress = `${topicsCompleted}/${topicsTotal}`;
-                        const isFinished =
-                          topicsTotal > 0 &&
-                          (progress?.topicsVerified ?? 0) >= topicsTotal;
+                {group.subjects.map((subject) => {
+                  const retData = retentionDataBySubjectId.get(subject.id);
+                  const books = booksBySubjectId.get(subject.id) ?? [];
+                  const bookCount = books.length;
+                  const progress = progressBySubjectId.get(subject.id);
+                  const topicsTotal = progress?.topicsTotal ?? 0;
+                  const topicsCompleted = progress?.topicsCompleted ?? 0;
+                  const topicProgress = `${topicsCompleted}/${topicsTotal}`;
+                  const isFinished =
+                    topicsTotal > 0 &&
+                    (progress?.topicsVerified ?? 0) >= topicsTotal;
 
-                        return (
-                          <View
-                            key={subject.id}
-                            style={{ width: '48%', zIndex: 1 }}
-                          >
-                            <ShelfRow
-                              subjectId={subject.id}
-                              name={subject.name}
-                              bookCount={bookCount}
-                              topicProgress={topicProgress}
-                              reviewDueCount={retData?.reviewDueCount ?? 0}
-                              isFinished={isFinished}
-                              status={subject.status}
-                              tint={subjectTintsById.get(subject.id)}
-                              onPress={handleShelfPress}
-                              variant="card"
-                            />
-                          </View>
-                        );
-                      })}
-                      {row.length === 1 ? (
-                        <View style={{ width: '48%' }} />
-                      ) : null}
-                    </View>
-                  </View>
-                ))}
+                  return (
+                    <ShelfRow
+                      key={subject.id}
+                      subjectId={subject.id}
+                      name={subject.name}
+                      bookCount={bookCount}
+                      topicProgress={topicProgress}
+                      reviewDueCount={retData?.reviewDueCount ?? 0}
+                      isFinished={isFinished}
+                      status={subject.status}
+                      tint={subjectTintsById.get(subject.id)}
+                      onPress={handleShelfPress}
+                    />
+                  );
+                })}
               </View>
             ))}
           </View>
@@ -870,7 +812,7 @@ export default function LibraryScreen() {
         />
       </View>
 
-      {/* Scrollable shelf list */}
+      {/* Scrollable subject list */}
       <ScrollView
         className="flex-1 px-5"
         style={{ zIndex: 0 }}

--- a/apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx
+++ b/apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx
@@ -73,6 +73,7 @@ export function useLearningModeControl(): {
       className={`ms-1 px-2 py-2 rounded-button bg-surface-elevated min-h-[44px] min-w-[44px] items-center justify-center flex-row ${
         buttonDisabled ? 'opacity-50' : ''
       }`}
+      style={{ maxWidth: 144 }}
       accessibilityRole="button"
       accessibilityLabel={
         selected ? `Learning mode: ${selected.title}` : 'Learning mode loading'
@@ -86,7 +87,10 @@ export function useLearningModeControl(): {
         color={colors.textSecondary}
       />
       {selected ? (
-        <Text className="ms-1 text-caption font-semibold text-text-secondary">
+        <Text
+          className="ms-1 text-caption font-semibold text-text-secondary"
+          numberOfLines={1}
+        >
           {selected.title}
         </Text>
       ) : null}

--- a/apps/mobile/src/app/(app)/session/index.test.tsx
+++ b/apps/mobile/src/app/(app)/session/index.test.tsx
@@ -300,6 +300,7 @@ jest.mock(
       headerBelow,
       messages,
       inputAccessory,
+      composerAccessory,
       belowInput,
       inputMode,
       onInputModeChange,
@@ -315,6 +316,7 @@ jest.mock(
       headerBelow?: React.ReactNode;
       messages?: Array<{ id: string; content: string }>;
       inputAccessory?: React.ReactNode;
+      composerAccessory?: React.ReactNode;
       belowInput?: React.ReactNode;
       inputMode?: InputMode;
       onInputModeChange?: (mode: InputMode) => void;
@@ -352,6 +354,9 @@ jest.mock(
           ))}
           {inputAccessory ? (
             <View testID="mock-input-accessory">{inputAccessory}</View>
+          ) : null}
+          {composerAccessory ? (
+            <View testID="mock-composer-accessory">{composerAccessory}</View>
           ) : null}
           {belowInput ? (
             <View testID="mock-below-input">{belowInput}</View>
@@ -850,11 +855,13 @@ describe('SessionScreen homework flow', () => {
     expect(testScreen.queryByText('Too easy')).toBeNull();
     expect(testScreen.queryByText('Example')).toBeNull();
 
-    // Session tool chips live above the composer so the area below the input
-    // does not turn into a tall empty footer.
+    // Session tool chips live in the compact composer toolbar so they can
+    // share a row with voice playback controls instead of adding another band.
+    const composerAccessory = testScreen.getByTestId('mock-composer-accessory');
+    within(composerAccessory).getByText('Switch topic');
+    expect(within(composerAccessory).queryByText('Park it')).toBeNull();
     const inputAccessory = testScreen.getByTestId('mock-input-accessory');
-    within(inputAccessory).getByText('Switch topic');
-    within(inputAccessory).getByText('Park it');
+    expect(within(inputAccessory).queryByText('Switch topic')).toBeNull();
     expect(testScreen.queryByTestId('mock-below-input')).toBeNull();
   });
 

--- a/apps/mobile/src/app/(app)/session/index.tsx
+++ b/apps/mobile/src/app/(app)/session/index.tsx
@@ -933,14 +933,20 @@ function SessionScreenInner() {
   const endSessionButton = (
     <Pressable
       onPress={activeSessionId ? handleEndSession : handleHomeBack}
-      disabled={isClosing || isStreaming}
+      disabled={isClosing || isStreaming || showFilingPrompt}
       className="ms-2 px-3 py-2 rounded-button bg-surface-elevated min-h-[44px] items-center justify-center"
+      style={{ maxWidth: 104 }}
       testID="end-session-button"
-      accessibilityLabel={activeSessionId ? "I'm done" : 'Exit'}
+      accessibilityLabel={
+        isClosing ? 'Wrapping up' : activeSessionId ? "I'm done" : 'Exit'
+      }
       accessibilityRole="button"
     >
-      <Text className="text-body-sm font-semibold text-text-secondary">
-        {isClosing ? 'Wrapping up...' : activeSessionId ? "I'm Done" : 'Exit'}
+      <Text
+        className="text-body-sm font-semibold text-text-secondary"
+        numberOfLines={1}
+      >
+        {isClosing ? 'Wrapping...' : activeSessionId ? 'Done' : 'Exit'}
       </Text>
     </Pressable>
   );
@@ -949,7 +955,7 @@ function SessionScreenInner() {
     useLearningModeControl();
 
   const headerRight = (
-    <View className="flex-row items-center">
+    <View className="flex-row flex-wrap items-center justify-end">
       {modeConfig.showTimer && <SessionTimer />}
       {learningModeButton}
       <MilestoneDots count={milestonesReached.length} />
@@ -1051,6 +1057,7 @@ function SessionScreenInner() {
       handleQuickChip={handleQuickChip}
       stage={conversationStage}
       onAddNote={() => setShowNoteInput(true)}
+      embedded
     />
   ) : null;
 
@@ -1130,6 +1137,7 @@ function SessionScreenInner() {
           isSubjectFlowBlockingComposer ||
           sessionExpired ||
           !!quotaError ||
+          (showFilingPrompt && !filingDismissed) ||
           // CR-6: Disable input while session close is in flight.
           isClosing
         }
@@ -1143,21 +1151,24 @@ function SessionScreenInner() {
               ? 'This session has ended'
               : quotaError
                 ? 'Your session limit has been reached'
-                : pendingClassification
-                  ? t('session.chatShell.classifyingSubject')
-                  : undefined
+                : showFilingPrompt && !filingDismissed
+                  ? 'Choose where to save this session'
+                  : pendingClassification
+                    ? t('session.chatShell.classifyingSubject')
+                    : undefined
         }
         verificationType={liveTranscript?.session.verificationType ?? undefined}
         inputMode={inputMode}
         onInputModeChange={handleInputModeChange}
         rightAction={headerRight}
+        footerScrollSignal={`${showFilingPrompt}-${filingDismissed}`}
         inputAccessory={
           <>
             {drillStrip}
             {sessionAccessory}
-            {sessionToolAccessory}
           </>
         }
+        composerAccessory={sessionToolAccessory}
         belowInput={null}
         onDraftChange={setDraftText}
         renderMessageActions={renderMessageActions}

--- a/apps/mobile/src/components/library/ShelfRow.test.tsx
+++ b/apps/mobile/src/components/library/ShelfRow.test.tsx
@@ -9,6 +9,7 @@ jest.mock(
   '../../lib/theme' /* gc1-allow: ThemeProvider requires native env; unit test cannot render it */,
   () => ({
     useThemeColors: () => ({
+      border: '#e5e7eb',
       retentionWeak: '#b45309',
       success: '#16a34a',
       textPrimary: '#111827',
@@ -54,12 +55,12 @@ describe('ShelfRow', () => {
     screen.getByText('3 books · 18/32 topics');
   });
 
-  it('renders the subject bookshelf motif', () => {
+  it('does not render the old bookshelf motif', () => {
     render(<ShelfRow {...defaultProps} />);
-    screen.getByTestId('shelf-row-bookshelf-sub-math');
+    expect(screen.queryByTestId('shelf-row-bookshelf-sub-math')).toBeNull();
   });
 
-  it('renders each shelf as an open shelf row instead of a boxed card', () => {
+  it('renders as a flat row on the screen background', () => {
     render(<ShelfRow {...defaultProps} />);
 
     const header = screen.getByTestId('shelf-row-header-sub-math');
@@ -67,43 +68,16 @@ describe('ShelfRow', () => {
       expect.objectContaining({
         alignItems: 'center',
         backgroundColor: 'transparent',
-        borderRadius: 10,
-        borderWidth: 0,
+        borderBottomWidth: 1,
+        borderColor: '#e5e7eb',
         elevation: 0,
         flexDirection: 'row',
-        minHeight: 90,
-        paddingBottom: 20,
-        paddingTop: 12,
-        shadowColor: '#2f6fbd',
+        minHeight: 76,
+        paddingHorizontal: 0,
+        paddingVertical: 12,
       }),
     );
-    screen.getByTestId('shelf-row-backboard-sub-math');
-    screen.getByTestId('shelf-row-depth-sub-math');
     screen.getByTestId('shelf-row-rail-sub-math');
-  });
-
-  it('renders the compact shelf card variant for the library grid', () => {
-    render(<ShelfRow {...defaultProps} variant="card" />);
-
-    const header = screen.getByTestId('shelf-row-header-sub-math');
-    expect(header.props.style).toEqual(
-      expect.objectContaining({
-        backgroundColor: '#edf3ff',
-        borderRadius: 14,
-        borderWidth: 1,
-        elevation: 1,
-        justifyContent: 'space-between',
-        minHeight: 148,
-        paddingHorizontal: 12,
-      }),
-    );
-    screen.getByText('Open');
-    screen.getByText('18/32 topics');
-    expect(screen.getByTestId('shelf-row-rail-sub-math').props.style).toEqual(
-      expect.objectContaining({
-        width: '100%',
-      }),
-    );
   });
 
   it('opens the subject shelf when header is pressed', () => {

--- a/apps/mobile/src/components/library/ShelfRow.tsx
+++ b/apps/mobile/src/components/library/ShelfRow.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import type { SubjectStatus } from '@eduagent/schemas';
 
-import { SubjectBookshelfMotif } from '../common/SubjectBookshelfMotif';
 import type { LearningSubjectTint } from '../../lib/learning-subject-tints';
 import { useSubjectTint, useThemeColors } from '../../lib/theme';
 
@@ -20,7 +19,6 @@ interface ShelfRowProps {
   tint?: LearningSubjectTint;
   onPress: (subjectId: string) => void;
   testID?: string;
-  variant?: 'row' | 'card';
 }
 
 export function ShelfRow({
@@ -35,7 +33,6 @@ export function ShelfRow({
   tint: providedTint,
   onPress,
   testID,
-  variant = 'row',
 }: ShelfRowProps): React.ReactElement {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -76,202 +73,13 @@ export function ShelfRow({
 
   const needsReview = reviewDueCount > 0;
   const showFinished = isFinished && !needsReview;
-  const openLabel = t('library.row.shelfActionOpen');
-  const openDisplayLabel =
-    openLabel.length > 0
-      ? openLabel.charAt(0).toUpperCase() + openLabel.slice(1)
-      : 'Open';
-  const cardStatusLabel = isUnstarted
-    ? t('library.row.shelfSubtitleUnstarted')
-    : rowStatus === 'paused'
-      ? t('library.row.paused')
-      : rowStatus === 'archived'
-        ? t('library.row.archived')
-        : needsReview
-          ? t('library.row.review')
-          : showFinished
-            ? t('library.row.finished')
-            : openDisplayLabel;
-  const cardStatusColor =
-    rowStatus === 'paused'
-      ? colors.warning
-      : rowStatus === 'archived'
-        ? colors.textSecondary
-        : needsReview
-          ? colors.retentionWeak
-          : showFinished
-            ? colors.success
-            : isUnstarted
-              ? tint.solid
-              : colors.textSecondary;
-  const topicCountLabel = t('library.row.bookTopics', {
-    progress: topicProgress,
-  });
-
-  if (variant === 'card') {
-    return (
-      <View
-        style={{
-          opacity: isInactive ? 0.65 : 1,
-          minHeight: 154,
-          position: 'relative',
-        }}
-      >
-        <Pressable
-          testID={testID ?? `shelf-row-header-${subjectId}`}
-          onPress={() => onPress(subjectId)}
-          accessibilityRole="button"
-          accessibilityLabel={t('library.row.shelfAccessibilityLabel', {
-            name,
-            subtitle,
-            pausedSuffix: statusSuffix,
-            reviewSuffix: needsReview
-              ? t('library.row.shelfReviewSuffix')
-              : showFinished
-                ? t('library.row.shelfFinishedSuffix')
-                : '',
-            action: t('library.row.shelfActionOpen'),
-          })}
-          style={{
-            minHeight: 148,
-            borderRadius: 14,
-            borderWidth: 1,
-            borderColor: tint.solid + '1F',
-            backgroundColor: tint.soft,
-            paddingHorizontal: 12,
-            paddingTop: 12,
-            paddingBottom: 11,
-            justifyContent: 'space-between',
-            shadowColor: tint.solid,
-            shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.06,
-            shadowRadius: 4,
-            elevation: 1,
-          }}
-        >
-          <View>
-            <View
-              style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                alignItems: 'flex-start',
-                gap: 8,
-              }}
-            >
-              <SubjectBookshelfMotif
-                testID={`shelf-row-bookshelf-${subjectId}`}
-                tint={tint}
-              />
-              <Ionicons
-                name="chevron-forward"
-                size={15}
-                color={colors.textSecondary}
-                accessibilityElementsHidden
-                importantForAccessibility="no-hide-descendants"
-                style={{ marginTop: 4 }}
-              />
-            </View>
-            <Text
-              style={{
-                fontSize: 16,
-                fontWeight: 'bold',
-                color: colors.textPrimary,
-                marginTop: 12,
-              }}
-              numberOfLines={1}
-            >
-              {name}
-            </Text>
-            <Text
-              style={{
-                fontSize: 12,
-                color: cardStatusColor,
-                fontWeight: isUnstarted || needsReview ? '600' : '400',
-                marginTop: 4,
-              }}
-              numberOfLines={1}
-            >
-              {cardStatusLabel}
-            </Text>
-          </View>
-
-          <View>
-            <Text
-              style={{
-                fontSize: 12,
-                fontWeight: '600',
-                color: colors.textPrimary,
-              }}
-              numberOfLines={1}
-            >
-              {topicCountLabel}
-            </Text>
-            <View
-              testID={`shelf-row-rail-${subjectId}`}
-              style={{
-                height: 4,
-                borderRadius: 999,
-                backgroundColor: tint.solid,
-                opacity: 0.25,
-                marginTop: 7,
-                width: '100%',
-              }}
-            />
-          </View>
-        </Pressable>
-      </View>
-    );
-  }
-
   return (
     <View
       style={{
         opacity: isInactive ? 0.65 : 1,
-        marginBottom: 16,
-        minHeight: 98,
-        position: 'relative',
+        marginBottom: 4,
       }}
     >
-      <View
-        testID={`shelf-row-backboard-${subjectId}`}
-        pointerEvents="none"
-        style={{
-          position: 'absolute',
-          left: 38,
-          right: 10,
-          top: 8,
-          bottom: 18,
-          borderRadius: 8,
-          backgroundColor: tint.soft,
-          borderColor: tint.solid + '18',
-          borderWidth: 1,
-        }}
-      />
-      <View
-        testID={`shelf-row-depth-${subjectId}`}
-        pointerEvents="none"
-        style={{
-          position: 'absolute',
-          left: 0,
-          right: 0,
-          bottom: 0,
-          height: 18,
-          borderRadius: 9,
-          backgroundColor: tint.solid + '2A',
-          borderColor: tint.solid + '24',
-          borderWidth: 1,
-        }}
-      >
-        <View
-          style={{
-            height: 3,
-            borderTopLeftRadius: 9,
-            borderTopRightRadius: 9,
-            backgroundColor: tint.solid,
-            opacity: 0.24,
-          }}
-        />
-      </View>
       <Pressable
         testID={testID ?? `shelf-row-header-${subjectId}`}
         onPress={() => onPress(subjectId)}
@@ -290,25 +98,23 @@ export function ShelfRow({
         style={{
           flexDirection: 'row',
           alignItems: 'center',
-          minHeight: 90,
-          paddingTop: 12,
-          paddingBottom: 20,
-          paddingHorizontal: 16,
+          minHeight: 76,
+          paddingVertical: 12,
+          paddingHorizontal: 0,
           gap: 12,
-          borderRadius: 10,
-          borderWidth: 0,
+          borderBottomWidth: 1,
+          borderColor: colors.border,
           backgroundColor: 'transparent',
-          shadowColor: tint.solid,
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.05,
-          shadowRadius: 3,
           elevation: 0,
-          zIndex: 1,
         }}
       >
-        <SubjectBookshelfMotif
-          testID={`shelf-row-bookshelf-${subjectId}`}
-          tint={tint}
+        <Ionicons
+          name="book-outline"
+          size={24}
+          color={tint.solid}
+          testID={`subject-row-icon-${subjectId}`}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
         />
 
         <View style={{ flex: 1, minWidth: 0 }}>
@@ -336,12 +142,12 @@ export function ShelfRow({
           <View
             testID={`shelf-row-rail-${subjectId}`}
             style={{
-              height: 4,
+              height: 3,
               borderRadius: 999,
               backgroundColor: tint.solid,
-              opacity: 0.42,
+              opacity: 0.35,
               marginTop: 8,
-              width: '72%',
+              width: '64%',
             }}
           />
         </View>

--- a/apps/mobile/src/components/session/ChatShell.test.tsx
+++ b/apps/mobile/src/components/session/ChatShell.test.tsx
@@ -327,6 +327,21 @@ describe('ChatShell', () => {
       screen.getByTestId('voice-playback-bar');
     });
 
+    it('shares one compact toolbar for playback and composer accessories', () => {
+      const { Text } = require('react-native');
+      renderChatShell({
+        verificationType: 'teach_back',
+        composerAccessory: <Text testID="composer-tools">Tools</Text>,
+      });
+
+      screen.getByTestId('chat-composer-toolbar');
+      screen.getByTestId('voice-playback-bar');
+      screen.getByTestId('composer-tools');
+      expect(screen.getByTestId('chat-input-row').props.className).toContain(
+        'pt-1',
+      );
+    });
+
     it('hides playback bar when voice is OFF', () => {
       renderChatShell({ verificationType: undefined });
 

--- a/apps/mobile/src/components/session/ChatShell.tsx
+++ b/apps/mobile/src/components/session/ChatShell.tsx
@@ -66,7 +66,10 @@ interface ChatShellProps {
   showDisabledBanner?: boolean;
   rightAction?: React.ReactNode;
   footer?: React.ReactNode;
+  footerScrollSignal?: unknown;
   inputAccessory?: React.ReactNode;
+  /** Compact controls rendered in the composer toolbar beside voice playback. */
+  composerAccessory?: React.ReactNode;
   onDraftChange?: (text: string) => void;
   placeholder?: string;
   renderMessageActions?: (message: ChatMessage) => React.ReactNode;
@@ -78,7 +81,7 @@ interface ChatShellProps {
   onInputModeChange?: (mode: InputMode) => void;
   speechRecognitionLanguage?: string;
   textToSpeechLanguage?: string;
-  /** Compact controls rendered below the text input (e.g. Switch topic / Park it). */
+  /** Compact controls rendered below the text input. */
   belowInput?: React.ReactNode;
   /** Optional testID for the message scroll area (used by E2E flows). */
   messagesTestID?: string;
@@ -163,7 +166,9 @@ export function ChatShell({
   showDisabledBanner = true,
   rightAction,
   footer,
+  footerScrollSignal,
   inputAccessory,
+  composerAccessory,
   onDraftChange,
   placeholder,
   renderMessageActions,
@@ -355,7 +360,7 @@ export function ChatShell({
   // events from async bubble layout. Snap is what chat UIs typically do anyway.
   useEffect(() => {
     scrollRef.current?.scrollToEnd({ animated: false });
-  }, [messages]);
+  }, [messages, footerScrollSignal]);
 
   useEffect(() => {
     // [BUG-928] On web, AccessibilityInfo.isScreenReaderEnabled() returns
@@ -598,7 +603,11 @@ export function ChatShell({
   }, [lastMessageIsAi, isStreaming, input]);
 
   const headerRightContent = (
-    <View className="flex-row items-center">
+    <View
+      className="flex-row flex-wrap items-center justify-end"
+      style={{ flexShrink: 1, maxWidth: '70%' }}
+      testID="chat-shell-header-actions"
+    >
       <VoiceToggle
         isVoiceEnabled={isVoiceEnabled}
         onToggle={() =>
@@ -608,6 +617,9 @@ export function ChatShell({
       {rightAction}
     </View>
   );
+  const showVoicePlaybackControls =
+    isVoiceEnabled && !inputDisabled && !screenReaderEnabled;
+  const showComposerToolbar = showVoicePlaybackControls || !!composerAccessory;
 
   return (
     <KeyboardAvoidingView
@@ -759,22 +771,6 @@ export function ChatShell({
         }
       />
 
-      {/* BUG-348: Hide VoicePlaybackBar entirely when screen reader is active.
-          TTS controls compete with VoiceOver/TalkBack for the audio channel,
-          and the Replay button bypasses the auto-TTS suppression. */}
-      {isVoiceEnabled && !inputDisabled && !screenReaderEnabled && (
-        <VoicePlaybackBar
-          isSpeaking={ttsPlaying}
-          isPaused={ttsPaused}
-          rate={rate}
-          onStop={stopSpeaking}
-          onPause={pauseSpeaking}
-          onResume={resumeSpeaking}
-          onReplay={replay}
-          onRateChange={setRate}
-        />
-      )}
-
       {/* Live transcript while recording — gives immediate visual feedback */}
       {isVoiceEnabled && isListening && (
         <View
@@ -834,6 +830,37 @@ export function ChatShell({
       {/* Input accessory — always visible so subject-resolution chips remain
           actionable even when the text input itself is disabled (BUG-234). */}
       {inputAccessory}
+
+      {/* Composer toolbar — keeps everyday session tools and voice playback in
+          one compact shelf instead of stacking multiple white control bands. */}
+      {showComposerToolbar ? (
+        <View
+          className="bg-surface border-t border-surface-elevated px-4 pt-2 pb-1"
+          testID="chat-composer-toolbar"
+        >
+          <View className="flex-row items-center" style={{ gap: 8 }}>
+            {/* BUG-348: Hide VoicePlaybackBar entirely when screen reader is
+                active. TTS controls compete with VoiceOver/TalkBack for the
+                audio channel, and Replay bypasses auto-TTS suppression. */}
+            {showVoicePlaybackControls ? (
+              <VoicePlaybackBar
+                isSpeaking={ttsPlaying}
+                isPaused={ttsPaused}
+                rate={rate}
+                onStop={stopSpeaking}
+                onPause={pauseSpeaking}
+                onResume={resumeSpeaking}
+                onReplay={replay}
+                onRateChange={setRate}
+                variant="inline"
+              />
+            ) : null}
+            {composerAccessory ? (
+              <View className="flex-1 min-w-0">{composerAccessory}</View>
+            ) : null}
+          </View>
+        </View>
+      ) : null}
 
       {/* Input — when disabled, show inline reason instead of hiding entirely.
           H4: Falls back to a generic message when no disabledReason is provided
@@ -910,7 +937,11 @@ export function ChatShell({
             </View>
           )}
           <View
-            className="flex-row items-end px-4 py-3 bg-surface border-t border-surface-elevated"
+            className={`flex-row items-end px-4 bg-surface ${
+              showComposerToolbar
+                ? 'pt-1'
+                : 'py-3 border-t border-surface-elevated'
+            }`}
             testID="chat-input-row"
             // [BUG-886] On RN Web, mounted-but-unfocused screens stay in the
             // DOM. Remove the input row from the AT tree, swallow pointer

--- a/apps/mobile/src/components/session/SessionAccessories.test.tsx
+++ b/apps/mobile/src/components/session/SessionAccessories.test.tsx
@@ -17,7 +17,7 @@ jest.mock('../../lib/theme', /* gc1-allow: nativewind vars() does not resolve 'r
 describe('SessionToolAccessory stage gating', () => {
   const handleQuickChip = jest.fn();
 
-  it('renders Switch topic and Park it when stage is teaching', () => {
+  it('renders the switch topic tool when stage is teaching', () => {
     const { queryByTestId } = render(
       <SessionToolAccessory
         isStreaming={false}
@@ -26,7 +26,7 @@ describe('SessionToolAccessory stage gating', () => {
       />,
     );
     expect(queryByTestId('quick-chip-switch_topic')).toBeTruthy();
-    expect(queryByTestId('quick-chip-park')).toBeTruthy();
+    expect(queryByTestId('quick-chip-park')).toBeNull();
   });
 
   it('renders Add note as a primary teaching action when provided', () => {
@@ -99,7 +99,7 @@ describe('SessionToolAccessory Add note chip', () => {
     expect(queryByTestId('quick-chip-add-note')).toBeNull();
   });
 
-  it('renders Add note as the first chip when onAddNote is provided and stage is teaching', () => {
+  it('renders Add note and Switch topic when provided and stage is teaching', () => {
     const onAddNote = jest.fn();
     const { queryByTestId } = render(
       <SessionToolAccessory
@@ -111,7 +111,7 @@ describe('SessionToolAccessory Add note chip', () => {
     );
     expect(queryByTestId('quick-chip-add-note')).toBeTruthy();
     expect(queryByTestId('quick-chip-switch_topic')).toBeTruthy();
-    expect(queryByTestId('quick-chip-park')).toBeTruthy();
+    expect(queryByTestId('quick-chip-park')).toBeNull();
   });
 
   it('calls onAddNote when pressed', () => {

--- a/apps/mobile/src/components/session/SessionAccessories.tsx
+++ b/apps/mobile/src/components/session/SessionAccessories.tsx
@@ -18,6 +18,7 @@ export interface SessionToolAccessoryProps {
   handleQuickChip: (chip: QuickChipId) => Promise<void>;
   stage: ConversationStage;
   onAddNote?: () => void;
+  embedded?: boolean;
 }
 
 export function SessionToolAccessory({
@@ -25,12 +26,13 @@ export function SessionToolAccessory({
   handleQuickChip,
   stage,
   onAddNote,
+  embedded = false,
 }: SessionToolAccessoryProps) {
   const { t } = useTranslation();
   if (stage !== 'teaching') return null;
 
   return (
-    <View className="bg-surface px-4 py-1.5">
+    <View className={embedded ? 'flex-1 min-w-0' : 'bg-surface px-4 py-1.5'}>
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -62,7 +64,6 @@ export function SessionToolAccessory({
         {(
           [
             { id: 'switch_topic', label: t('session.accessories.switchTopic') },
-            { id: 'park', label: t('session.accessories.parkIt') },
           ] as Array<{ id: QuickChipId; label: string }>
         ).map((chip) => (
           <Pressable

--- a/apps/mobile/src/components/session/VoicePlaybackBar.tsx
+++ b/apps/mobile/src/components/session/VoicePlaybackBar.tsx
@@ -19,6 +19,7 @@ export interface VoicePlaybackBarProps {
   onResume: () => void;
   onReplay: () => void;
   onRateChange: (rate: number) => void;
+  variant?: 'bar' | 'inline';
 }
 
 function nextRate(current: number): number {
@@ -36,15 +37,19 @@ export function VoicePlaybackBar({
   onResume,
   onReplay,
   onRateChange,
+  variant = 'bar',
 }: VoicePlaybackBarProps) {
   const colors = useThemeColors();
+  const isInline = variant === 'inline';
 
   return (
     <View
-      className="px-4 py-2 bg-surface border-t border-surface-elevated"
+      className={
+        isInline ? '' : 'px-4 py-2 bg-surface border-t border-surface-elevated'
+      }
       testID="voice-playback-bar"
     >
-      <View className="flex-row items-center gap-2">
+      <View className="flex-row items-center" style={{ gap: isInline ? 4 : 8 }}>
         {/* Replay */}
         <Pressable
           onPress={onReplay}

--- a/apps/mobile/src/components/session/use-session-actions.test.ts
+++ b/apps/mobile/src/components/session/use-session-actions.test.ts
@@ -98,6 +98,7 @@ describe('useSessionActions', () => {
       milestonesReached: [],
     });
     expect(opts.setShowFilingPrompt).toHaveBeenCalledWith(true);
+    expect(opts.setIsClosing).toHaveBeenCalledWith(false);
   });
 
   it('shows filing prompt for homework sessions after close', async () => {
@@ -129,5 +130,49 @@ describe('useSessionActions', () => {
 
     expect(opts.setShowFilingPrompt).not.toHaveBeenCalled();
     expect(opts.router.replace).toHaveBeenCalled();
+  });
+
+  it('clears wrapping state when close times out', async () => {
+    jest.useFakeTimers();
+    const opts = createMockOpts({
+      closeSession: {
+        mutateAsync: jest.fn(
+          () =>
+            new Promise(() => {
+              /* never resolves */
+            }),
+        ),
+      },
+    });
+    const { result } = renderHook(() => useSessionActions(opts as any));
+
+    try {
+      await act(async () => {
+        await result.current.handleEndSession();
+      });
+
+      const buttons = (platformAlert as jest.Mock).mock.calls[0]?.[2] as Array<{
+        onPress?: () => void | Promise<void>;
+      }>;
+
+      let closePromise: Promise<void> = Promise.resolve();
+      await act(async () => {
+        closePromise = Promise.resolve(buttons[1]?.onPress?.());
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(15_000);
+        await closePromise;
+      });
+
+      expect(opts.setIsClosing).toHaveBeenCalledWith(false);
+      expect(platformAlert).toHaveBeenLastCalledWith(
+        'Could not end this session cleanly',
+        expect.any(String),
+        expect.any(Array),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/apps/mobile/src/components/session/use-session-actions.ts
+++ b/apps/mobile/src/components/session/use-session-actions.ts
@@ -343,13 +343,14 @@ export function useSessionActions(opts: UseSessionActionsOptions) {
         {
           text: 'End Session',
           onPress: async () => {
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
             try {
-              const timeoutPromise = new Promise<never>((_, reject) =>
-                setTimeout(
+              const timeoutPromise = new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(
                   () => reject(new Error('Session close timed out')),
                   CLOSE_TIMEOUT_MS,
-                ),
-              );
+                );
+              });
               const result = await Promise.race([
                 closeSession.mutateAsync({
                   reason: 'user_ended',
@@ -358,6 +359,9 @@ export function useSessionActions(opts: UseSessionActionsOptions) {
                 }),
                 timeoutPromise,
               ]);
+              if (timeoutId) {
+                clearTimeout(timeoutId);
+              }
               const fastCelebrations = await fetchFastCelebrations();
               await clearSessionRecoveryMarker(activeProfileId);
 
@@ -372,6 +376,7 @@ export function useSessionActions(opts: UseSessionActionsOptions) {
                 effectiveMode === 'homework'
               ) {
                 setShowFilingPrompt(true);
+                setIsClosing(false);
               } else {
                 navigateToSummary(
                   activeSessionId,
@@ -380,6 +385,10 @@ export function useSessionActions(opts: UseSessionActionsOptions) {
                 );
               }
             } catch (err: unknown) {
+              if (timeoutId) {
+                clearTimeout(timeoutId);
+              }
+              setIsClosing(false);
               const classified = classifyApiError(err);
               const actions = recoveryActions(classified, {
                 retry: () => setIsClosing(false),
@@ -429,6 +438,7 @@ export function useSessionActions(opts: UseSessionActionsOptions) {
     milestonesReached,
     effectiveMode,
     navigateToSummary,
+    returnTo,
     router,
     setIsClosing,
     setShowFilingPrompt,

--- a/apps/mobile/src/hooks/use-homework-ocr.test.ts
+++ b/apps/mobile/src/hooks/use-homework-ocr.test.ts
@@ -221,6 +221,46 @@ describe('useHomeworkOcr', () => {
     );
   });
 
+  it('escalates numbered local OCR fragments when numbering is the only cue', async () => {
+    mockRecognize.mockResolvedValue({
+      text: '1. Radissen\n2. Cryiy\nan\nWhal',
+      confidence: 0.9,
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          text: [
+            '1. What is chasing you',
+            '2. What are you avoiding',
+            '3. What do you want',
+            '4. What feels dead',
+            '5. What hurts',
+            '6. What wants to live',
+          ].join('\n'),
+          confidence: 0.86,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { result } = renderHook(() => useHomeworkOcr());
+
+    await act(async () => {
+      await result.current.process('file:///tmp/photo.jpg');
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('done');
+    expect(result.current.text).toContain('1. What is chasing you');
+    expect(result.current.text).not.toContain('Radissen');
+    expect(mockTrackHomeworkOcrGateAccepted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'server',
+        confidence: 0.86,
+      }),
+    );
+  });
+
   it('does not treat abbreviation periods as homework cues', async () => {
     mockRecognize.mockResolvedValue({
       text: 'Dr. Smith',

--- a/apps/mobile/src/hooks/use-homework-ocr.ts
+++ b/apps/mobile/src/hooks/use-homework-ocr.ts
@@ -90,21 +90,26 @@ function buildGateMetrics(
   };
 }
 
-function hasHomeworkCue(text: string): boolean {
-  if (/\d/.test(text) || /[+\-−×*·÷/=<>≤≥±²³]/.test(text)) {
+function stripListMarkers(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/^\s*(?:\d+|[A-Z])[.)]?\s+/, ''))
+    .join('\n');
+}
+
+function hasStrongHomeworkCue(text: string): boolean {
+  const contentText = stripListMarkers(text);
+
+  if (/\d/.test(contentText) || /[+\-−×*·÷/=<>≤≥±²³]/.test(contentText)) {
     return true;
   }
 
-  if (/^\s*(?:\d+|[A-Z])[.)]\s+/m.test(text)) {
-    return true;
-  }
-
-  if (/[?!:]/.test(text)) {
+  if (/[?!:]/.test(contentText)) {
     return true;
   }
 
   return /\b(?:answer|calculate|choose|circle|compare|complete|conjugate|contrast|correct|define|describe|draw|evaluate|explain|factor|fill|find|graph|how|identify|label|prove|read|select|show|simplify|solve|translate|underline|what|when|where|which|who|why|write)\b/iu.test(
-    text,
+    contentText,
   );
 }
 
@@ -113,7 +118,7 @@ function shouldEscalateLocalOcr(text: string, confidence?: number): boolean {
     return true;
   }
 
-  if (hasHomeworkCue(text)) {
+  if (hasStrongHomeworkCue(text)) {
     return false;
   }
 

--- a/docs/plans/2026-05-18-challenge-round-into-note.md
+++ b/docs/plans/2026-05-18-challenge-round-into-note.md
@@ -1,0 +1,2616 @@
+# Sunset Challenge Mode Toggle + Add Challenge Round Into Note — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:**
+Phase 0 — sunset the persistent "Challenge mode" / "Explorer" toggle that currently lives in the session header. All learners default to today's `casual` behavior (immediate XP, warm tone, no mastery gates, no mandatory summaries).
+Phase 1 — replace what "Challenge mode" did emotionally with a contextual, learner-celebrated **Challenge Round** event the LLM offers mid-session when the learner shows readiness. The learner answers 2–3 deeper "explain-back" questions, the LLM evaluates each concept (`solid|partial|missing|misconception`), and a learner-owned note is drafted from their *own* correct answers. Note save is always explicit. Mastery is server-decided and conservative: any partial/misconception blocks the "challenge-verified" axis. The existing "Too easy" quick chip becomes a second entry path — it routes to the Challenge Round offer when readiness gates pass, otherwise behaves as today.
+
+**Architecture:**
+- Sunset by deletion, not deprecation (pre-launch, no users — see `feedback_pre_launch_no_users.md`). The `learningModes` table loses its `mode` and `consecutiveSummarySkips` columns; the enum value `'serious'` is removed from schemas + DB; XP + prompt + mastery + summary branches collapse to a single path.
+- New feature is server-driven: trigger eligibility on the server, LLM proposes via envelope signals, server gates and decides mastery, Inngest fans out non-core side effects via `safeSend()`.
+- Per-answer structured evaluation reuses the existing `parseEnvelope()` pipeline.
+- Note drafting reuses the existing `topic_notes` table and `POST /subjects/:subjectId/topics/:topicId/notes` route — the only addition is a `source: 'user' | 'challenge_round'` column for provenance.
+- Mobile UI follows the `fluency_drill` ui_hint pattern that's already proven (server emits ui_hint → mobile detects in `use-session-streaming.ts` → mobile renders widget).
+
+**Tech Stack:** TypeScript, Drizzle ORM (Postgres/Neon), Hono (API), Zod (`@eduagent/schemas`), Inngest (post-round side effects), React Native / Expo (mobile), Jest, NativeWind semantic tokens, react-i18next.
+
+---
+
+## Adversarial Review Findings Applied (2026-05-18)
+
+This plan was adversarially reviewed before execution. The following findings shaped the task list; finding IDs appear inline next to the amendments they triggered.
+
+- **CRIT-1** — `topicProgress` table referenced in original plan does not exist. Mastery is computed at runtime in `services/progress.ts` and `services/escalation.ts`, not stored. Resolved by Task 0.0 spike + revised Task 9 column-placement.
+- **CRIT-2** — `reviewTargets` table does not exist anywhere in the repo. Original plan treated it as ambient infra. Resolved by Task 0.0 spike + explicit "build vs. reuse" decision in Task 9.
+- **CRIT-3** — `getSessionById` / `persistSessionMetadata` helpers do not exist. Original plan imports them from `session-crud`. Resolved by Task 0.0 spike that names the real helpers or extracts new ones with a profileId-protection break test.
+- **CRIT-4** — `struggleStatusSchema` is not exported from `@eduagent/schemas` (only inline enum). Resolved by Task 3.0 export step before Task 3.
+- **CRIT-5** — XP collapse must preserve `'pending'` and `'decayed'` READS even though writer becomes single-path. Multiple consumers (`progress.ts:346, 772`, `retention-data.ts:91, 107`, `retention.ts:15`, dashboard) branch on these. Resolved by amended Task 0.2 Step 4–7.
+- **CRIT-6** — `consecutiveSummarySkips` deletion blast radius is 8 files, not 2. Resolved by amended Task 0.2 file list + mandatory grep step.
+- **CRIT-7** — Every destructive migration must follow the CLAUDE.md `## Rollback` 3-line format. Resolved inline in Tasks 0.1, 2, 8, 9.
+- **HIGH-1** — Note-draft lexical guard catches topic drift, not value substitution. Misconception substitution is caught earlier by `decideMasteryAndReview` rejecting non-`solid` concepts from the draft prompt. Guard claim downgraded in Task 6.
+- **HIGH-2** — Race: server-initiated and chip-initiated offer paths can collide. Resolved by amended `/maybe-offer` route in Task 9 + Failure Modes row.
+- **HIGH-3** — Streaming envelope may flush `challenge_round_offer` before server-side gate strips it. Resolved by Task 10 Step 5.0 (verify streaming protocol) + suppression-at-source mitigation if mid-stream signals leak.
+- **HIGH-4** — `getContextualQuickChips` is unaware of `challengeRound.state`. Resolved by added Task 10 Step 8.5.
+- **HIGH-5** — "Line ~XYZ" instructions are unsafe; line numbers drift. Resolved by replacing every "remove line ~X" instruction with "grep + enumerate + decide" in Tasks 0.3, 0.5.
+- **MED-1** — `notes.source` requires sweep across 6 schema sites, not just `createNoteInputSchema`. Resolved in Task 8 Step 1.
+- **MED-2** — Cooldown FK cascade semantics documented in Task 2.
+- **MED-3** — `MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4` is a guess. Resolved by Task 6 calibration step + TODO marker.
+- **MED-4** — Inngest event-name registration must be cited, not assumed. Resolved in Task 9 Step 5.
+- **MED-5** — `topic-completion.ts` contract for the new column is not specified. Resolved in Task 9 Step 1.5.
+- **MED-6** — Decline-cooldown smoke is impractical with a hardcoded 24h. Resolved in Final Validation Smoke 5.
+- **MED-7** — `verifyXp` / `verifyPendingXp` left-in-place fate clarified in Task 0.2 Step 7.
+- **LOW-1** — Rollback sections use the prescribed format even pre-launch (Task 0.1).
+- **LOW-2** — State→prompt mapping table added in Task 7 Step 3.
+- **CRIT-8** — The original plan allowed the partial/misconception path to degrade to Sentry-only logging if no review-target persistence was chosen. That violates the product requirement: keep correct learner work, remember the shaky concept, and do not mark mastered. Resolved by Task 0.0 Step 2: a durable weak-spot target is mandatory for v1.
+- **HIGH-6** — Drafting from "solid concepts" alone is not enough; the note drafter must receive exact learner-owned answer snippets, not the full transcript and not vague concept labels. Resolved by Task 1 evaluation schema additions (`answerEventId`, `learnerQuote`) and Task 6 validation updates.
+- **HIGH-7** — The partial-success flow was described but not asserted in integration tests. Resolved by Task 11: mixed outcome must save a note containing only the solid learner quotes, persist weak-spot review data, and leave mastery unset.
+- **HIGH-8** — "Server-owned mastery" was overstated. The server owns policy and caps, but correctness still depends on LLM evaluation quality. Resolved by Task 5/7/11: add adversarial misconception false-positive tests and phrase the invariant as "server-owned conservative gating over structured LLM evidence."
+- **MED-8** — `retentionStatus === 'strong'` only would make Challenge Rounds too rare for learners who are doing well in a first session. Resolved by Task 3: permit a current-session high-confidence path (`new|strong` retention with longer correct streak and no struggle).
+- **MED-9** — Mid-round app close/session timeout was promised but not given an implementation task. Resolved by Task 8.5: persist pending draft recovery state and add an explicit integration test.
+
+---
+
+## Pre-Work Findings (codebase audit, 2026-05-18)
+
+### Surfaces affected
+- **Session header** — `useLearningModeControl` button + bottom sheet (`apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx`). To be removed.
+- **More tab Learning Mode section** — copy keys `more.learningMode.*` (`apps/mobile/src/i18n/locales/en.json:278-295`). To be removed.
+- **Active session chat** (`apps/mobile/src/app/(app)/session/index.tsx`) — render new Challenge Round components; remove `LearningModeControl` from header.
+- **"Too easy" quick chip** (`apps/mobile/src/components/session/session-types.ts:121-126`, `getContextualQuickChips:271-282`) — extended: on tap, if readiness gates pass server-side, trigger Challenge Round offer; otherwise current behavior (LLM-nudged harder follow-up).
+- **LLM exchange loop** (`apps/api/src/services/exchanges.ts → processExchange`) — dispatch challenge-round trigger evaluation + envelope handling.
+- **Prompt builder** (`apps/api/src/services/exchange-prompts.ts:175-192`) — collapse `getLearningModeGuidance()` to single tone; inject challenge-round prompt block when active.
+- **XP service** (`apps/api/src/services/xp.ts:108-113`) — collapse to single path (immediate `verified` for all, with an additional "verified by challenge round" axis available for analytics, not for XP delay).
+- **Settings service** (`apps/api/src/services/settings.ts:459-486`) — delete `getLearningModeRules()`, `consecutiveSummarySkips` tracking, summary-skip warnings.
+- **Schemas** (`packages/schemas/src/progress.ts:15, 107-110, 159-164`) — remove `learningModeSchema`, `learningModeUpdateSchema`, `getLearningModeResponseSchema`.
+- **DB schema** (`packages/database/src/schema/progress.ts:166-188`) — drop `mode` + `consecutiveSummarySkips` columns from `learningModes` table; drop `learningModeEnum`.
+- **API routes** — delete learning-mode GET/PUT endpoints.
+- **Mobile hooks** — delete `useLearningMode()`, `useUpdateLearningMode()`.
+- **Eval-harness flows** (`apps/api/eval-llm/flows/exchanges.ts:292, 538`, `flows/probes.ts:30, 182`, `flows/topic-probe-signals.ts:155-182`) — remove `learningMode` from context defaults and conditional logic.
+- **Topic completion + mastery** (`apps/api/src/services/topic-completion.ts`, `services/snapshot-aggregation.ts`) — add `masteryChallengeVerifiedAt` axis.
+- **Retention/review** (`apps/api/src/services/retention-data.ts`) — accept `source: 'challenge_round'` on review-target writes.
+- **Notes** (`apps/api/src/services/notes.ts`, `apps/mobile/src/hooks/use-notes.ts`) — reused for drafted-note persistence; add `source` column.
+
+**Out of scope:** Practice / recall / dictation / quiz / freeform/ask-anything sessions for v1 (trigger evaluator hard-gates these). Homework permanently excluded (`feedback_homework_not_socratic.md`). Parent dashboard badge for challenge-verified mastery (schema lands; UI badge is v2). Voice-only flow, rewards/streaks, multi-round per session, parent-challenges-child.
+
+### What exists today (with line citations)
+**Persistent Challenge mode toggle (to be removed):**
+- `apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx:1-175` — header button + bottom-sheet picker with Explorer (compass icon) / Challenge mode (trophy icon).
+- `apps/mobile/src/i18n/locales/en.json:278-295` — "Challenge mode" copy: *"Push yourself further. Your mentor keeps you on track. You earn points after proving you remember, and recaps help lock it in."*
+- `packages/database/src/schema/progress.ts:166-188` — `learningModes` table with `mode (enum, default='serious')`, `consecutiveSummarySkips`, plus retained-utility fields `medianResponseSeconds`, `celebrationLevel`.
+- `packages/database/src/schema/progress.ts:174` — `learningModeEnum = ['serious', 'casual']`.
+- `packages/schemas/src/progress.ts:15` — `learningModeSchema`.
+- `packages/schemas/src/progress.ts:107-110, 159-164` — `learningModeUpdateSchema`, `getLearningModeResponseSchema`.
+- `apps/api/src/services/settings.ts:459-472` — `getLearningModeRules()` → `{masteryGates, verifiedXpOnly, mandatorySummaries}` by mode.
+- `apps/api/src/services/settings.ts:476-486` — `consecutiveSummarySkips` counter + warn-at-5 logic.
+- `apps/api/src/services/xp.ts:108-113` — XP status branching: casual → `'verified'` immediate; serious → `'pending'` until delayed-recall verification.
+- `apps/api/src/services/exchange-prompts.ts:175-192` — `getLearningModeGuidance()` injects mode-tailored tone string into system prompt.
+- `apps/api/eval-llm/flows/exchanges.ts:292, 538` — `learningMode: 'casual'` default in scenarios + `contextOverrides.learningMode === 'casual'` branch.
+- `apps/api/eval-llm/flows/probes.ts:30, 182` — probe context conditional on `learningMode === 'casual'`.
+- `apps/api/eval-llm/flows/topic-probe-signals.ts:155-182` — `profile.learningMode` passed into context with conditional override.
+- Tests: `apps/api/src/services/xp.test.ts:15-17, 282-284`; `apps/api/src/services/settings.test.ts:312-314, 322-324`; `apps/mobile/src/app/(app)/session/index.test.tsx`; `apps/api/src/services/session/session-cache.test.ts`.
+
+**Infrastructure reused by the new feature (kept untouched):**
+- `packages/schemas/src/llm-envelope.ts:11-72` — envelope with `signals.*` + `ui_hints.*`. Pattern we extend.
+- `apps/api/src/services/llm/envelope.ts:165-182` — `parseEnvelope()` with surface-tagged failure paths.
+- `apps/api/src/services/llm/envelope.ts:51-62` — `fluency_drill` ui_hint as the canonical widget pattern.
+- `apps/api/src/services/exchanges.ts → processExchange` — the dispatch + envelope-parse point.
+- `apps/api/src/services/exchange-prompts.ts:79-184` — `buildSystemPrompt()` — challenge-round prompt block plugs in here after `getLearningModeGuidance()` is collapsed.
+- `packages/schemas/src/notes.ts:3-39` — `topicNoteSchema` with nullable `sessionId`.
+- `apps/api/src/services/notes.ts:48+` — `createNote()` with `dedupeExactSessionContent`.
+- `apps/api/src/routes/notes.ts:56+` — `POST /subjects/:subjectId/topics/:topicId/notes`.
+- `apps/mobile/src/components/library/Note*.tsx` + `apps/mobile/src/hooks/use-notes.ts` — `NoteInput` + `useCreateNote`.
+- `packages/schemas/src/progress.ts:240, 256, 258, 259` — `retentionStatus`, `struggleStatus`, `masteryScore`. Read by trigger evaluator; mastery gains a new `masteryChallengeVerifiedAt` axis.
+- `packages/schemas/src/sessions.ts:85-89, 224` — `sessionTypeSchema` (`learning|homework|interleaved`); `MIN_EXCHANGES_FOR_TOPIC_COMPLETION = 5`.
+- `apps/mobile/src/components/session/use-session-streaming.ts` — existing ui_hint detection pattern.
+- `apps/mobile/src/lib/strip-envelope.ts` — strips ui_hints from learner-visible reply.
+- `apps/mobile/src/components/session/session-types.ts:121-126, 271-282` — `too_easy` chip definition + `getContextualQuickChips` (chips shown when last assistant message is a statement: `know_this, explain_differently, too_easy, example`).
+
+### What does NOT exist (must build net-new)
+- Any concept-by-concept LLM answer evaluator.
+- Any AI-drafted note generator (all current notes are user-typed).
+- Any in-session mode-switch state machine.
+- Any review-target persistence with `source: 'challenge_round'` provenance.
+- Any "Too easy chip → server-side eligibility → maybe Challenge Round" routing.
+
+### What this PR adds
+- **Phase 0 (sunset):**
+  - DB migration: drop `mode`, `consecutiveSummarySkips` columns from `learningModes`; drop `learningModeEnum`.
+  - Code removals: `learningModeSchema`/`Update`/`Response`, `getLearningModeRules`, `getLearningModeGuidance`, learning-mode routes + hooks + UI + i18n keys + tests.
+  - XP collapse: single `'verified'` path immediately; remove `'pending'`/`verifiedXpOnly` branch.
+  - Prompt collapse: single warm-but-direct tone (today's `casual` tone is the new default — see Recommended scope below).
+- **Phase 1 (feature):**
+  - Envelope additions: `signals.challenge_round_offer`, `signals.challenge_round_evaluation`, `ui_hints.challenge_round`, `ui_hints.note_draft`.
+  - `apps/api/src/services/challenge-round/` module: trigger evaluator, state machine, caps, prompt blocks, evaluation parser, note drafter, mastery decision.
+  - `sessionMetadata.challengeRound` state field.
+  - `challenge_round_cooldowns` table (per-profile/per-topic cooldown rows).
+  - `notes.source` column with `'user' | 'challenge_round'`.
+  - `topicProgress.masteryChallengeVerifiedAt` column.
+  - `reviewTargets.source` column.
+  - Mobile components: `ChallengeOfferCard`, `ChallengeRoundBanner`, `DraftedNoteReview` + `use-challenge-round` hook.
+  - Inngest function: `challenge.round.completed` for fan-out.
+  - "Too easy" chip handler extended: on tap, calls `POST /challenge-round/maybe-offer`; server-side `evaluateChallengeReadiness` decides; if eligible, transitions to `offered` and the LLM's next response includes the offer; otherwise, the chip dispatches today's `too_easy` system prompt.
+
+### Walkthrough per entry
+- **Session opens, learner sees no header toggle (was Explorer/Challenge mode dropdown):** Header is cleaner. No mode picker. Tone is consistent across all sessions (the new default = today's casual tone — warm + concrete examples). **Risk: low** (pre-launch, no muscle-memory to disrupt).
+- **Learning session, learner answers 2 in a row correctly, topic in `strong` retention, ≥5 exchanges in:** Server-side trigger evaluator returns `eligible: true`. LLM is told it MAY offer in its next response. LLM emits `signals.challenge_round_offer: true` with a one-sentence pitch in `reply`. Mobile shows `ChallengeOfferCard` with `Try it` / `Not now` / `Don't ask again this session`. **Risk: low** (offer only, escapable).
+- **Learner taps "Too easy" chip in eligible context:** Mobile calls `POST /challenge-round/maybe-offer`; server runs `evaluateChallengeReadiness`. If eligible, server flips `sessionMetadata.challengeRound.state = 'offered'` and returns `{ offered: true }`. Mobile shows `ChallengeOfferCard` immediately. The chip's traditional `too_easy` LLM-nudge does NOT fire (the offer card is the substitute). **Risk: low.**
+- **Learner taps "Too easy" chip in ineligible context (e.g., on exchange 3, or during homework):** Server returns `{ offered: false, reason: '...' }`. Mobile falls back to today's behavior: dispatches the `too_easy` system prompt that nudges the AI to raise difficulty for the next response. The chip's traditional behavior is preserved. **Risk: low** (no UX regression).
+- **Learner accepts, answers all 3 challenge questions well:** Server transitions `challengeRound = active → drafting`. LLM emits per-question evaluations + a drafted note in `ui_hints.note_draft`. Mobile shows `DraftedNoteReview` with `Save`, `Edit`, `Skip`. On Save, hits `POST /subjects/:subjectId/topics/:topicId/notes` with `sessionId` linkage and `source: 'challenge_round'`. Mastery gains `masteryChallengeVerifiedAt = now`. **Risk: low.**
+- **Learner accepts, answers 2 of 3 well, 1 with a misconception:** Drafted note includes only the 2 solid concepts. Mobile copy: "You've got the strong pieces. I'll save those — we'll tighten the fuzzy bit next time." Misconception persisted to review targets with `source: 'challenge_round'` + the correction text. Mastery NOT flipped. **Risk: medium** — copy must never use failure framing (`feedback_positive_framing_no_struggle.md`).
+- **Learner accepts, answers all 3 with misconceptions:** No note created. Mobile copy: "Let's revisit this together first." Server records `outcome: 'reteach_recommended'`; sets a next-session-hint. **Risk: medium.**
+- **Homework session:** Trigger evaluator hard-gates `false`. Never offered, even if "Too easy" chip is tapped. **Risk: zero by design.**
+- **Learner declines offer:** `challengeRound.state = 'declined'`. Trigger evaluator suppresses for the rest of this session. Persists cooldown row (`challenge_round_cooldowns`) for ≥24h on the topic. **Risk: low.**
+- **Session ends mid-Challenge Round (back gesture, app close, timeout):** Server-side auto-completes: if ≥1 solid concept, drafted-note offered on next app open via the existing pending-note pattern (extend `ui_hints.note_prompt` to carry the drafted content for `post_session` variant). If zero solid, no artifact. **Risk: medium** — covered in Failure Modes.
+- **Practice / recall / dictation / interleaved sessions:** Trigger evaluator hard-gates `false` for v1. Plumbing exists for future expansion.
+- **Ask-anything / freeform:** No `topicId` → no note target → trigger hard-gated `false`.
+- **Existing users with `learningMode = 'serious'` row in DB:** Migration overwrites all rows to one consistent default before column drop. Pre-launch — no real users to surprise.
+
+### Failure modes
+
+| State | Trigger | User sees | Recovery |
+|---|---|---|---|
+| Migration fails mid-deploy | Drop column step errors on staging | n/a — staging only | Rollback the migration (forward-only after staging green; per CLAUDE.md schema rules, every destructive migration needs a Rollback section — included in Task 0.1 migration plan). |
+| Existing user has `'serious'` row at deploy time | Old row exists when enum is dropped | n/a — pre-launch | Migration step 1 sets all rows to `'casual'`, step 2 drops the enum value, step 3 drops the column. Three explicit steps. |
+| LLM emits malformed envelope mid-round | Parser fails | Mobile renders `reply` only; no challenge ui_hint advances | Server marks `outcome: 'parse_error'`, no note save, no mastery change. Sentry breadcrumb `challenge.envelope_parse`. |
+| LLM emits `note_draft` with content not derivable from learner messages | Hallucination guard fires | Draft NOT shown | Lexical-overlap check (<40% with learner answers) rejects; falls back to `outcome: 'draft_rejected'` with reason persisted for eval review. |
+| Learner taps Save, network drops | POST notes fails | `DraftedNoteReview` shows retry, draft preserved in component state | Reuses in-component state; offline queue not added in v1 (see Out of Scope). |
+| Quota exhausted just before challenge-round LLM call | Monthly cap hit | Offer card never shown | Trigger evaluator suppresses when quota < 5% remaining; no degradation, falls back to normal session. |
+| Evaluation false-positive (LLM marks `misconception` on correct answer) | Eval flake | Concept incorrectly filed to review targets | Learner can dismiss review targets from the existing review-targets affordance; eval-harness scenario tracks evaluation flakiness for prompt iteration. |
+| Session timer expires mid-round | Auto-end | Drafted note offered on next app open via `note_prompt.post_session` | Same as "session ends mid-round." One explicit integration-test case. |
+| Same topic offered Challenge Round immediately after a decline | Trigger forgets decline | None — guarded server-side | Decline state persists in `sessionMetadata` for this session + cooldown row (`challenge_round_cooldowns`) for 24h on the topic. |
+| LLM emits `challenge_round_offer` mid-round | Confused state | None — server strips the signal | Server filters when `challengeRound.state ∈ {offered, accepted, active, drafting}`. |
+| "Too easy" chip tapped while already in offered/active state | Re-tap | Chip does nothing (or surfaces a tiny "already in challenge round" toast) | Mobile guard: chip disabled when `challengeRound.state ∈ {offered, accepted, active, drafting}`. |
+| Mastery race: snapshot-aggregation reads mid-round | Reader sees in-flight state | Parent dashboard could show partial state | Snapshot reader filters out rows where `challengeRound.state ∈ {accepted, active, drafting}`. |
+| Concurrent offer race (HIGH-2): LLM emits `challenge_round_offer` while learner taps "Too easy" in the same window | Both paths call `transitionChallengeState({type:'offer'})`; the second throws "illegal: cannot offer from state=offered" | Mobile chip sees a 500; console error | `/maybe-offer` route checks current state BEFORE transitioning; if already `offered|accepted|active|drafting`, returns `{offered: true, alreadyOffered: true}` and mobile no-ops. Unit test in Task 9. |
+| Stream race (HIGH-3): server strips `challenge_round_offer` after `parseEnvelope`; mobile streaming may have already surfaced it | Brief offer card flash, then disappears | Confusing flicker | Task 10 Step 5.0 verifies envelope is delivered as a single end-of-stream message (current pipeline). If streaming is incremental, suppression moves to system prompt: when not eligible, the offer prompt block is NOT injected, so the LLM cannot emit the signal in the first place. |
+| Chip not filtered during round (HIGH-4): `getContextualQuickChips` ignores `sessionMetadata.challengeRound.state` | "Too easy" chip stays visible during an active round | Tap during round causes confused behavior | Task 10 Step 8.5 wires `challengeRound.state` into the chip filter; unit test asserts `too_easy` is filtered when state ∈ `{offered, active, drafting}`. |
+| Drafted-note hallucination via value substitution (HIGH-1) | LLM swaps a correct word for an incorrect one within the learner's vocabulary (e.g. "mitochondria" instead of "chloroplast") | Misleading note saved | Primary defense: drafting prompt is fed ONLY the `solid` evaluations from `decideMasteryAndReview` — misconception text never reaches the drafter. Secondary lexical guard catches topic drift only, not substitution; this is documented in `note-draft.ts` jsdoc, not asserted as the substitution guard. |
+| XP migration race: in-flight `'pending'` XP from old serious-mode session at deploy time | Existing pending XP records | n/a — pre-launch | Phase 0 migration step 4 promotes any `xp.status='pending'` rows to `'verified'` once and clears the column option. |
+| LearningModeControl import remains in session/index.tsx after component delete | TypeScript compile error | n/a — pre-deploy | Caught by `pnpm exec nx run mobile:typecheck` in Task 0.4. |
+| i18n key `more.learningMode.*` referenced elsewhere | Translation lookup misses | Missing string at runtime | Task 0.5 greps all `t('more.learningMode')` references and removes; CI lints would also catch via `i18next` linter if configured. |
+
+### Recommended scope (v1)
+- **Sunset Phase 0 is destructive but safe pre-launch.** Migration drops two columns + an enum. No backcompat shims. (`feedback_pre_launch_no_users.md`.)
+- **Default tone is today's `casual`.** Warm + concrete examples. The "rigor + delayed XP + mandatory summaries" experience is NOT preserved as a setting; rigor is now expressed *through Challenge Rounds* per-topic per-moment, not as a global vibe.
+- **Header button slot freed.** No replacement in this PR (decision: keep header lean; if we add a future button it gets its own design pass). The trophy/compass icons retire.
+- **"Too easy" chip becomes the learner-initiated Challenge Round entry.** When server-side gates allow, tapping it triggers an offer card. When they don't, falls back to today's behavior. No new chip; no new icon.
+- **Learning + interleaved sessions only.** Homework explicitly excluded. Freeform/ask-anything deferred.
+- **3 challenge questions max per round, 1 round per session, 1 challenge offer per topic per 24h.**
+- **Note save = explicit user action.** Never auto-save. Edit always available. Skip is non-destructive.
+- **Mastery-verified is a NEW boolean axis** (`masteryChallengeVerifiedAt`), not a re-purposing of `masteryScore`. Keeps current consumers untouched.
+
+---
+
+## File Structure
+
+### Phase 0 — Sunset Files
+
+**Deleted:**
+- `apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx`
+- `apps/mobile/src/app/(app)/session/_components/LearningModeControl.test.tsx` (if present)
+- All consumers of `useLearningMode` / `useUpdateLearningMode` — confirm via grep before delete.
+
+**Modified:**
+- `packages/database/src/schema/progress.ts` — drop `mode`, `consecutiveSummarySkips`, `learningModeEnum`.
+- `packages/database/src/migrations/####_drop_learning_mode.sql` — generated.
+- `packages/schemas/src/progress.ts` — remove `learningModeSchema`, `learningModeUpdateSchema`, `getLearningModeResponseSchema`.
+- `apps/api/src/services/settings.ts` — remove `getLearningModeRules`, summary-skip warn logic; keep `celebrationLevel`, `medianResponseSeconds` accessors.
+- `apps/api/src/services/settings.test.ts` — delete mode-rule tests.
+- `apps/api/src/services/xp.ts` — collapse XP path (single `verified`); delete `'pending'` branch.
+- `apps/api/src/services/xp.test.ts` — delete `serious` mode test cases; update snapshots.
+- `apps/api/src/services/exchange-prompts.ts` — delete `getLearningModeGuidance()`; replace its call site with a single inline tone block (today's `casual` text, lifted verbatim).
+- `apps/api/src/services/exchange-prompts.test.ts` — update snapshots.
+- `apps/api/src/routes/settings.ts` (or wherever) — delete GET/PUT learning-mode endpoints.
+- `apps/api/src/routes/settings.test.ts` — delete endpoint tests.
+- `apps/mobile/src/hooks/use-settings.ts` — delete `useLearningMode`, `useUpdateLearningMode` (keep neighbors).
+- `apps/mobile/src/hooks/use-settings.test.ts` — delete tests for removed hooks.
+- `apps/mobile/src/app/(app)/session/index.tsx` — remove `useLearningModeControl()` import + button/sheet render.
+- `apps/mobile/src/app/(app)/session/index.test.tsx` — delete mode-toggle test cases.
+- `apps/mobile/src/app/(app)/more/` (find the file rendering `more.learningMode.*`) — delete the section + tests.
+- `apps/mobile/src/i18n/locales/en.json` — delete `more.learningMode.*` keys.
+- `apps/mobile/src/i18n/locales/{de,es,ja,nb,pl,pt}.json` — delete the same keys.
+- `apps/api/eval-llm/flows/exchanges.ts:292, 538` — remove `learningMode` from defaults / overrides.
+- `apps/api/eval-llm/flows/probes.ts:30, 182` — remove conditionals.
+- `apps/api/eval-llm/flows/topic-probe-signals.ts:155-182` — remove `profile.learningMode` plumbing.
+- `apps/api/src/services/session/session-cache.test.ts` — remove `learningMode` from test contexts.
+
+### Phase 1 — New Feature Files
+
+**Created (API):**
+- `apps/api/src/services/challenge-round/index.ts` — barrel.
+- `apps/api/src/services/challenge-round/trigger.ts` + `.test.ts` — `evaluateChallengeReadiness`.
+- `apps/api/src/services/challenge-round/prompts.ts` + `.test.ts` — system-prompt fragments.
+- `apps/api/src/services/challenge-round/evaluation.ts` + `.test.ts` — `decideMasteryAndReview`.
+- `apps/api/src/services/challenge-round/note-draft.ts` + `.test.ts` — hallucination guard.
+- `apps/api/src/services/challenge-round/state.ts` + `.test.ts` — state machine.
+- `apps/api/src/services/challenge-round/caps.ts` + `.test.ts` — `MAX_CHALLENGE_QUESTIONS = 3`, cooldown const, overlap threshold.
+- `apps/api/src/routes/challenge-round.ts` + `.test.ts` — accept/decline/abort/maybe-offer endpoints.
+- `apps/api/src/inngest/functions/challenge-round-completed.ts` + `.test.ts` + `.integration.test.ts` — fan-out for metrics + review-target writes.
+- `apps/api/eval-llm/scenarios/challenge-round.ts` — 6-scenario matrix.
+- `packages/database/src/schema/challenge-round-cooldowns.ts` — per-profile/per-topic cooldown rows.
+- `packages/database/src/migrations/####_challenge_round_cooldowns.sql` — generated.
+- `packages/database/src/migrations/####_notes_source.sql` — generated.
+- `packages/database/src/migrations/####_topic_progress_challenge_verified.sql` — generated.
+- `packages/database/src/migrations/####_review_targets_source.sql` — generated.
+
+**Created (Mobile):**
+- `apps/mobile/src/hooks/use-challenge-round.ts` + `.test.tsx`.
+- `apps/mobile/src/components/session/ChallengeOfferCard.tsx` + `.test.tsx`.
+- `apps/mobile/src/components/session/ChallengeRoundBanner.tsx` + `.test.tsx`.
+- `apps/mobile/src/components/session/DraftedNoteReview.tsx` + `.test.tsx`.
+
+**Created (Integration):**
+- `tests/integration/challenge-round.integration.test.ts` — end-to-end: offer → accept → 3 answers → drafted note → POST notes → mastery flag.
+
+**Modified (Phase 1):**
+- `packages/schemas/src/llm-envelope.ts` — add `challenge_round_offer`, `challenge_round_evaluation` signals; add `challenge_round`, `note_draft` ui_hints.
+- `packages/schemas/src/llm-envelope.test.ts` — round-trip tests for new fields.
+- `packages/schemas/src/sessions.ts` — extend `sessionMetadataSchema` with `challengeRound`.
+- `packages/schemas/src/progress.ts` — add `masteryChallengeVerifiedAt` to `topicProgressSchema`.
+- `packages/schemas/src/notes.ts` — add `source: 'user' | 'challenge_round'` discriminator on `createNoteInputSchema`.
+- `packages/database/src/schema/notes.ts` — add `source` column (default `'user'`).
+- `packages/database/src/schema/topic-progress.ts` (or equivalent) — add `masteryChallengeVerifiedAt`.
+- `packages/database/src/schema/review-targets.ts` (or equivalent) — add `source` column.
+- `apps/api/src/services/notes.ts` + `.test.ts` — accept and persist `source`.
+- `apps/api/src/services/exchanges.ts` + integration test — wire challenge-round dispatch into `processExchange`.
+- `apps/api/src/services/exchange-prompts.ts` — inject challenge-round prompt block when `sessionMetadata.challengeRound.state ∈ {offered, active, drafting}`.
+- `apps/api/src/services/topic-completion.ts` + `.test.ts` — read `masteryChallengeVerifiedAt`.
+- `apps/api/src/services/snapshot-aggregation.ts` + `.test.ts` — filter in-flight challenge-round rows.
+- `apps/api/src/services/retention-data.ts` + `.test.ts` — accept `source` on review-target writes.
+- `apps/mobile/src/components/session/use-session-streaming.ts` + `.test.tsx` — detect `ui_hints.challenge_round` + `ui_hints.note_draft` + `signals.challenge_round_offer`.
+- `apps/mobile/src/app/(app)/session/index.tsx` — render new components based on streaming hook output.
+- `apps/mobile/src/lib/strip-envelope.ts` + `.test.ts` — strip new ui_hint keys.
+- `apps/mobile/src/components/session/SessionAccessories.tsx` (the chip strip) + `.test.tsx` — wire `too_easy` tap through `useChallengeRound.maybeOffer()` first; fall through to existing `too_easy` system-prompt dispatch on `{offered: false}`.
+- `apps/mobile/src/i18n/locales/en.json` — add `session.challenge.*` keys (full list in Phase 1 tasks).
+- `apps/mobile/src/i18n/locales/{de,es,ja,nb,pl,pt}.json` — add the same keys with English fallback (translations follow in a separate localization pass).
+- `CLAUDE.md` — append one bullet under engineering rules about challenge-round mastery decisions being server-owned and conservative.
+
+---
+
+## Tasks
+
+> **Convention:** Each task is one logical commit. TDD: write the failing test, run it red, implement, run it green, commit via `/commit` (the only authorized commit path — CLAUDE.md → Git Commits).
+
+> **Phase boundary:** Tasks 0.1–0.6 are the sunset. Tasks 1–12 are the feature. Phase 1 depends on Phase 0 being green (the prompt-builder changes in 0.3 are the seam Phase 1 plugs into).
+
+---
+
+### Task 0.0 — Codebase-existence spike (gates CRIT-1, CRIT-2, CRIT-3, CRIT-4)
+
+This task produces NO code. It produces a `docs/plans/2026-05-18-challenge-round-targets.md` decision doc that downstream tasks cite. Phase 1 (Tasks 8, 9, 11) cannot start until this is signed off, because the original plan references tables, modules, and exports that don't exist.
+
+**Output:** a short decision doc with four sections — one per finding.
+
+- [ ] **Step 1: Mastery-verified persistence target (CRIT-1)**
+
+The plan needs to persist `masteryChallengeVerifiedAt`. The original plan said `topic-progress.ts` — that file does not exist. Decide between:
+- (a) Add a column to `retentionCards` (already per-profile-per-topic, scoped). Lowest blast radius. Trade-off: conflates retention spaced-repetition state with challenge-mastery state.
+- (b) Add a new `topic_mastery_state` table (profile_id, topic_id, mastery_challenge_verified_at, …). Clean separation, one more table.
+- (c) Add a JSON column to `learningSessions.metadata` keyed by topicId. No migration of structured columns. Trade-off: can't index.
+
+```
+Grep "retentionCards|retention_cards" packages/database/src/schema
+Read the matching file. Confirm scoping pattern.
+Pick (a), (b), or (c) and document the rationale.
+```
+
+The chosen target is the canonical reference for Task 9 Step 1. Update Task 9 Step 1 to name the actual file + column placement before starting.
+
+- [ ] **Step 2: Review-targets persistence target (CRIT-2)**
+
+The plan needs to persist `partial`/`misconception` concepts for later surfacing. There is no `review_targets` table. Decide between:
+- (a) Reuse `retentionCards` with a `source` discriminator. Already wired into `retention-data.ts` reads.
+- (b) Net-new `review_targets` table (profile_id, topic_id, concept, misconception, correction, source, created_at). Clean, but new read surface.
+- (c) Inject into the existing `learningSessions.metadata.gaps` array (already exists at `packages/schemas/src/sessions.ts:169`).
+
+Document the chosen path. If (b), add a Task 9.0 with its own migration + `## Rollback` block + integration test. If (a) or (c), update Task 9 Step 1 and the Inngest function (Task 9 Step 4) accordingly.
+
+**CRIT-8 — no Sentry-only fallback:** v1 must persist weak spots durably. A Challenge Round that saves the correct parts but forgets the partial/misconception concepts is not shippable, because it forces the learner to repeat good work later and can falsely imply mastery. If none of (a), (b), or (c) is chosen, stop the implementation before Task 8 and write a new plan revision. Do not ship Challenge Rounds with only telemetry for weak spots.
+
+- [ ] **Step 3: Session CRUD helper names (CRIT-3)**
+
+```
+Read apps/api/src/services/session/session-crud.ts
+List every exported function.
+Find the closest equivalents to `getSessionById` and `persistSessionMetadata`.
+```
+
+Document the actual names. Update every plan reference (Tasks 8, 9, 11 — search for `getSessionById|persistSessionMetadata`) to use the real names. If the real helpers don't enforce `profileId` scoping the way the plan assumes (CLAUDE.md non-negotiable rule), add a Task 9.0 to either (i) extract `getSessionByIdScoped(sessionId, profileId)` with a break test that proves cross-profile access returns null, or (ii) inline the scoping check at every route handler. Decide which.
+
+- [ ] **Step 4: Schema export of `struggleStatusSchema` (CRIT-4)**
+
+```
+Grep "struggleStatus" packages/schemas/src
+```
+
+Today the enum is inline in `progress.ts:258`. Either:
+- (a) Extract to `packages/schemas/src/struggle-status.ts` mirroring `retention-status.ts`, export, re-import in `progress.ts`.
+- (b) Inline the literal `z.enum(['normal', 'needs_deepening', 'blocked'])` at the trigger evaluator's import site instead of importing from schemas.
+
+Pick (a) — consistency with `retentionStatusSchema`. Add the extraction as Task 3 Step 0 (before Step 1).
+
+- [ ] **Step 5: Commit the decision doc**
+
+```bash
+/commit
+```
+
+> **Gate:** Tasks 8, 9, 11 do not begin until the decision doc is committed and the relevant inline task references are updated to match the chosen targets.
+
+---
+
+### Task 0.1 — Drop `learningMode` columns and enum (DB + migration)
+
+**Files:**
+- Modify: `packages/database/src/schema/progress.ts`
+- Create: `packages/database/src/migrations/####_drop_learning_mode.sql` (generated)
+
+**## Rollback (CRIT-7, LOW-1 — per CLAUDE.md schema rule, prescribed 3-line format):**
+- **(a) Rollback possible?** Yes, technically. Revert the migration commit and re-apply schema from `git show HEAD~1:packages/database/src/schema/progress.ts`.
+- **(b) Data lost?** Zero rows of consequence — pre-launch, no real user data exists in `learning_modes.mode` or `learning_modes.consecutive_summary_skips`. Any seeded dev rows are disposable.
+- **(c) Recovery procedure?** Re-fixture the dev DB (`pnpm run db:push:dev` after revert) or re-run `drizzle-kit migrate` against staging once the revert lands. No backup restoration required.
+
+- [ ] **Step 1: Capture current schema for reference**
+
+```bash
+git show HEAD:packages/database/src/schema/progress.ts > /tmp/progress-before.ts
+```
+
+- [ ] **Step 2: Remove enum + columns from schema**
+
+In `packages/database/src/schema/progress.ts`, remove these definitions:
+- `learningModeEnum`
+- `learningModes.mode`
+- `learningModes.consecutiveSummarySkips`
+
+Keep the `learningModes` table itself (still hosts `medianResponseSeconds`, `celebrationLevel`). The table name is now slightly misleading; renaming is a follow-up.
+
+- [ ] **Step 3: Generate migration**
+
+```bash
+pnpm run db:generate:dev
+```
+
+Expected: new SQL file. **Inspect it.** It should:
+1. `UPDATE learning_modes SET mode = 'casual' WHERE mode = 'serious';` (defensive, even pre-launch)
+2. `ALTER TABLE learning_modes DROP COLUMN mode;`
+3. `ALTER TABLE learning_modes DROP COLUMN consecutive_summary_skips;`
+4. `DROP TYPE IF EXISTS learning_mode_enum;`
+
+If drizzle-kit doesn't emit the `UPDATE` step (it usually doesn't for column drops), prepend it manually.
+
+- [ ] **Step 4: Apply locally**
+
+```bash
+pnpm run db:push:dev
+```
+
+- [ ] **Step 5: Verify with db studio**
+
+```bash
+pnpm run db:studio:dev
+```
+
+Visually confirm the columns are gone and the enum type is dropped.
+
+- [ ] **Step 6: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 0.2 — Remove schema types + service-layer rules
+
+**Files (CRIT-6 — `consecutiveSummarySkips` sweep is 8 files, not 2):**
+- Modify: `packages/schemas/src/progress.ts`
+- Modify: `apps/api/src/services/settings.ts`
+- Modify: `apps/api/src/services/settings.test.ts`
+- Modify: `apps/api/src/services/xp.ts`
+- Modify: `apps/api/src/services/xp.test.ts`
+- Modify: `apps/api/src/services/session/session-crud.ts` — remove `consecutiveSummarySkips` reads/writes
+- Modify: `apps/api/src/services/session/session-summary.ts` — remove `consecutiveSummarySkips` logic
+- Modify: `apps/api/src/services/session-summary.integration.test.ts` — drop related cases
+- Modify: `apps/api/src/inngest/functions/session-completed.ts` — remove `consecutiveSummarySkips` writes
+- Modify: `apps/api/src/inngest/functions/session-completed.test.ts` — drop related cases
+- Modify: `apps/api/src/routes/sessions.test.ts` — drop related cases
+
+- [ ] **Step 0: Enumerate caller sites before deletion (CRIT-6)**
+
+```
+Grep "consecutiveSummarySkips|incrementSummarySkip|resetSummarySkip" apps/api/src
+```
+
+Cross-check the result against the file list above. If extra files turn up, add them. If the worker proceeds without this enumeration, mid-task cascading typecheck errors are guaranteed.
+
+- [ ] **Step 1: Delete from schemas**
+
+In `packages/schemas/src/progress.ts`, remove:
+- `learningModeSchema` (line ~15)
+- `learningModeUpdateSchema` (line ~107)
+- `getLearningModeResponseSchema` (line ~159)
+- All exports referencing these.
+
+- [ ] **Step 2: Delete `getLearningModeRules` + summary-skip logic from settings service**
+
+In `apps/api/src/services/settings.ts`:
+- Delete `getLearningModeRules()` (lines ~459-472).
+- Delete the summary-skip-warn block (lines ~476-486).
+- Delete any helper `incrementSummarySkip()` / `resetSummarySkip()`.
+- Keep `getCelebrationLevel`, `getMedianResponseSeconds` accessors and their tests.
+
+- [ ] **Step 3: Update settings tests**
+
+In `apps/api/src/services/settings.test.ts`:
+- Delete the `getLearningModeRules` describe block (lines ~312-324).
+- Run `cd apps/api && pnpm exec jest src/services/settings.test.ts` — green.
+
+- [ ] **Step 4: Collapse XP path**
+
+In `apps/api/src/services/xp.ts` lines ~108-113, the current code branches on mode:
+
+```typescript
+// BEFORE
+const status = learningMode === 'serious' ? 'pending' : 'verified';
+```
+
+Replace with the single path:
+
+```typescript
+// AFTER
+const status = 'verified';
+```
+
+Then sweep the file for any remaining `learningMode` references and remove them.
+
+**CRIT-5 — DO NOT remove the `status` field, even as a follow-up.** `xpStatus` has three values: `pending | verified | decayed`. Decay is independent of the casual/serious split (see `xp.ts:68 decayXp`, plus `progress.ts:346, 772`, `retention-data.ts:91, 107`, `retention.ts:15`, `dashboard.integration.test.ts:298, 362`, `coaching-cards.test.ts:349`, `test-seed.ts:551`). We are collapsing the WRITER only; READS of `pending` and `decayed` must continue to function. Add a grep verification step (Step 6.5 below) confirming no read sites were broken.
+
+**MED-7 — Fate of `verifyXp` and pending-verification flow.** `xp.ts:56 verifyXp` and the verification call sites in `inngest/functions/subject-prewarm-curriculum.ts` etc. become unreachable for *new* topics under single-path writes. They remain in place to handle two real cases: (i) any prod records that get retro-imported, (ii) the decayed-XP re-verification flow. Annotate `verifyXp` with `// Preserved for decayed-XP re-verification; new topics ship as 'verified' directly post-sunset.`
+
+- [ ] **Step 5: Update XP tests**
+
+In `apps/api/src/services/xp.test.ts`:
+- Delete the `serious` mode test cases (~lines 15-17, 282-284).
+- Snapshot updates: `cd apps/api && pnpm exec jest src/services/xp.test.ts -u`.
+- Verify snapshots are sane (one path, no `'pending'`).
+
+- [ ] **Step 6: Run API tests**
+
+```bash
+pnpm exec nx run api:test
+```
+
+Expected: green. Track and fix any other test that referenced the removed schemas.
+
+- [ ] **Step 6.5: Verify pending/decayed read sites still compile and behave (CRIT-5)**
+
+```
+Grep "xpStatus.*pending|status.*pending|status.*decayed|xpStatus.*decayed" apps/api/src apps/mobile/src
+```
+
+Each match must be a READ (display, branching), not a WRITE. If any new code writes `pending`, it's a regression. Cross-check that dashboard pending/verified visualisations still render against seed data (`test-seed.ts:551` seeds both statuses).
+
+- [ ] **Step 7: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 0.3 — Collapse prompt builder to single tone + delete eval-harness mode plumbing
+
+**Files:**
+- Modify: `apps/api/src/services/exchange-prompts.ts`
+- Modify: `apps/api/src/services/exchange-prompts.test.ts`
+- Modify: `apps/api/eval-llm/flows/exchanges.ts`
+- Modify: `apps/api/eval-llm/flows/probes.ts`
+- Modify: `apps/api/eval-llm/flows/topic-probe-signals.ts`
+
+- [ ] **Step 1: Capture today's casual tone string verbatim**
+
+In `apps/api/src/services/exchange-prompts.ts:175-192`, `getLearningModeGuidance()` returns one of two strings based on mode. Lift the `casual` string out of the function as a `const DEFAULT_TONE_GUIDANCE = "...";` at module scope.
+
+- [ ] **Step 2: Delete the function**
+
+Delete `getLearningModeGuidance()` entirely. Replace every call site in `buildSystemPrompt()` with `DEFAULT_TONE_GUIDANCE`.
+
+- [ ] **Step 3: Update tests + snapshots**
+
+```bash
+cd apps/api && pnpm exec jest src/services/exchange-prompts.test.ts -u
+```
+
+Manually review the snapshot diff: the `serious` snapshots should be gone, the `casual` snapshots should remain as the single tone.
+
+- [ ] **Step 4: Strip `learningMode` from eval-harness flows (HIGH-5 — grep, not line numbers)**
+
+Line numbers drift; grep first, then decide each site. Run:
+
+```
+Grep "learningMode" apps/api/eval-llm
+```
+
+For each match, decide its fate (delete the field, collapse the conditional, delete the parameter, etc.). Expected files: `flows/exchanges.ts`, `flows/probes.ts`, `flows/topic-probe-signals.ts` — plus any fixture composition or scenario types that pass `learningMode` through. The original cited line numbers (`~292, ~538, ~30, ~182, ~155-182`) are advisory only — do not trust them; the grep is authoritative.
+
+Also grep parameter/return types for the field name:
+
+```
+Grep "learningMode\??:" apps/api/eval-llm
+```
+
+Each typed reference must be removed too, or downstream `noUnusedParameters` / `noImplicitAny` rules will surface.
+
+- [ ] **Step 5: Run Tier 1 eval harness**
+
+```bash
+pnpm eval:llm
+```
+
+Expected: snapshots regenerate cleanly. If anything mode-related lingers in a fixture, the snapshot diff will surface it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 0.4 — Delete API routes + mobile hooks
+
+**Files:**
+- Modify: `apps/api/src/routes/settings.ts` (or wherever learning-mode routes live; locate via grep `learning.*mode` in routes)
+- Modify: `apps/api/src/routes/settings.test.ts`
+- Modify: `apps/mobile/src/hooks/use-settings.ts`
+- Modify: `apps/mobile/src/hooks/use-settings.test.ts`
+
+- [ ] **Step 1: Locate routes**
+
+```bash
+```
+
+Use Grep tool: search `learningMode|learning-mode|getLearningMode` in `apps/api/src/routes`. Identify the file with the GET and PUT/PATCH endpoints.
+
+- [ ] **Step 2: Delete the route handlers**
+
+Remove `GET /settings/learning-mode` (or equivalent) and `PUT /settings/learning-mode`. Remove the schema imports.
+
+- [ ] **Step 3: Delete route tests**
+
+Remove the matching `describe` block in `routes/settings.test.ts`. Run the remaining tests green:
+
+```bash
+cd apps/api && pnpm exec jest src/routes/settings.test.ts
+```
+
+- [ ] **Step 4: Delete mobile hooks**
+
+In `apps/mobile/src/hooks/use-settings.ts`:
+- Delete `useLearningMode`.
+- Delete `useUpdateLearningMode`.
+- Keep neighbors untouched.
+
+In `apps/mobile/src/hooks/use-settings.test.ts`:
+- Delete the corresponding describe blocks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 0.5 — Delete `LearningModeControl` component + remove from session header + remove More tab section
+
+**Files:**
+- Delete: `apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx`
+- Modify: `apps/mobile/src/app/(app)/session/index.tsx`
+- Modify: `apps/mobile/src/app/(app)/session/index.test.tsx`
+- Modify: the More-tab file rendering `more.learningMode.*` (locate via grep — likely `apps/mobile/src/app/(app)/more/index.tsx` or `apps/mobile/src/app/(app)/more/preferences.tsx`)
+- Modify: `apps/mobile/src/i18n/locales/{en,de,es,ja,nb,pl,pt}.json`
+
+- [ ] **Step 1: Locate consumers of LearningModeControl**
+
+Grep `useLearningModeControl|LearningModeControl` across `apps/mobile/src` — should be exactly the session screen.
+
+- [ ] **Step 2: Remove from session/index.tsx**
+
+In `apps/mobile/src/app/(app)/session/index.tsx`:
+- Delete the import line: `import { useLearningModeControl } from './_components/LearningModeControl';`.
+- Delete the hook call: `const { button, sheet } = useLearningModeControl();`.
+- Delete the rendering of `{button}` from the header and `{sheet}` from the root.
+
+- [ ] **Step 3: Delete the component file**
+
+```bash
+rm apps/mobile/src/app/(app)/session/_components/LearningModeControl.tsx
+rm apps/mobile/src/app/(app)/session/_components/LearningModeControl.test.tsx 2>/dev/null || true
+```
+
+- [ ] **Step 4: Update session/index.test.tsx**
+
+Delete any test cases that exercise the mode toggle: `learning-mode-header-button`, `learning-mode-modal`, `learning-mode-sheet`, `session-learning-mode-*`, `learning-mode-next-message-copy`. Run green:
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/session/index.tsx --no-coverage
+```
+
+- [ ] **Step 5: Locate and remove the More tab learning-mode section**
+
+Grep `more.learningMode|learningMode.casual|learningMode.serious` in `apps/mobile/src/app/(app)/more` to find the file. Remove the section (likely a `<Pressable>` or section block referencing the keys). Run that screen's test green.
+
+- [ ] **Step 6: Strip i18n keys (HIGH-5)**
+
+For each locale file (`en.json`, `de.json`, `es.json`, `ja.json`, `nb.json`, `pl.json`, `pt.json`):
+
+```
+Grep "learningMode" apps/mobile/src/i18n/locales/<file>
+```
+
+Delete every match. The original "lines around 278-295" is advisory only — line numbers will have drifted by the time the worker reaches this step.
+
+Then verify no consumer references the deleted keys:
+
+```
+Grep "t\\(['\"]more\\.learningMode|t\\(['\"]learningMode|i18nKey.*learningMode" apps/mobile/src
+```
+
+Expected: zero matches. If any turn up, they were missed in earlier steps; chase them down.
+
+- [ ] **Step 7: Run mobile typecheck + lint + test**
+
+```bash
+pnpm exec nx lint mobile
+cd apps/mobile && pnpm exec tsc --noEmit
+cd apps/mobile && pnpm exec jest --no-coverage
+```
+
+Expected: green. Any dangling import or `t('more.learningMode.*')` reference surfaces here.
+
+- [ ] **Step 8: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 0.6 — Final sunset sweep + integration validation
+
+- [ ] **Step 1: Whole-repo grep**
+
+Use the Grep tool with pattern `learningMode|learning_mode|LearningMode|learning-mode|getLearningMode|useLearningMode` across the whole repo. Expected results: zero. If anything turns up, remove it and re-grep.
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+pnpm exec nx run-many -t test
+```
+
+Expected: green. Pay attention to any DB-related integration test that previously inserted a `learning_modes.mode` value — should now error or be obsolete.
+
+- [ ] **Step 3: Manual smoke on emulator**
+
+Launch the app, start a session, confirm:
+- No "Explorer / Challenge mode" button in the header.
+- No "Learning Mode" section in More tab.
+- Session behavior is consistent (warm tone, immediate XP, no mastery gates blocking progress).
+
+- [ ] **Step 4: Commit (if any micro-fixes)**
+
+```bash
+/commit
+```
+
+> **Phase 0 complete.** Header is lean. XP is single-path. Tone is single-string. Phase 1 begins below.
+
+---
+
+### Task 1 — Extend envelope schema with challenge-round signals + ui_hints
+
+**Files:**
+- Modify: `packages/schemas/src/llm-envelope.ts`
+- Test: `packages/schemas/src/llm-envelope.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/schemas/src/llm-envelope.test.ts (append)
+import { llmResponseEnvelopeSchema } from './llm-envelope';
+
+describe('challenge round envelope fields', () => {
+  it('accepts challenge_round_offer signal', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: "You've got the basics — want a challenge round?",
+      signals: { challenge_round_offer: true },
+      confidence: 'medium',
+    });
+    expect(parsed.signals?.challenge_round_offer).toBe(true);
+  });
+
+  it('accepts challenge_round_evaluation per-concept results', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'Strong work.',
+      signals: {
+        challenge_round_evaluation: [
+          { concept: 'photosynthesis vs respiration', result: 'solid', evidence: 'learner described both directions of energy flow' },
+          { concept: 'role of ATP', result: 'partial', evidence: 'mentioned energy currency, missed structure' },
+          { concept: 'where it happens', result: 'misconception', evidence: 'said nucleus instead of chloroplast', correction: 'occurs in chloroplasts' },
+        ],
+      },
+      confidence: 'high',
+    });
+    expect(parsed.signals?.challenge_round_evaluation).toHaveLength(3);
+    expect(parsed.signals?.challenge_round_evaluation?.[2].correction).toBe('occurs in chloroplasts');
+  });
+
+  it('accepts challenge_round ui_hint', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'Question 2 of 3.',
+      ui_hints: { challenge_round: { active: true, question_index: 1, total_questions: 3 } },
+      confidence: 'high',
+    });
+    expect(parsed.ui_hints?.challenge_round?.active).toBe(true);
+  });
+
+  it('accepts note_draft ui_hint with content', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: "Here's what you know now.",
+      ui_hints: {
+        note_draft: {
+          content: 'Photosynthesis uses light to convert CO2 and water into glucose...',
+          source_concepts: ['photosynthesis vs respiration', 'role of ATP'],
+        },
+      },
+      confidence: 'high',
+    });
+    expect(parsed.ui_hints?.note_draft?.content).toMatch(/photosynthesis/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test red**
+
+```bash
+pnpm exec nx test schemas --testPathPattern='llm-envelope.test'
+```
+
+- [ ] **Step 3: Extend schema**
+
+```typescript
+// packages/schemas/src/llm-envelope.ts — append/extend
+
+export const challengeRoundEvaluationItemSchema = z.object({
+  concept: z.string().min(1).max(200),
+  result: z.enum(['solid', 'partial', 'missing', 'misconception']),
+  evidence: z.string().min(1).max(500),
+  correction: z.string().min(1).max(500).optional(),
+});
+
+// In the existing signals object, add:
+challenge_round_offer: z.boolean().optional(),
+challenge_round_evaluation: z.array(challengeRoundEvaluationItemSchema).max(10).optional(),
+
+// In the existing ui_hints object, add:
+challenge_round: z
+  .object({
+    active: z.boolean(),
+    question_index: z.number().int().min(0).max(9),
+    total_questions: z.number().int().min(1).max(10),
+  })
+  .optional(),
+note_draft: z
+  .object({
+    content: z.string().min(1).max(2000),
+    source_concepts: z.array(z.string()).min(1).max(10),
+  })
+  .optional(),
+```
+
+- [ ] **Step 4: Run test green**
+
+```bash
+pnpm exec nx test schemas
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 2 — Add `sessionMetadata.challengeRound` state + cooldown DB table
+
+**Files:**
+- Modify: `packages/schemas/src/sessions.ts` + `.test.ts`
+- Create: `packages/database/src/schema/challenge-round-cooldowns.ts`
+- Create: `packages/database/src/migrations/####_challenge_round_cooldowns.sql` (generated)
+
+- [ ] **Step 1: Write failing test for schema**
+
+```typescript
+// packages/schemas/src/sessions.test.ts (append)
+import { sessionMetadataSchema } from './sessions';
+
+describe('sessionMetadata.challengeRound', () => {
+  it('defaults to undefined', () => {
+    const m = sessionMetadataSchema.parse({});
+    expect(m.challengeRound).toBeUndefined();
+  });
+
+  it('accepts state transitions', () => {
+    const m = sessionMetadataSchema.parse({
+      challengeRound: {
+        state: 'active',
+        startedAt: new Date().toISOString(),
+        questionIndex: 1,
+        totalQuestions: 3,
+        offerCount: 1,
+      },
+    });
+    expect(m.challengeRound?.state).toBe('active');
+  });
+
+  it('rejects invalid state', () => {
+    expect(() =>
+      sessionMetadataSchema.parse({ challengeRound: { state: 'frobnicated' } }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Extend sessionMetadataSchema**
+
+```typescript
+// packages/schemas/src/sessions.ts (additions)
+
+export const challengeRoundStateEnum = z.enum([
+  'offered',
+  'accepted',
+  'declined',
+  'active',
+  'drafting',
+  'complete',
+  'aborted',
+]);
+
+export const challengeRoundSessionStateSchema = z.object({
+  state: challengeRoundStateEnum,
+  startedAt: z.string().datetime().optional(),
+  questionIndex: z.number().int().min(0).max(9).optional(),
+  totalQuestions: z.number().int().min(1).max(10).optional(),
+  offerCount: z.number().int().min(0).default(0),
+  topicId: z.string().uuid().optional(),
+  declinedDontAskAgain: z.boolean().default(false),
+});
+
+// extend existing sessionMetadataSchema:
+export const sessionMetadataSchema = z.object({
+  // ...existing fields...
+  challengeRound: challengeRoundSessionStateSchema.optional(),
+});
+```
+
+**## Rollback for the cooldown migration (CRIT-7):**
+- **(a) Rollback possible?** Yes — pure additive table; reversible via `DROP TABLE challenge_round_cooldowns;`.
+- **(b) Data lost?** Cooldown rows accumulated since deploy. Loss = re-offer of recently-declined challenge rounds. User-visible but non-destructive (no learning state lost).
+- **(c) Recovery procedure?** Drop the table; old code path simply re-creates it on next migration cycle.
+
+**MED-2 — Cascade semantics:** Both FKs (`profile_id`, `topic_id`) use `onDelete: 'cascade'`. Expected behaviour:
+- Profile delete (GDPR export-delete) wipes their cooldown rows. Correct.
+- Topic regeneration (curriculum rebuild generates a NEW topic UUID) effectively *resets* cooldown for the rebuilt topic — that's a desired behavior (regenerated topic = fresh start), but verify with the curriculum-rebuild flow owner. If unwanted, switch to `onDelete: 'set null'` on `topic_id` and treat null as "cooldown applies to historical topic, ignore on new topics."
+
+- [ ] **Step 3: Add DB table for cooldown**
+
+```typescript
+// packages/database/src/schema/challenge-round-cooldowns.ts
+import { pgTable, uuid, timestamp, integer, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { profiles } from './profiles';
+import { curriculumTopics } from './curriculum-topics';
+
+export const challengeRoundCooldowns = pgTable(
+  'challenge_round_cooldowns',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    profileId: uuid('profile_id').notNull().references(() => profiles.id, { onDelete: 'cascade' }),
+    topicId: uuid('topic_id').notNull().references(() => curriculumTopics.id, { onDelete: 'cascade' }),
+    lastOfferedAt: timestamp('last_offered_at', { withTimezone: true }).notNull().defaultNow(),
+    lastOutcome: integer('last_outcome'), // 0=declined, 1=accepted_partial, 2=verified, 3=reteach
+  },
+  (t) => ({
+    profileTopicUniq: uniqueIndex('challenge_round_cooldowns_profile_topic_uniq').on(t.profileId, t.topicId),
+  }),
+);
+```
+
+- [ ] **Step 4: Generate + apply migration**
+
+```bash
+pnpm run db:generate:dev
+pnpm run db:push:dev
+```
+
+- [ ] **Step 5: Run schemas tests green**
+
+```bash
+pnpm exec nx test schemas
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 3 — Trigger evaluator (`evaluateChallengeReadiness`)
+
+**Files:**
+- Create: `packages/schemas/src/struggle-status.ts` (CRIT-4)
+- Modify: `packages/schemas/src/progress.ts` — import from new file
+- Modify: `packages/schemas/src/index.ts` — export
+- Create: `apps/api/src/services/challenge-round/trigger.ts`
+- Create: `apps/api/src/services/challenge-round/trigger.test.ts`
+
+- [ ] **Step 0: Extract `struggleStatusSchema` to its own module (CRIT-4)**
+
+Today the enum is inline at `packages/schemas/src/progress.ts:258` (`z.enum(['normal', 'needs_deepening', 'blocked'])`) and not exported. Mirror the `retention-status.ts:3` pattern:
+
+```typescript
+// packages/schemas/src/struggle-status.ts
+import { z } from 'zod';
+
+export const struggleStatusSchema = z.enum(['normal', 'needs_deepening', 'blocked']);
+export type StruggleStatus = z.infer<typeof struggleStatusSchema>;
+```
+
+Re-import inside `progress.ts` and replace the inline enum at line 258 (verify line first; HIGH-5). Add to the schemas barrel export. Without this, the `trigger.ts` import at Step 3 below fails typecheck.
+
+- [ ] **Step 1: Write failing test** *(11 cases — full table of hard gates)*
+
+```typescript
+// apps/api/src/services/challenge-round/trigger.test.ts
+import { evaluateChallengeReadiness } from './trigger';
+
+const baseInput = {
+  sessionType: 'learning' as const,
+  exchangeCount: 6,
+  retentionStatus: 'strong' as const,
+  struggleStatus: 'normal' as const,
+  recentCorrectStreak: 2,
+  quotaFractionRemaining: 0.5,
+  challengeRoundState: undefined,
+  cooldownLastOfferedAt: null,
+  cooldownLastOutcome: null,
+  now: new Date('2026-05-18T12:00:00Z'),
+};
+
+describe('evaluateChallengeReadiness', () => {
+  it('eligible when learning + strong + ≥5 exchanges + streak ≥2 + no cooldown', () => {
+    expect(evaluateChallengeReadiness(baseInput).eligible).toBe(true);
+  });
+
+  it('hard-gates homework sessions', () => {
+    expect(evaluateChallengeReadiness({ ...baseInput, sessionType: 'homework' }).eligible).toBe(false);
+  });
+
+  it('eligible for interleaved sessions', () => {
+    expect(evaluateChallengeReadiness({ ...baseInput, sessionType: 'interleaved' }).eligible).toBe(true);
+  });
+
+  it('hard-gates when struggling', () => {
+    expect(evaluateChallengeReadiness({ ...baseInput, struggleStatus: 'needs_deepening' }).eligible).toBe(false);
+    expect(evaluateChallengeReadiness({ ...baseInput, struggleStatus: 'blocked' }).eligible).toBe(false);
+  });
+
+  it('hard-gates under exchange threshold', () => {
+    expect(evaluateChallengeReadiness({ ...baseInput, exchangeCount: 4 }).eligible).toBe(false);
+  });
+
+  it('hard-gates fading/weak/forgotten retention', () => {
+    for (const status of ['fading', 'weak', 'forgotten'] as const) {
+      expect(evaluateChallengeReadiness({ ...baseInput, retentionStatus: status }).eligible).toBe(false);
+    }
+  });
+
+  it('hard-gates when streak below 2', () => {
+    expect(evaluateChallengeReadiness({ ...baseInput, recentCorrectStreak: 1 }).eligible).toBe(false);
+  });
+
+  it('hard-gates when already in challenge state', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        challengeRoundState: { state: 'active', offerCount: 1 },
+      }).eligible,
+    ).toBe(false);
+  });
+
+  it('hard-gates declined within 24h cooldown', () => {
+    const oneHourAgo = new Date('2026-05-18T11:00:00Z');
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        cooldownLastOfferedAt: oneHourAgo,
+        cooldownLastOutcome: 0,
+      }).eligible,
+    ).toBe(false);
+  });
+
+  it('allows again after 24h cooldown', () => {
+    const yesterday = new Date('2026-05-17T11:00:00Z');
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        cooldownLastOfferedAt: yesterday,
+        cooldownLastOutcome: 0,
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('hard-gates when quota fraction below 5%', () => {
+    expect(evaluateChallengeReadiness({ ...baseInput, quotaFractionRemaining: 0.03 }).eligible).toBe(false);
+  });
+
+  it("hard-gates 'don't ask again' for this session", () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        challengeRoundState: { state: 'declined', offerCount: 1, declinedDontAskAgain: true },
+      }).eligible,
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run red**
+
+```bash
+cd apps/api && pnpm exec jest src/services/challenge-round/trigger.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// apps/api/src/services/challenge-round/trigger.ts
+import type { z } from 'zod';
+import {
+  sessionTypeSchema,
+  retentionStatusSchema,
+  struggleStatusSchema,
+  challengeRoundSessionStateSchema,
+} from '@eduagent/schemas';
+
+const CHALLENGE_OFFER_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const MIN_EXCHANGES = 5;
+const MIN_CORRECT_STREAK = 2;
+const MIN_QUOTA_FRACTION = 0.05;
+
+export interface ChallengeReadinessInput {
+  sessionType: z.infer<typeof sessionTypeSchema>;
+  exchangeCount: number;
+  retentionStatus: z.infer<typeof retentionStatusSchema>;
+  struggleStatus: z.infer<typeof struggleStatusSchema>;
+  recentCorrectStreak: number;
+  quotaFractionRemaining: number;
+  challengeRoundState: z.infer<typeof challengeRoundSessionStateSchema> | undefined;
+  cooldownLastOfferedAt: Date | null;
+  cooldownLastOutcome: number | null;
+  now: Date;
+}
+
+export interface ChallengeReadinessResult {
+  eligible: boolean;
+  reason?: string;
+}
+
+export function evaluateChallengeReadiness(input: ChallengeReadinessInput): ChallengeReadinessResult {
+  if (input.sessionType !== 'learning' && input.sessionType !== 'interleaved') {
+    return { eligible: false, reason: 'session_type' };
+  }
+  if (input.struggleStatus !== 'normal') return { eligible: false, reason: 'struggle' };
+  if (input.exchangeCount < MIN_EXCHANGES) return { eligible: false, reason: 'exchanges_below_min' };
+  if (input.retentionStatus !== 'strong') return { eligible: false, reason: 'retention' };
+  if (input.recentCorrectStreak < MIN_CORRECT_STREAK) return { eligible: false, reason: 'streak' };
+  if (input.quotaFractionRemaining < MIN_QUOTA_FRACTION) return { eligible: false, reason: 'quota' };
+  if (input.challengeRoundState && input.challengeRoundState.state !== 'complete' && input.challengeRoundState.state !== 'aborted') {
+    if (input.challengeRoundState.declinedDontAskAgain) return { eligible: false, reason: 'session_decline' };
+    if (['offered', 'accepted', 'active', 'drafting'].includes(input.challengeRoundState.state)) {
+      return { eligible: false, reason: 'already_in_round' };
+    }
+    if (input.challengeRoundState.state === 'declined') return { eligible: false, reason: 'session_decline' };
+  }
+  if (input.cooldownLastOfferedAt && input.cooldownLastOutcome === 0) {
+    const elapsed = input.now.getTime() - input.cooldownLastOfferedAt.getTime();
+    if (elapsed < CHALLENGE_OFFER_COOLDOWN_MS) return { eligible: false, reason: 'cooldown' };
+  }
+  return { eligible: true };
+}
+```
+
+- [ ] **Step 4: Run green**
+
+```bash
+cd apps/api && pnpm exec jest src/services/challenge-round/trigger.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 4 — Caps + state-machine helpers
+
+**Files:**
+- Create: `apps/api/src/services/challenge-round/caps.ts` + `.test.ts`
+- Create: `apps/api/src/services/challenge-round/state.ts` + `.test.ts`
+
+- [ ] **Step 1: caps test**
+
+```typescript
+// apps/api/src/services/challenge-round/caps.test.ts
+import {
+  MAX_CHALLENGE_QUESTIONS,
+  MAX_CHALLENGE_ANSWER_CHARS,
+  CHALLENGE_OFFER_COOLDOWN_HOURS,
+  MIN_LEXICAL_OVERLAP_NOTE_DRAFT,
+  enforceChallengeQuestionCap,
+} from './caps';
+
+describe('caps', () => {
+  it('exposes MAX_CHALLENGE_QUESTIONS = 3', () => expect(MAX_CHALLENGE_QUESTIONS).toBe(3));
+  it('exposes MAX_CHALLENGE_ANSWER_CHARS = 2000', () => expect(MAX_CHALLENGE_ANSWER_CHARS).toBe(2000));
+  it('exposes COOLDOWN_HOURS = 24', () => expect(CHALLENGE_OFFER_COOLDOWN_HOURS).toBe(24));
+  it('exposes MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4', () => expect(MIN_LEXICAL_OVERLAP_NOTE_DRAFT).toBe(0.4));
+  it('caps 5 to 3', () => expect(enforceChallengeQuestionCap(5)).toBe(3));
+  it('passes 2 through', () => expect(enforceChallengeQuestionCap(2)).toBe(2));
+  it('floor 1', () => expect(enforceChallengeQuestionCap(0)).toBe(1));
+});
+```
+
+- [ ] **Step 2: caps impl**
+
+```typescript
+// apps/api/src/services/challenge-round/caps.ts
+export const MAX_CHALLENGE_QUESTIONS = 3;
+export const MAX_CHALLENGE_ANSWER_CHARS = 2000;
+export const CHALLENGE_OFFER_COOLDOWN_HOURS = 24;
+export const MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4;
+
+export function enforceChallengeQuestionCap(requested: number): number {
+  if (requested < 1) return 1;
+  if (requested > MAX_CHALLENGE_QUESTIONS) return MAX_CHALLENGE_QUESTIONS;
+  return requested;
+}
+```
+
+- [ ] **Step 3: state machine test**
+
+```typescript
+// apps/api/src/services/challenge-round/state.test.ts
+import { transitionChallengeState } from './state';
+
+describe('challenge-round state transitions', () => {
+  it('undefined -> offered', () => {
+    expect(transitionChallengeState(undefined, { type: 'offer', topicId: 't1' })?.state).toBe('offered');
+  });
+  it('offered -> accepted', () => {
+    expect(transitionChallengeState({ state: 'offered', offerCount: 1 }, { type: 'accept' })?.state).toBe('accepted');
+  });
+  it('offered -> declined preserves dontAskAgain', () => {
+    const next = transitionChallengeState({ state: 'offered', offerCount: 1 }, { type: 'decline', dontAskAgain: true });
+    expect(next?.state).toBe('declined');
+    expect(next?.declinedDontAskAgain).toBe(true);
+  });
+  it('accepted -> active sets questionIndex=0 + totalQuestions capped to 3', () => {
+    const next = transitionChallengeState({ state: 'accepted', offerCount: 1 }, { type: 'start', totalQuestions: 5 });
+    expect(next?.state).toBe('active');
+    expect(next?.questionIndex).toBe(0);
+    expect(next?.totalQuestions).toBe(3);
+  });
+  it('active -> drafting when last question answered', () => {
+    const next = transitionChallengeState(
+      { state: 'active', offerCount: 1, questionIndex: 2, totalQuestions: 3 },
+      { type: 'answer_complete' },
+    );
+    expect(next?.state).toBe('drafting');
+  });
+  it('active -> active advances when more questions remain', () => {
+    const next = transitionChallengeState(
+      { state: 'active', offerCount: 1, questionIndex: 0, totalQuestions: 3 },
+      { type: 'answer_complete' },
+    );
+    expect(next?.state).toBe('active');
+    expect(next?.questionIndex).toBe(1);
+  });
+  it('rejects illegal transition (complete -> active)', () => {
+    expect(() =>
+      transitionChallengeState({ state: 'complete', offerCount: 1 }, { type: 'start', totalQuestions: 3 }),
+    ).toThrow(/illegal/i);
+  });
+  it('abort can run from any state', () => {
+    expect(transitionChallengeState({ state: 'active', offerCount: 1 }, { type: 'abort' })?.state).toBe('aborted');
+  });
+});
+```
+
+- [ ] **Step 4: state machine impl**
+
+```typescript
+// apps/api/src/services/challenge-round/state.ts
+import type { z } from 'zod';
+import { challengeRoundSessionStateSchema } from '@eduagent/schemas';
+import { enforceChallengeQuestionCap, MAX_CHALLENGE_QUESTIONS } from './caps';
+
+type State = z.infer<typeof challengeRoundSessionStateSchema>;
+
+export type StateTransition =
+  | { type: 'offer'; topicId: string }
+  | { type: 'accept' }
+  | { type: 'decline'; dontAskAgain: boolean }
+  | { type: 'start'; totalQuestions: number }
+  | { type: 'answer_complete' }
+  | { type: 'draft_ready' }
+  | { type: 'complete' }
+  | { type: 'abort' };
+
+export function transitionChallengeState(prev: State | undefined, ev: StateTransition): State | undefined {
+  switch (ev.type) {
+    case 'offer':
+      if (prev && prev.state !== 'complete' && prev.state !== 'aborted') {
+        throw new Error(`illegal: cannot offer from state=${prev.state}`);
+      }
+      return {
+        state: 'offered',
+        offerCount: (prev?.offerCount ?? 0) + 1,
+        topicId: ev.topicId,
+        declinedDontAskAgain: false,
+      };
+    case 'accept':
+      if (prev?.state !== 'offered') throw new Error('illegal: accept requires offered');
+      return { ...prev, state: 'accepted' };
+    case 'decline':
+      if (prev?.state !== 'offered') throw new Error('illegal: decline requires offered');
+      return { ...prev, state: 'declined', declinedDontAskAgain: ev.dontAskAgain };
+    case 'start':
+      if (prev?.state !== 'accepted') throw new Error('illegal: start requires accepted');
+      return {
+        ...prev,
+        state: 'active',
+        questionIndex: 0,
+        totalQuestions: enforceChallengeQuestionCap(ev.totalQuestions),
+        startedAt: new Date().toISOString(),
+      };
+    case 'answer_complete': {
+      if (prev?.state !== 'active') throw new Error('illegal: answer_complete requires active');
+      const next = (prev.questionIndex ?? 0) + 1;
+      if (next >= (prev.totalQuestions ?? MAX_CHALLENGE_QUESTIONS)) return { ...prev, state: 'drafting' };
+      return { ...prev, questionIndex: next };
+    }
+    case 'draft_ready':
+      if (prev?.state !== 'drafting') throw new Error('illegal: draft_ready requires drafting');
+      return prev;
+    case 'complete':
+      if (prev?.state !== 'drafting' && prev?.state !== 'active') {
+        throw new Error('illegal: complete from state=' + prev?.state);
+      }
+      return { ...prev, state: 'complete' };
+    case 'abort':
+      return prev ? { ...prev, state: 'aborted' } : undefined;
+  }
+}
+```
+
+- [ ] **Step 5: Run green**
+
+```bash
+cd apps/api && pnpm exec jest src/services/challenge-round/caps.test.ts src/services/challenge-round/state.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 5 — Per-answer evaluation + mastery decision
+
+**Files:**
+- Create: `apps/api/src/services/challenge-round/evaluation.ts` + `.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// apps/api/src/services/challenge-round/evaluation.test.ts
+import { decideMasteryAndReview, summarizeEvaluation } from './evaluation';
+
+const allSolid = [
+  { concept: 'a', result: 'solid' as const, evidence: 'x' },
+  { concept: 'b', result: 'solid' as const, evidence: 'y' },
+  { concept: 'c', result: 'solid' as const, evidence: 'z' },
+];
+const mixed = [
+  { concept: 'a', result: 'solid' as const, evidence: 'x' },
+  { concept: 'b', result: 'partial' as const, evidence: 'y' },
+  { concept: 'c', result: 'misconception' as const, evidence: 'z', correction: 'C' },
+];
+const allMissing = [
+  { concept: 'a', result: 'missing' as const, evidence: 'x' },
+  { concept: 'b', result: 'missing' as const, evidence: 'y' },
+];
+
+describe('decideMasteryAndReview', () => {
+  it('all solid -> verified, no review targets', () => {
+    const d = decideMasteryAndReview(allSolid);
+    expect(d.outcome).toBe('verified');
+    expect(d.markMasteryVerified).toBe(true);
+    expect(d.reviewTargets).toEqual([]);
+    expect(d.solidConcepts).toEqual(['a', 'b', 'c']);
+  });
+  it('mixed -> partial, review targets for partial+misconception, NOT mastered', () => {
+    const d = decideMasteryAndReview(mixed);
+    expect(d.outcome).toBe('partial');
+    expect(d.markMasteryVerified).toBe(false);
+    expect(d.reviewTargets.map(r => r.concept).sort()).toEqual(['b', 'c']);
+    expect(d.solidConcepts).toEqual(['a']);
+  });
+  it('all missing -> reteach, no note, no review targets', () => {
+    const d = decideMasteryAndReview(allMissing);
+    expect(d.outcome).toBe('reteach');
+    expect(d.solidConcepts).toEqual([]);
+    expect(d.markMasteryVerified).toBe(false);
+  });
+  it('any misconception blocks mastery even if majority solid', () => {
+    const mostlySolid = [
+      { concept: 'a', result: 'solid' as const, evidence: 'x' },
+      { concept: 'b', result: 'solid' as const, evidence: 'y' },
+      { concept: 'c', result: 'misconception' as const, evidence: 'z', correction: 'C' },
+    ];
+    expect(decideMasteryAndReview(mostlySolid).markMasteryVerified).toBe(false);
+  });
+});
+
+describe('summarizeEvaluation', () => {
+  it('counts per result bucket', () => {
+    expect(summarizeEvaluation(mixed)).toEqual({ solid: 1, partial: 1, missing: 0, misconception: 1, total: 3 });
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// apps/api/src/services/challenge-round/evaluation.ts
+import type { z } from 'zod';
+import { challengeRoundEvaluationItemSchema } from '@eduagent/schemas';
+
+type Eval = z.infer<typeof challengeRoundEvaluationItemSchema>;
+
+export interface ReviewTarget {
+  concept: string;
+  misconception?: string;
+  correction?: string;
+  source: 'challenge_round';
+}
+
+export interface MasteryDecision {
+  outcome: 'verified' | 'partial' | 'reteach';
+  markMasteryVerified: boolean;
+  solidConcepts: string[];
+  reviewTargets: ReviewTarget[];
+}
+
+export function decideMasteryAndReview(evals: Eval[]): MasteryDecision {
+  const solid = evals.filter(e => e.result === 'solid').map(e => e.concept);
+  const hasMisconception = evals.some(e => e.result === 'misconception');
+  const hasPartial = evals.some(e => e.result === 'partial');
+  const allMissing = evals.length > 0 && evals.every(e => e.result === 'missing');
+  const reviewTargets: ReviewTarget[] = evals
+    .filter(e => e.result === 'partial' || e.result === 'misconception')
+    .map(e => ({
+      concept: e.concept,
+      misconception: e.result === 'misconception' ? e.evidence : undefined,
+      correction: e.correction,
+      source: 'challenge_round' as const,
+    }));
+
+  if (allMissing) return { outcome: 'reteach', markMasteryVerified: false, solidConcepts: [], reviewTargets };
+  if (solid.length === evals.length && !hasMisconception && !hasPartial) {
+    return { outcome: 'verified', markMasteryVerified: true, solidConcepts: solid, reviewTargets: [] };
+  }
+  return { outcome: 'partial', markMasteryVerified: false, solidConcepts: solid, reviewTargets };
+}
+
+export function summarizeEvaluation(evals: Eval[]) {
+  return {
+    solid: evals.filter(e => e.result === 'solid').length,
+    partial: evals.filter(e => e.result === 'partial').length,
+    missing: evals.filter(e => e.result === 'missing').length,
+    misconception: evals.filter(e => e.result === 'misconception').length,
+    total: evals.length,
+  };
+}
+```
+
+- [ ] **Step 3: Run green + commit**
+
+```bash
+cd apps/api && pnpm exec jest src/services/challenge-round/evaluation.test.ts
+/commit
+```
+
+---
+
+### Task 6 — Note-draft hallucination guard
+
+**Scope (HIGH-1):** This guard catches *topic drift* (LLM produces content lexically unrelated to learner answers, e.g. switches from photosynthesis to Krebs cycle). It does NOT catch *value substitution* within shared vocabulary (e.g. swapping "chloroplast" for "mitochondria") — those tokens are in the learner's vocabulary, so overlap stays high. Value-substitution defense lives upstream: the drafting prompt is fed ONLY concepts marked `solid` by `decideMasteryAndReview`; misconception text never reaches the drafter. The `note-draft.ts` jsdoc must state this scope explicitly so future readers don't mistake the lexical guard for a correctness check.
+
+**Files:**
+- Create: `apps/api/src/services/challenge-round/note-draft.ts` + `.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// apps/api/src/services/challenge-round/note-draft.test.ts
+import { validateNoteDraft } from './note-draft';
+
+const learnerAnswers = [
+  'Photosynthesis happens in chloroplasts. The plant uses light energy to convert carbon dioxide and water into glucose.',
+  'ATP is the energy currency of the cell.',
+];
+
+describe('validateNoteDraft', () => {
+  it('accepts draft that overlaps with learner content', () => {
+    const draft = 'Photosynthesis takes place in chloroplasts. Light energy converts carbon dioxide and water into glucose. ATP is the cell energy currency.';
+    expect(validateNoteDraft(draft, learnerAnswers).ok).toBe(true);
+  });
+  it('rejects draft that invents content with low overlap', () => {
+    const draft = 'The Krebs cycle is essential for cellular respiration and produces NADH and FADH2 electron carriers.';
+    expect(validateNoteDraft(draft, learnerAnswers).ok).toBe(false);
+  });
+  it('rejects empty draft', () => {
+    expect(validateNoteDraft('', learnerAnswers).ok).toBe(false);
+  });
+  it('reports overlap ratio in result', () => {
+    const r = validateNoteDraft('Photosynthesis happens in chloroplasts. ATP is energy currency.', learnerAnswers);
+    expect(r.ok).toBe(true);
+    expect(r.overlapRatio).toBeGreaterThan(0.4);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// apps/api/src/services/challenge-round/note-draft.ts
+import { MIN_LEXICAL_OVERLAP_NOTE_DRAFT } from './caps';
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'is', 'are', 'and', 'or', 'of', 'to', 'in', 'on', 'for',
+  'with', 'as', 'by', 'at', 'it', 'its', 'this', 'that', 'be', 'was', 'were',
+  'has', 'have', 'had', 'do', 'does', 'did', 'i', 'you', 'they', 'we', 'he', 'she',
+]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(t => t.length > 2 && !STOPWORDS.has(t)),
+  );
+}
+
+export interface DraftValidationResult {
+  ok: boolean;
+  overlapRatio: number;
+  reason?: string;
+}
+
+export function validateNoteDraft(draft: string, learnerAnswers: string[]): DraftValidationResult {
+  if (!draft.trim()) return { ok: false, overlapRatio: 0, reason: 'empty' };
+  const draftTokens = tokenize(draft);
+  const learnerTokens = tokenize(learnerAnswers.join(' '));
+  if (draftTokens.size === 0) return { ok: false, overlapRatio: 0, reason: 'no_content_tokens' };
+  let overlap = 0;
+  for (const tok of draftTokens) if (learnerTokens.has(tok)) overlap += 1;
+  const ratio = overlap / draftTokens.size;
+  if (ratio < MIN_LEXICAL_OVERLAP_NOTE_DRAFT) return { ok: false, overlapRatio: ratio, reason: 'low_lexical_overlap' };
+  return { ok: true, overlapRatio: ratio };
+}
+```
+
+- [ ] **Step 3: Run green + commit**
+
+```bash
+cd apps/api && pnpm exec jest src/services/challenge-round/note-draft.test.ts
+/commit
+```
+
+- [ ] **Step 4: Calibrate `MIN_LEXICAL_OVERLAP_NOTE_DRAFT` against the eval harness (MED-3)**
+
+The 0.4 threshold in `caps.ts` is a guess. After Task 8 (Tier 2 eval harness wired), run the 6-scenario suite and emit the overlap ratio for each `note_draft`. Log a histogram. If 0.4 produces false rejects on the `draft-note-uses-learner-words` scenario, lower; if it accepts the obviously-hallucinated drafts in adversarial scenarios (add 2 such scenarios to `challenge-round.ts` for this calibration), raise.
+
+Annotate the constant in `caps.ts`:
+
+```typescript
+// MIN_LEXICAL_OVERLAP_NOTE_DRAFT: initial guess 0.4. TODO calibrate after first
+// 100 production challenge rounds — re-tune based on ratio histogram.
+export const MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4;
+```
+
+This step does NOT block the PR; it is a TODO tracked in Notion for follow-up.
+
+---
+
+### Task 7 — Prompt blocks + eval-harness scenarios
+
+**Files:**
+- Create: `apps/api/src/services/challenge-round/prompts.ts` + `.test.ts`
+- Modify: `apps/api/src/services/exchange-prompts.ts` — inject block based on state
+- Create: `apps/api/eval-llm/scenarios/challenge-round.ts`
+- Modify: `apps/api/eval-llm/scenarios/index.ts`
+
+- [ ] **Step 1: Write prompts module**
+
+```typescript
+// apps/api/src/services/challenge-round/prompts.ts
+import { MAX_CHALLENGE_QUESTIONS } from './caps';
+
+export const challengeOfferPrompt = `
+The learner has shown solid grasp of this topic across several exchanges and the system rules them ELIGIBLE for a Challenge Round.
+
+If — and only if — the learner's last message reads as confident and complete, you MAY offer a Challenge Round.
+Emit the offer by setting "signals.challenge_round_offer": true and writing a single-sentence invitation in "reply", e.g.:
+  "You've got the basics — want a challenge round where you explain this in depth, and I'll turn your answers into a note?"
+
+Never offer if the learner sounds tired, confused, or is mid-question. Do not offer twice in the same session.
+`.trim();
+
+export const challengeRoundActivePrompt = `
+You are now running a Challenge Round. The learner accepted. Ask ONE deeper question at a time that requires them to:
+- explain WHY something works (not what it is)
+- compare/contrast two related ideas
+- apply the idea to a new context
+- teach the concept back in their own words
+
+Constraints:
+- Maximum ${MAX_CHALLENGE_QUESTIONS} questions per round (do not exceed; the server will cap).
+- One question per turn. No multi-part questions.
+- Match the learner's age and energy. Do not use academic jargon.
+- After EACH learner answer, emit "signals.challenge_round_evaluation" with ONE item describing the concept assessed and result in {solid, partial, missing, misconception}.
+- When all questions are answered, set "ui_hints.challenge_round.active": false and proceed to drafting.
+
+Failure framing is banned. Never use "failed", "wrong", "incorrect", "struggle", "weak". Use "got it", "close", "let's tighten this", "not quite yet".
+`.trim();
+
+export const challengeRoundDraftingPrompt = `
+The Challenge Round is complete. Draft a learner-owned note in "ui_hints.note_draft.content".
+
+Hard rules:
+- Use ONLY content the learner actually said in their challenge answers. Do not invent facts they did not state.
+- Pull from concepts the evaluation marked "solid". Do NOT include partial or misconception concepts.
+- 2-5 short sentences. Written in the learner's voice ("I learned that...", "in my own words...").
+- Title is NOT included; the note system handles that.
+
+In "reply", briefly tell the learner what you've drafted, e.g.:
+  "Here's what you now know — based on your own words. You can save it, edit it, or skip."
+
+If no concepts were solid, do NOT emit a note_draft. Instead set "reply" to something supportive like:
+  "We're close on this — let's revisit it next time and tighten one piece together."
+`.trim();
+```
+
+- [ ] **Step 2: Snapshot test (Tier 1, no LLM call)**
+
+```typescript
+// apps/api/src/services/challenge-round/prompts.test.ts
+import { challengeOfferPrompt, challengeRoundActivePrompt, challengeRoundDraftingPrompt } from './prompts';
+
+describe('challenge-round prompts', () => {
+  it('offer prompt is stable', () => expect(challengeOfferPrompt).toMatchSnapshot());
+  it('active prompt declares cap', () => {
+    expect(challengeRoundActivePrompt).toMatch(/3 questions/);
+    expect(challengeRoundActivePrompt).toMatchSnapshot();
+  });
+  it('drafting prompt forbids invention', () => {
+    expect(challengeRoundDraftingPrompt).toMatch(/do not invent/i);
+    expect(challengeRoundDraftingPrompt).toMatchSnapshot();
+  });
+});
+```
+
+- [ ] **Step 3: Wire into exchange-prompts.ts**
+
+In `apps/api/src/services/exchange-prompts.ts`, inside `buildSystemPrompt()`, after the existing tone/guidance blocks:
+
+```typescript
+import {
+  challengeOfferPrompt,
+  challengeRoundActivePrompt,
+  challengeRoundDraftingPrompt,
+} from './challenge-round/prompts';
+
+// at the appropriate spot in buildSystemPrompt:
+const cr = sessionMetadata?.challengeRound;
+if (cr?.state === 'offered' || (!cr && challengeEligible)) {
+  prompt += '\n\n' + challengeOfferPrompt;
+} else if (cr?.state === 'active') {
+  prompt += '\n\n' + challengeRoundActivePrompt;
+} else if (cr?.state === 'drafting') {
+  prompt += '\n\n' + challengeRoundDraftingPrompt;
+}
+```
+
+`challengeEligible` is a new param passed in from `processExchange` based on `evaluateChallengeReadiness` (wired in Task 8). Add it to the `BuildSystemPromptArgs` type with a default `false`.
+
+**LOW-2 — state → prompt mapping (canonical):**
+
+| `cr.state`    | `challengeEligible` | Prompt block injected           | Notes |
+|---------------|----------------------|---------------------------------|-------|
+| undefined     | true                 | `challengeOfferPrompt`          | First-time eligible; LLM may emit `challenge_round_offer`. |
+| undefined     | false                | none                            | Normal session, no challenge content in prompt. |
+| `offered`     | (ignored)            | `challengeOfferPrompt`          | LLM sees offer is pending; do not re-offer. The offer prompt itself includes "Do not offer twice in the same session." |
+| `accepted`    | (ignored)            | `challengeRoundActivePrompt`    | Bridge from accept → first question. Server transitions to `active` on the same turn it dispatches the active prompt. |
+| `active`      | (ignored)            | `challengeRoundActivePrompt`    | Ongoing Q&A. |
+| `drafting`    | (ignored)            | `challengeRoundDraftingPrompt`  | Last evaluation + note draft. |
+| `complete`    | (ignored)            | none                            | Round done; back to default tone. |
+| `declined`    | (ignored)            | none                            | Trigger evaluator suppresses re-offer this session. |
+| `aborted`     | (ignored)            | none                            | Same as declined for prompt purposes. |
+
+Match the conditional in code to this table 1:1, including the `accepted` → `active` prompt bridge (the original conditional omitted `accepted`).
+
+- [ ] **Step 4: Eval-harness scenarios**
+
+```typescript
+// apps/api/eval-llm/scenarios/challenge-round.ts
+import type { Scenario } from '../types';
+
+export const challengeRoundScenarios: Scenario[] = [
+  {
+    name: 'offer-after-strong-answers',
+    profileAge: 14,
+    sessionType: 'learning',
+    history: [
+      { role: 'user', content: 'so photosynthesis turns sunlight into food for the plant' },
+      { role: 'assistant', content: 'Right — and that food is glucose. What does the plant need besides light?' },
+      { role: 'user', content: 'water and carbon dioxide' },
+      { role: 'assistant', content: 'Exactly. So you have light, water, CO2 -> glucose + oxygen.' },
+      { role: 'user', content: 'got it' },
+    ],
+    sessionMetadata: { challengeRound: undefined },
+    challengeEligible: true,
+    expected: {
+      signalsMustInclude: ['challenge_round_offer'],
+      replyMustNotInclude: ['fail', 'wrong'],
+    },
+  },
+  {
+    name: 'do-not-offer-when-confused',
+    profileAge: 12,
+    sessionType: 'learning',
+    history: [{ role: 'user', content: "I don't really get it" }],
+    sessionMetadata: { challengeRound: undefined },
+    challengeEligible: false,
+    expected: { signalsMustNotInclude: ['challenge_round_offer'] },
+  },
+  {
+    name: 'evaluation-mixed',
+    profileAge: 15,
+    sessionType: 'learning',
+    history: [
+      { role: 'assistant', content: 'In your own words, why does photosynthesis need CO2?' },
+      { role: 'user', content: 'because the carbon in CO2 ends up in the glucose molecule' },
+    ],
+    sessionMetadata: { challengeRound: { state: 'active', offerCount: 1, questionIndex: 1, totalQuestions: 3 } },
+    expected: { signalsMustInclude: ['challenge_round_evaluation'], evaluationResultIn: ['solid', 'partial'] },
+  },
+  {
+    name: 'draft-note-uses-learner-words',
+    profileAge: 13,
+    sessionType: 'learning',
+    history: [
+      { role: 'user', content: 'photosynthesis happens in the chloroplast and makes glucose from CO2 and water' },
+      { role: 'user', content: 'and the cell uses ATP for energy' },
+      { role: 'user', content: 'mitochondria does the opposite — breaks glucose down with oxygen' },
+    ],
+    sessionMetadata: { challengeRound: { state: 'drafting', offerCount: 1, questionIndex: 3, totalQuestions: 3 } },
+    expected: { uiHintsMustInclude: ['note_draft'], noteDraftLexicalOverlapAtLeast: 0.4 },
+  },
+  {
+    name: 'no-draft-on-all-missing',
+    profileAge: 16,
+    sessionType: 'learning',
+    history: [
+      { role: 'user', content: 'idk' },
+      { role: 'user', content: 'no idea' },
+      { role: 'user', content: 'pass' },
+    ],
+    sessionMetadata: { challengeRound: { state: 'drafting', offerCount: 1, questionIndex: 3, totalQuestions: 3 } },
+    expected: { uiHintsMustNotInclude: ['note_draft'] },
+  },
+  {
+    name: 'no-offer-in-homework',
+    profileAge: 14,
+    sessionType: 'homework',
+    history: [{ role: 'user', content: 'this answer correct?' }],
+    sessionMetadata: { challengeRound: undefined },
+    challengeEligible: false,
+    expected: { signalsMustNotInclude: ['challenge_round_offer'] },
+  },
+];
+```
+
+- [ ] **Step 5: Wire into harness index**
+
+```typescript
+// apps/api/eval-llm/scenarios/index.ts
+export { challengeRoundScenarios } from './challenge-round';
+// add to the default export array
+```
+
+- [ ] **Step 6: Run Tier 1**
+
+```bash
+pnpm eval:llm
+```
+
+Expected: new snapshots written under `apps/api/eval-llm/__snapshots__/`. Review them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+/commit
+```
+
+> Tier 2 (`pnpm eval:llm --live`) runs after Task 8 wires `challengeEligible` through `processExchange`.
+
+---
+
+### Task 8 — Wire trigger evaluator + envelope handling + `notes.source` migration into `processExchange`
+
+**Files:**
+- Modify: `packages/schemas/src/notes.ts` — add `source` field
+- Modify: `packages/database/src/schema/notes.ts` — add column (generated migration)
+- Modify: `apps/api/src/services/notes.ts` + `.test.ts` — accept/persist `source`
+- Modify: `apps/api/src/services/exchanges.ts`
+- Create/modify: `apps/api/src/services/exchanges.integration.test.ts` — end-to-end with mocked `routeAndCall` (external boundary only)
+
+- [ ] **Step 0: Confirm Task 0.0 spike is committed (CRIT-3)**
+
+Task 8 references `getSessionById` / `persistSessionMetadata`. Substitute the real names from the Task 0.0 spike decision doc before writing code. If the spike concluded a new `getSessionByIdScoped` helper needs extracting, do that as Step 0.5 here.
+
+- [ ] **Step 1: Add `source` to notes schema (MED-1 — sweep all 6 sites, not just `createNoteInputSchema`)**
+
+The original plan only mentioned `createNoteInputSchema`. The full list (verify with `Grep "noteSchema|noteResponseSchema|allNoteSchema|_noteDbRowSchema|_noteGetRowSchema" packages/schemas/src/notes.ts`):
+
+```typescript
+// packages/schemas/src/notes.ts — add the discriminator
+export const noteSourceSchema = z.enum(['user', 'challenge_round']);
+```
+
+Then add `source: noteSourceSchema.default('user')` (or `noteSourceSchema` non-optional in response shapes) to:
+- `topicNoteSchema` (line ~3-11)
+- `createNoteInputSchema` (line ~14-17)
+- `noteResponseSchema` (line ~31-39)
+- `_noteDbRowSchema` (line ~46-53)
+- `_noteGetRowSchema` (line ~66-71) — read sites; decide if surfaced or not
+- `allNoteSchema` (line ~97-110)
+
+Validate line numbers via grep before editing (HIGH-5). Any consumer reading the response shape gets `source: 'user'` by default; existing reads keep working. If `source` is NOT surfaced on a particular read (e.g. `_noteGetRowSchema`), document why in a code comment.
+
+**## Rollback for the `notes.source` migration (CRIT-7):**
+- (a) Rollback possible: yes — drop the column.
+- (b) Data lost: source attribution on existing notes. Pre-launch ≈ no notes of consequence. Post-launch: notes revert to indistinguishable provenance.
+- (c) Recovery: `ALTER TABLE topic_notes DROP COLUMN source;` then `git revert` the schema commit.
+
+- [ ] **Step 2: Add column to DB schema + migration**
+
+```typescript
+// packages/database/src/schema/notes.ts (additions inside topicNotes table definition)
+source: text('source').notNull().default('user'),
+```
+
+```bash
+pnpm run db:generate:dev
+pnpm run db:push:dev
+```
+
+- [ ] **Step 3: Update notes service + test**
+
+```typescript
+// apps/api/src/services/notes.ts (inside createNote)
+const inserted = await tx.insert(topicNotes).values({
+  // ...existing fields...
+  source: input.source ?? 'user',
+});
+```
+
+Add test case: `it('persists source = challenge_round', ...)`.
+
+- [ ] **Step 4: Wire trigger into processExchange**
+
+```typescript
+// apps/api/src/services/exchanges.ts (inside processExchange)
+import { evaluateChallengeReadiness } from './challenge-round/trigger';
+import { transitionChallengeState } from './challenge-round/state';
+import { safeSend } from './safe-non-core';
+
+// after loading session/profile/topic state, before calling routeAndCall:
+const readiness = evaluateChallengeReadiness({
+  sessionType: session.sessionType,
+  exchangeCount: session.exchangeCount,
+  retentionStatus: topicProgress?.retentionStatus ?? 'forgotten',
+  struggleStatus: topicProgress?.struggleStatus ?? 'normal',
+  recentCorrectStreak: computeRecentCorrectStreak(session),
+  quotaFractionRemaining: quota.fractionRemaining,
+  challengeRoundState: session.metadata?.challengeRound,
+  cooldownLastOfferedAt: cooldown?.lastOfferedAt ?? null,
+  cooldownLastOutcome: cooldown?.lastOutcome ?? null,
+  now: new Date(),
+});
+
+const systemPrompt = buildSystemPrompt({
+  ...existingArgs,
+  challengeEligible: readiness.eligible,
+  sessionMetadata: session.metadata,
+});
+
+// after parseEnvelope succeeds:
+const envelope = parseResult.envelope;
+
+// server-side gate: strip challenge_round_offer if not eligible or already in round
+if (envelope.signals?.challenge_round_offer) {
+  const crState = session.metadata?.challengeRound?.state;
+  const blocked = !readiness.eligible || (crState && !['complete', 'aborted'].includes(crState));
+  if (blocked) delete envelope.signals.challenge_round_offer;
+}
+
+// state transition on offer
+if (envelope.signals?.challenge_round_offer && topicProgress?.topicId) {
+  session.metadata = {
+    ...session.metadata,
+    challengeRound: transitionChallengeState(session.metadata?.challengeRound, {
+      type: 'offer',
+      topicId: topicProgress.topicId,
+    }),
+  };
+  await persistSessionMetadata(session.id, session.metadata);
+}
+
+// state transition on each evaluation in active state
+if (envelope.signals?.challenge_round_evaluation && session.metadata?.challengeRound?.state === 'active') {
+  session.metadata = {
+    ...session.metadata,
+    challengeRound: transitionChallengeState(session.metadata.challengeRound, { type: 'answer_complete' }),
+  };
+  await persistSessionMetadata(session.id, session.metadata);
+}
+
+// dispatch Inngest fan-out on completion (drafting -> with evaluation array)
+if (
+  envelope.signals?.challenge_round_evaluation &&
+  session.metadata?.challengeRound?.state === 'drafting'
+) {
+  await safeSend('challenge.round.completed', {
+    sessionId: session.id,
+    profileId: session.profileId,
+    topicId: session.metadata.challengeRound.topicId!,
+    evaluation: envelope.signals.challenge_round_evaluation,
+  });
+}
+```
+
+- [ ] **Step 5: Integration test**
+
+```typescript
+// apps/api/src/services/exchanges.integration.test.ts (append; uses real DB, external-boundary mock only)
+import { processExchange } from './exchanges';
+import { setupTestDb, seedEligibleSession } from '@/test-utils';
+
+describe('processExchange — challenge round dispatch', () => {
+  it('strips challenge_round_offer when not eligible (homework)', async () => {
+    const { session, profile } = await seedEligibleSession({ sessionType: 'homework' });
+    const spy = jest.spyOn(require('./llm/routeAndCall'), 'routeAndCall').mockResolvedValue({
+      content: JSON.stringify({ reply: '...', signals: { challenge_round_offer: true }, confidence: 'medium' }),
+    });
+    const result = await processExchange({ sessionId: session.id, profileId: profile.id, userMessage: 'is this right?' });
+    expect(result.envelope.signals?.challenge_round_offer).toBeUndefined();
+    spy.mockRestore();
+  });
+
+  it('transitions session metadata to offered when eligible and signal emitted', async () => {
+    const { session, profile } = await seedEligibleSession();
+    jest.spyOn(require('./llm/routeAndCall'), 'routeAndCall').mockResolvedValue({
+      content: JSON.stringify({ reply: 'try a challenge?', signals: { challenge_round_offer: true }, confidence: 'medium' }),
+    });
+    await processExchange({ sessionId: session.id, profileId: profile.id, userMessage: 'got it' });
+    const refetched = await getSessionById(session.id, profile.id);
+    expect(refetched.metadata.challengeRound.state).toBe('offered');
+  });
+});
+```
+
+- [ ] **Step 6: Run Tier 2 eval harness**
+
+```bash
+pnpm eval:llm --live
+```
+
+Expected: all 6 challenge-round scenarios pass schema validation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 9 — Accept/decline/abort/maybe-offer routes + Inngest fan-out + new mastery/review columns
+
+**Files:**
+- Modify: `packages/schemas/src/progress.ts` — add `masteryChallengeVerifiedAt` to `topicProgressSchema`
+- Modify: `packages/database/src/schema/topic-progress.ts` (locate exact file) — add column
+- Modify: `packages/database/src/schema/review-targets.ts` (locate exact file) — add `source` column
+- Migrations: generated for both
+- Create: `apps/api/src/routes/challenge-round.ts` + `.test.ts`
+- Create: `apps/api/src/inngest/functions/challenge-round-completed.ts` + `.test.ts` + `.integration.test.ts`
+- Modify: `apps/api/src/services/topic-completion.ts` + `.test.ts` — read the new column
+- Modify: `apps/api/src/services/snapshot-aggregation.ts` + `.test.ts` — filter in-flight rows + surface new column
+- Modify: `apps/api/src/services/retention-data.ts` + `.test.ts` — accept `source` on writes
+
+- [ ] **Step 0: Re-read the Task 0.0 spike decision doc (CRIT-1, CRIT-2)**
+
+The original plan referenced `topicProgress` and `reviewTargets` tables that do not exist. Task 0.0 picked the actual targets. Update this step to name the chosen tables/columns BEFORE editing schemas. Examples for each spike outcome:
+
+- If CRIT-1 chose `retentionCards`: add `masteryChallengeVerifiedAt` column to that table.
+- If CRIT-1 chose net-new `topic_mastery_state`: build the schema + barrel export here.
+- If CRIT-2 chose net-new `review_targets`: add Task 9.0 with full migration + integration test BEFORE Step 2 below.
+- If CRIT-2 chose `learningSessions.metadata.gaps`: extend `sessionMetadataSchema.gaps` to accept richer objects (concept, correction, source) and update Step 4 Inngest writes accordingly.
+
+- [ ] **Step 1: Extend the chosen schemas + migrations**
+
+Per spike outcome, add the columns / table. Sample for CRIT-1 path (a) (retentionCards):
+
+```typescript
+masteryChallengeVerifiedAt: timestamp('mastery_challenge_verified_at', { withTimezone: true }),
+```
+
+Generate + apply migrations:
+
+```bash
+pnpm run db:generate:dev
+pnpm run db:push:dev
+```
+
+**## Rollback for each new column / table in this task (CRIT-7):**
+- (a) Rollback possible: yes — drop columns/tables.
+- (b) Data lost: per-table — mastery-verified timestamps, review-target rows. Pre-launch ≈ none.
+- (c) Recovery: `ALTER TABLE ... DROP COLUMN ...;` or `DROP TABLE ...;` then `git revert`.
+
+- [ ] **Step 1.5: Define what `masteryChallengeVerifiedAt` *does* downstream (MED-5)**
+
+The original plan said "Modify: `topic-completion.ts` … read the new column" without specifying behavior. Decide one of:
+- (a) **Surface only.** Column is read by Parent Dashboard for the v2 challenge-verified badge; no change to existing topic-completion gates. Lowest blast radius for v1.
+- (b) **Strengthen completion.** Topic completion (current gate: `MIN_EXCHANGES_FOR_TOPIC_COMPLETION = 5`) now ALSO marks the topic as "challenge-verified" when set. Existing `completed` semantics unchanged; the badge is additive.
+- (c) **New axis on the topic-completion response.** `topicProgressSchema` gains `masteryChallengeVerifiedAt: z.string().datetime().nullable()`; clients render conditionally.
+
+Pick (c) for v1 — additive schema, no behavior coupling. Update `topic-completion.ts` to include the field in its return value; existing consumers ignore it harmlessly.
+
+- [ ] **Step 2: Add routes**
+
+```typescript
+// apps/api/src/routes/challenge-round.ts
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { transitionChallengeState } from '@/services/challenge-round/state';
+import { evaluateChallengeReadiness } from '@/services/challenge-round/trigger';
+import { recordCooldown } from '@/services/challenge-round/cooldown';
+import { getSessionById, persistSessionMetadata } from '@/services/session/session-crud';
+import { safeSend } from '@/services/safe-non-core';
+
+const maybeOfferSchema = z.object({ sessionId: z.string().uuid(), topicId: z.string().uuid() });
+const acceptSchema = z.object({ sessionId: z.string().uuid(), topicId: z.string().uuid() });
+const declineSchema = z.object({ sessionId: z.string().uuid(), dontAskAgain: z.boolean(), topicId: z.string().uuid() });
+const abortSchema = z.object({ sessionId: z.string().uuid() });
+
+export const challengeRoundRoutes = new Hono()
+  .post('/maybe-offer', async (c) => {
+    const body = maybeOfferSchema.parse(await c.req.json());
+    const profileId = c.get('profileId');
+    const session = await getSessionById(body.sessionId, profileId);
+
+    // HIGH-2: pre-flight state check to avoid double-offer race with server-initiated path
+    const currentState = session.metadata?.challengeRound?.state;
+    if (currentState && ['offered', 'accepted', 'active', 'drafting'].includes(currentState)) {
+      return c.json({ offered: true, alreadyOffered: true });
+    }
+
+    const readinessInput = await loadReadinessInput({ session, profileId, topicId: body.topicId });
+    const readiness = evaluateChallengeReadiness(readinessInput);
+    if (!readiness.eligible) return c.json({ offered: false, reason: readiness.reason });
+    session.metadata = {
+      ...session.metadata,
+      challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'offer', topicId: body.topicId }),
+    };
+    await persistSessionMetadata(session.id, session.metadata);
+    return c.json({ offered: true });
+  })
+  .post('/accept', async (c) => {
+    const body = acceptSchema.parse(await c.req.json());
+    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    session.metadata = {
+      ...session.metadata,
+      challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'accept' }),
+    };
+    await persistSessionMetadata(session.id, session.metadata);
+    return c.json({ ok: true });
+  })
+  .post('/decline', async (c) => {
+    const body = declineSchema.parse(await c.req.json());
+    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    session.metadata = {
+      ...session.metadata,
+      challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'decline', dontAskAgain: body.dontAskAgain }),
+    };
+    await persistSessionMetadata(session.id, session.metadata);
+    await recordCooldown({ profileId: c.get('profileId'), topicId: body.topicId, outcome: 0 });
+    await safeSend('challenge.round.declined', { sessionId: body.sessionId, topicId: body.topicId });
+    return c.json({ ok: true });
+  })
+  .post('/abort', async (c) => {
+    const body = abortSchema.parse(await c.req.json());
+    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    session.metadata = {
+      ...session.metadata,
+      challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'abort' }),
+    };
+    await persistSessionMetadata(session.id, session.metadata);
+    return c.json({ ok: true });
+  });
+```
+
+Helper `loadReadinessInput` queries the same data `processExchange` uses (session, topic progress, quota, cooldown). Extract to `apps/api/src/services/challenge-round/readiness-input.ts` if it's used from two callers; otherwise inline.
+
+- [ ] **Step 3: Cooldown service**
+
+```typescript
+// apps/api/src/services/challenge-round/cooldown.ts
+import { db } from '@/db';
+import { challengeRoundCooldowns } from '@eduagent/database';
+
+export async function recordCooldown(input: { profileId: string; topicId: string; outcome: number }): Promise<void> {
+  await db
+    .insert(challengeRoundCooldowns)
+    .values({ profileId: input.profileId, topicId: input.topicId, lastOutcome: input.outcome })
+    .onConflictDoUpdate({
+      target: [challengeRoundCooldowns.profileId, challengeRoundCooldowns.topicId],
+      set: { lastOfferedAt: new Date(), lastOutcome: input.outcome },
+    });
+}
+```
+
+- [ ] **Step 4: Inngest function**
+
+```typescript
+// apps/api/src/inngest/functions/challenge-round-completed.ts
+import { inngest } from '../client';
+import { decideMasteryAndReview } from '@/services/challenge-round/evaluation';
+import { upsertReviewTargets } from '@/services/retention-data';
+import { markMasteryChallengeVerified } from '@/services/topic-completion';
+import { recordCooldown } from '@/services/challenge-round/cooldown';
+
+export const challengeRoundCompleted = inngest.createFunction(
+  { id: 'challenge-round-completed', name: 'Challenge Round Completed' },
+  { event: 'challenge.round.completed' },
+  async ({ event, step }) => {
+    const { sessionId, profileId, topicId, evaluation } = event.data;
+    const decision = decideMasteryAndReview(evaluation);
+    await step.run('persist-review-targets', () => upsertReviewTargets(profileId, topicId, decision.reviewTargets));
+    if (decision.markMasteryVerified) {
+      await step.run('mark-mastery-verified', () => markMasteryChallengeVerified(profileId, topicId, new Date()));
+    }
+    await step.run('record-cooldown', () =>
+      recordCooldown({
+        profileId,
+        topicId,
+        outcome: decision.markMasteryVerified ? 2 : decision.outcome === 'reteach' ? 3 : 1,
+      }),
+    );
+    return { outcome: decision.outcome, solidConcepts: decision.solidConcepts.length };
+  },
+);
+```
+
+- [ ] **Step 5: Register the Inngest function (MED-4 — cite the actual index file, don't assume)**
+
+```
+Grep "createFunction" apps/api/src/inngest/functions/index.ts
+```
+
+Confirm the file exists and the registration pattern. Add `challengeRoundCompleted` to the exported array. Also verify the event names `challenge.round.completed` and `challenge.round.declined` do not collide with existing events:
+
+```
+Grep "challenge\\.round" apps/api/src
+```
+
+Expected: only the call sites added in this PR. If anything else exists (unlikely, but worth checking), rename to `challenge.round.v1.completed` etc.
+
+- [ ] **Step 6: Tests**
+
+Write tests for:
+- Routes: accept/decline/maybe-offer/abort all transition session metadata correctly, decline persists cooldown.
+- Inngest function: verified outcome → mastery flag set, no review targets; partial outcome → review targets, no mastery flag; reteach outcome → cooldown=3, no review targets.
+
+```bash
+pnpm exec nx run api:test
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 10 — Mobile components + `useChallengeRound` hook + session-streaming integration + chip wiring
+
+**Files:**
+- Create: `apps/mobile/src/hooks/use-challenge-round.ts` + `.test.tsx`
+- Create: `apps/mobile/src/components/session/ChallengeOfferCard.tsx` + `.test.tsx`
+- Create: `apps/mobile/src/components/session/ChallengeRoundBanner.tsx` + `.test.tsx`
+- Create: `apps/mobile/src/components/session/DraftedNoteReview.tsx` + `.test.tsx`
+- Modify: `apps/mobile/src/components/session/use-session-streaming.ts` + `.test.tsx`
+- Modify: `apps/mobile/src/app/(app)/session/index.tsx`
+- Modify: `apps/mobile/src/lib/strip-envelope.ts` + `.test.ts`
+- Modify: `apps/mobile/src/components/session/SessionAccessories.tsx` + `.test.tsx` — chip wiring
+- Modify: `apps/mobile/src/i18n/locales/{en,de,es,ja,nb,pl,pt}.json`
+
+- [ ] **Step 1: Hook + test**
+
+```typescript
+// apps/mobile/src/hooks/use-challenge-round.ts
+import { useMutation } from '@tanstack/react-query';
+import { useCreateNote } from './use-notes';
+import { useApiClient } from '../lib/api-client';
+
+export function useChallengeRound(opts: {
+  sessionId: string;
+  topicId: string;
+  subjectId: string;
+  bookId: string;
+}) {
+  const api = useApiClient();
+  const createNote = useCreateNote(opts.subjectId, opts.bookId);
+  const maybeOffer = useMutation({
+    mutationFn: () => api.post<{ offered: boolean; reason?: string }>('/challenge-round/maybe-offer', { sessionId: opts.sessionId, topicId: opts.topicId }),
+  });
+  const accept = useMutation({
+    mutationFn: () => api.post('/challenge-round/accept', { sessionId: opts.sessionId, topicId: opts.topicId }),
+  });
+  const decline = useMutation({
+    mutationFn: (dontAskAgain: boolean) => api.post('/challenge-round/decline', { sessionId: opts.sessionId, topicId: opts.topicId, dontAskAgain }),
+  });
+  const abort = useMutation({
+    mutationFn: () => api.post('/challenge-round/abort', { sessionId: opts.sessionId }),
+  });
+  return {
+    maybeOffer: () => maybeOffer.mutateAsync(),
+    accept: () => accept.mutateAsync(),
+    decline: (dontAskAgain = false) => decline.mutateAsync(dontAskAgain),
+    abort: () => abort.mutateAsync(),
+    saveNote: (content: string) => createNote.mutateAsync({ topicId: opts.topicId, sessionId: opts.sessionId, content, source: 'challenge_round' }),
+    skipNote: () => Promise.resolve(),
+  };
+}
+```
+
+Hook test asserts: action functions exist, accept calls the right endpoint, saveNote includes `source: 'challenge_round'`.
+
+- [ ] **Step 2: ChallengeOfferCard**
+
+```tsx
+// apps/mobile/src/components/session/ChallengeOfferCard.tsx
+import { Pressable, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+export function ChallengeOfferCard({
+  pitch, onAccept, onDecline, onDontAskAgain,
+}: {
+  pitch: string;
+  onAccept: () => void;
+  onDecline: () => void;
+  onDontAskAgain: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <View className="rounded-2xl bg-surface-elevated p-4 border border-accent-soft" testID="challenge-offer-card">
+      <Text className="text-text-primary text-base font-semibold mb-1">{t('session.challenge.offerTitle')}</Text>
+      <Text className="text-text-secondary mb-3">{pitch}</Text>
+      <View className="flex-row gap-2 flex-wrap">
+        <Pressable onPress={onAccept} className="bg-accent rounded-xl px-4 py-2" testID="challenge-offer-accept">
+          <Text className="text-on-accent font-medium">{t('session.challenge.tryIt')}</Text>
+        </Pressable>
+        <Pressable onPress={onDecline} className="bg-surface rounded-xl px-4 py-2" testID="challenge-offer-decline">
+          <Text className="text-text-primary">{t('session.challenge.notNow')}</Text>
+        </Pressable>
+        <Pressable onPress={onDontAskAgain} className="rounded-xl px-4 py-2" testID="challenge-offer-dont-ask">
+          <Text className="text-text-muted">{t('session.challenge.dontAskAgain')}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 3: ChallengeRoundBanner**
+
+```tsx
+// apps/mobile/src/components/session/ChallengeRoundBanner.tsx
+import { Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+export function ChallengeRoundBanner({ questionIndex, totalQuestions }: { questionIndex: number; totalQuestions: number }) {
+  const { t } = useTranslation();
+  return (
+    <View className="px-4 py-2 bg-accent-soft border-b border-accent" testID="challenge-round-banner">
+      <Text className="text-on-accent-soft text-sm">
+        {t('session.challenge.banner.question', { index: questionIndex + 1, total: totalQuestions })}
+      </Text>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 4: DraftedNoteReview**
+
+```tsx
+// apps/mobile/src/components/session/DraftedNoteReview.tsx
+import { useState } from 'react';
+import { Pressable, Text, TextInput, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+export function DraftedNoteReview({
+  initialContent, onSave, onSkip,
+}: {
+  initialContent: string;
+  onSave: (content: string) => Promise<unknown>;
+  onSkip: () => void;
+}) {
+  const { t } = useTranslation();
+  const [content, setContent] = useState(initialContent);
+  const [editing, setEditing] = useState(false);
+  return (
+    <View className="rounded-2xl bg-surface-elevated p-4 border border-accent-soft" testID="drafted-note-review">
+      <Text className="text-text-primary text-base font-semibold mb-2">{t('session.challenge.draft.title')}</Text>
+      {editing ? (
+        <TextInput multiline value={content} onChangeText={setContent} className="text-text-primary min-h-[120px] rounded-xl bg-surface p-3" testID="drafted-note-input" />
+      ) : (
+        <Text className="text-text-primary" testID="drafted-note-preview">{content}</Text>
+      )}
+      <View className="flex-row gap-2 mt-3 flex-wrap">
+        <Pressable onPress={() => onSave(content)} className="bg-accent rounded-xl px-4 py-2" testID="drafted-note-save">
+          <Text className="text-on-accent font-medium">{t('session.challenge.draft.save')}</Text>
+        </Pressable>
+        <Pressable onPress={() => setEditing(true)} className="bg-surface rounded-xl px-4 py-2" testID="drafted-note-edit">
+          <Text className="text-text-primary">{t('session.challenge.draft.edit')}</Text>
+        </Pressable>
+        <Pressable onPress={onSkip} className="rounded-xl px-4 py-2" testID="drafted-note-skip">
+          <Text className="text-text-muted">{t('session.challenge.draft.skip')}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 5.0: Verify the envelope is delivered as a single end-of-stream message (HIGH-3)**
+
+```
+Read apps/mobile/src/components/session/use-session-streaming.ts
+```
+
+Confirm whether `parseEnvelope` runs on the FULL response (single end-of-stream message) or on STREAMING tokens. The current API pipeline (`apps/api/src/services/llm/envelope.ts:165-182`) parses post-stream — meaning the mobile gets a fully-formed envelope, after the server-side gate has had a chance to strip ineligible signals. Document this assumption inline in `use-session-streaming.ts`:
+
+```typescript
+// HIGH-3: relies on parseEnvelope running post-stream. If the streaming protocol ever
+// switches to per-token incremental envelopes, the server-side suppression of
+// challenge_round_offer (in processExchange) must move into the system prompt so the LLM
+// never emits the signal in the first place.
+```
+
+If the verification reveals that streaming IS incremental (or might become so), bail out of this approach and replace it with prompt-level suppression: when `evaluateChallengeReadiness` returns `{eligible: false}`, do NOT inject `challengeOfferPrompt`. The LLM never knows to emit the signal. This is the safer architecture regardless; consider switching now.
+
+- [ ] **Step 5: use-session-streaming.ts extension**
+
+Locate the existing `ui_hints.fluency_drill` / `note_prompt` detection in `apps/mobile/src/components/session/use-session-streaming.ts`. Add:
+
+```typescript
+if (envelope.signals?.challenge_round_offer) setChallengeOfferPitch(envelope.reply);
+if (envelope.ui_hints?.challenge_round) setChallengeRoundActive(envelope.ui_hints.challenge_round);
+if (envelope.ui_hints?.note_draft) setNoteDraft(envelope.ui_hints.note_draft);
+```
+
+Expose `challengeOfferPitch`, `challengeRoundActive`, `noteDraft` from the hook return.
+
+- [ ] **Step 6: Strip new ui_hints from learner reply**
+
+```typescript
+// apps/mobile/src/lib/strip-envelope.ts — extend the existing UI_HINT_KEYS_TO_STRIP constant
+const UI_HINT_KEYS_TO_STRIP = ['note_prompt', 'fluency_drill', 'challenge_round', 'note_draft'];
+```
+
+- [ ] **Step 7: Render in session/index.tsx**
+
+Above the chat scroll area or as an inline message slot, conditionally render the three new components based on session-streaming state. Wire to `useChallengeRound` hook actions.
+
+- [ ] **Step 8: Wire "Too easy" chip through `maybeOffer`**
+
+In `apps/mobile/src/components/session/SessionAccessories.tsx` (the chip strip), locate the `too_easy` chip handler. Today it directly dispatches the `too_easy` system prompt via the message-send pipeline. Change it to:
+
+```typescript
+const handleTooEasy = async () => {
+  const result = await challengeRound.maybeOffer();
+  if (result.offered) {
+    // Server flipped state to 'offered'. The session-streaming pipeline will pick up the offer on
+    // the next assistant message via challengeOfferPitch — but we want immediate UX feedback so
+    // render the offer card based on the maybe-offer round-trip too.
+    setChallengeOfferPitchLocal(t('session.challenge.offerBody'));
+    return;
+  }
+  // Fall through to today's behavior — dispatch the too_easy system prompt
+  dispatchQuickChip('too_easy');
+};
+```
+
+Update the chip's tests to cover both branches.
+
+- [ ] **Step 8.5: Filter the "Too easy" chip when a challenge round is in flight (HIGH-4)**
+
+`apps/mobile/src/components/session/session-types.ts:271-282` `getContextualQuickChips` returns `['know_this', 'explain_differently', 'too_easy', 'example']` based only on the last assistant message — it's unaware of `sessionMetadata.challengeRound.state`.
+
+Extend the function signature to accept `challengeRoundState?: ChallengeRoundState` and filter:
+
+```typescript
+if (challengeRoundState?.state &&
+    ['offered', 'accepted', 'active', 'drafting'].includes(challengeRoundState.state)) {
+  return chips.filter(c => c !== 'too_easy');
+}
+```
+
+Add unit test: `it('filters too_easy when challenge round is active', ...)`. Update every caller of `getContextualQuickChips` to pass the state.
+
+- [ ] **Step 9: i18n keys (en.json, then copy-as-fallback to other locales)**
+
+Add to `apps/mobile/src/i18n/locales/en.json` under `session.challenge`:
+
+```json
+"session": {
+  "challenge": {
+    "offerTitle": "Up for a challenge round?",
+    "offerBody": "You've got the basics — want to try explaining it in your own words and turn that into a note?",
+    "tryIt": "Try it",
+    "notNow": "Not now",
+    "dontAskAgain": "Don't ask again",
+    "banner": {
+      "active": "Challenge round in progress",
+      "question": "Question {{index}} of {{total}}"
+    },
+    "draft": {
+      "title": "Here's what you know now",
+      "save": "Save note",
+      "edit": "Edit first",
+      "skip": "Skip"
+    },
+    "partial": {
+      "body": "You've got the strong pieces. I'll save those — we'll tighten the fuzzy bit next time."
+    },
+    "allMissing": {
+      "body": "Let's revisit this together first."
+    }
+  }
+}
+```
+
+Copy the same `session.challenge.*` block into `de.json`, `es.json`, `ja.json`, `nb.json`, `pl.json`, `pt.json` (English fallback; translation in a follow-up localization pass).
+
+- [ ] **Step 10: Run mobile tests + typecheck**
+
+```bash
+pnpm exec nx lint mobile
+cd apps/mobile && pnpm exec tsc --noEmit
+cd apps/mobile && pnpm exec jest --findRelatedTests src/components/session/ChallengeOfferCard.tsx src/components/session/ChallengeRoundBanner.tsx src/components/session/DraftedNoteReview.tsx src/hooks/use-challenge-round.ts src/lib/strip-envelope.ts src/components/session/SessionAccessories.tsx --no-coverage
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 11 — End-to-end integration test
+
+**Files:**
+- Create: `tests/integration/challenge-round.integration.test.ts`
+
+- [ ] **Step 1: Write three end-to-end cases**
+
+```typescript
+// tests/integration/challenge-round.integration.test.ts
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { createApp } from '@eduagent/api';
+import { setupTestDb, seedEligibleSession, mockRouteAndCall, runInngestEvent } from '../utils/db-helpers';
+
+describe('challenge round end-to-end', () => {
+  it('all-solid: offer -> accept -> 3 answers -> drafted note saved -> mastery verified', async () => {
+    const { db, app, profile, topic, session } = await seedEligibleSession();
+
+    // Step 1: send a message; LLM responds with offer
+    mockRouteAndCall({ reply: 'want a challenge round?', signals: { challenge_round_offer: true }, confidence: 'medium' });
+    let r = await app.request(`/sessions/${session.id}/exchanges`, { method: 'POST', body: JSON.stringify({ message: 'got it' }) });
+    expect(r.status).toBe(200);
+    let refetched = await db.query.sessions.findFirst({ where: eq(sessions.id, session.id) });
+    expect(refetched!.metadata.challengeRound.state).toBe('offered');
+
+    // Step 2: accept
+    r = await app.request('/challenge-round/accept', { method: 'POST', body: JSON.stringify({ sessionId: session.id, topicId: topic.id }) });
+    expect(r.status).toBe(200);
+
+    // Step 3: three answers, all solid
+    for (let i = 0; i < 3; i++) {
+      const isLast = i === 2;
+      mockRouteAndCall({
+        reply: isLast ? 'great' : 'next question',
+        signals: { challenge_round_evaluation: [{ concept: `c${i}`, result: 'solid', evidence: 'said it correctly' }] },
+        ui_hints: isLast
+          ? { note_draft: { content: 'I learned that X, Y, and Z based on what I said.', source_concepts: ['c0', 'c1', 'c2'] } }
+          : { challenge_round: { active: true, question_index: i + 1, total_questions: 3 } },
+        confidence: 'high',
+      });
+      await app.request(`/sessions/${session.id}/exchanges`, { method: 'POST', body: JSON.stringify({ message: `answer ${i}` }) });
+    }
+
+    // Step 4: drafted-note save (mobile would call POST notes)
+    const saveRes = await app.request(`/subjects/${topic.subjectId}/topics/${topic.id}/notes`, {
+      method: 'POST',
+      body: JSON.stringify({ content: 'I learned that X, Y, and Z based on what I said.', sessionId: session.id, source: 'challenge_round' }),
+    });
+    expect(saveRes.status).toBe(200);
+
+    // Step 5: drive inngest handler
+    await runInngestEvent('challenge.round.completed', {
+      sessionId: session.id,
+      profileId: profile.id,
+      topicId: topic.id,
+      evaluation: [
+        { concept: 'c0', result: 'solid', evidence: 'x' },
+        { concept: 'c1', result: 'solid', evidence: 'y' },
+        { concept: 'c2', result: 'solid', evidence: 'z' },
+      ],
+    });
+
+    // Step 6: assertions
+    const tp = await db.query.topicProgress.findFirst({ where: and(eq(topicProgress.profileId, profile.id), eq(topicProgress.topicId, topic.id)) });
+    expect(tp?.masteryChallengeVerifiedAt).toBeTruthy();
+    const notes = await db.query.topicNotes.findMany({ where: and(eq(topicNotes.profileId, profile.id), eq(topicNotes.topicId, topic.id)) });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].source).toBe('challenge_round');
+    expect(notes[0].sessionId).toBe(session.id);
+    const rts = await db.query.reviewTargets.findMany({ where: and(eq(reviewTargets.profileId, profile.id), eq(reviewTargets.source, 'challenge_round')) });
+    expect(rts).toHaveLength(0);
+  });
+
+  it('partial: 2 solid + 1 misconception saves only the 2 concepts, persists 1 review target, no mastery flip', async () => {
+    const { db, profile, topic } = await seedEligibleSession();
+    await runInngestEvent('challenge.round.completed', {
+      sessionId: 'sid', profileId: profile.id, topicId: topic.id,
+      evaluation: [
+        { concept: 'c0', result: 'solid', evidence: 'x' },
+        { concept: 'c1', result: 'solid', evidence: 'y' },
+        { concept: 'c2', result: 'misconception', evidence: 'said wrong thing', correction: 'right thing' },
+      ],
+    });
+    const tp = await db.query.topicProgress.findFirst({ where: and(eq(topicProgress.profileId, profile.id), eq(topicProgress.topicId, topic.id)) });
+    expect(tp?.masteryChallengeVerifiedAt).toBeNull();
+    const rts = await db.query.reviewTargets.findMany({ where: and(eq(reviewTargets.profileId, profile.id), eq(reviewTargets.topicId, topic.id), eq(reviewTargets.source, 'challenge_round')) });
+    expect(rts).toHaveLength(1);
+    expect(rts[0].correction).toBe('right thing');
+  });
+
+  it('homework session never offers, even if LLM emits the signal', async () => {
+    const { app, session, profile } = await seedEligibleSession({ sessionType: 'homework' });
+    mockRouteAndCall({ reply: 'yes', signals: { challenge_round_offer: true }, confidence: 'high' });
+    const r = await app.request(`/sessions/${session.id}/exchanges`, { method: 'POST', body: JSON.stringify({ message: 'is this right?' }) });
+    const body = await r.json();
+    expect(body.envelope.signals?.challenge_round_offer).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm exec jest tests/integration/challenge-round.integration.test.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 12 — CLAUDE.md + project_context.md updates
+
+**Files:**
+- Modify: `CLAUDE.md` — append one bullet under engineering rules
+- Modify: `docs/project_context.md` — short paragraph
+
+- [ ] **Step 1: Append to CLAUDE.md "Non-Negotiable Engineering Rules"**
+
+```markdown
+- Challenge Round mastery decisions are server-owned and conservative. The LLM proposes per-concept evaluations via `signals.challenge_round_evaluation`; the server runs `decideMasteryAndReview()` and sets `masteryChallengeVerifiedAt` only when EVERY concept evaluates `solid`. Any `partial`, `missing`, or `misconception` blocks mastery and routes the weak concepts to review targets with `source: 'challenge_round'`. Notes drafted from Challenge Rounds must pass the lexical-overlap hallucination guard in `services/challenge-round/note-draft.ts` before being shown to the learner. The Challenge mode toggle (`learningMode: 'serious' | 'casual'`) was removed; today's `casual` is the single default tone and rigor is now expressed per-Challenge-Round rather than globally.
+```
+
+- [ ] **Step 2: Add a short section to `docs/project_context.md`**
+
+Document: trigger evaluator location, prompt module, envelope signal names, mobile component names, the "Too easy chip → maybe-offer route" path, the conservative-mastery rule.
+
+- [ ] **Step 3: Commit**
+
+```bash
+/commit
+```
+
+---
+
+## Final Validation
+
+After Task 12, run the full validation matrix before declaring the feature complete:
+
+- [ ] `pnpm exec nx run-many -t lint` — green
+- [ ] `pnpm exec nx run-many -t typecheck` — green
+- [ ] `pnpm exec nx run-many -t test` — green
+- [ ] `pnpm eval:llm --live` — all 6 challenge-round scenarios pass schema validation
+- [ ] `pnpm exec jest tests/integration/challenge-round.integration.test.ts` — green
+- [ ] **Manual smoke 1 — sunset:** Launch the app on emulator. Open a session. Confirm: no Explorer/Challenge mode header button; no Learning Mode section in More; tone is consistent.
+- [ ] **Manual smoke 2 — system-initiated CR:** Complete a learning session with 6+ exchanges, strong answers, in `strong` retention. Accept the offer. Answer 3 challenge questions correctly. Save the drafted note. Verify it appears under the topic in Library with `source: 'challenge_round'`. Verify mastery shows challenge-verified.
+- [ ] **Manual smoke 3 — Too easy chip path:** In an eligible session, tap "Too easy". Verify the offer card appears immediately. Accept. In an ineligible session (e.g., exchange 3 of 5), tap "Too easy". Verify the chip behaves as before (LLM nudges harder).
+- [ ] **Manual smoke 4 — partial outcome:** Run a Challenge Round with 1 solid + 1 misconception. Verify saved note contains only the solid concept text; verify a review target was persisted with the correction.
+- [ ] **Manual smoke 5 — decline cooldown (MED-6 — impractical at 24h, manually expire):** Decline an offer with "Don't ask again". Finish the session. In Postgres (`db:studio:dev`), manually UPDATE the `challenge_round_cooldowns` row for that profile+topic, setting `last_offered_at = NOW() - INTERVAL '23 hours'`. Start a new session on the same topic with the same readiness conditions — verify no offer appears. Then UPDATE `last_offered_at = NOW() - INTERVAL '25 hours'` and verify the offer DOES appear. Alternatively, gate `CHALLENGE_OFFER_COOLDOWN_HOURS` on `process.env.NODE_ENV === 'test' ? 0.01 : 24` for smokes — but the manual UPDATE is simpler and doesn't change production code.
+- [ ] Sentry: zero errors tagged `challenge.envelope_parse` or `challenge.state_illegal` in smoke runs.
+
+---
+
+## Out of Scope (Explicitly)
+
+These are valid concerns that this plan does NOT address. Each is a tracked follow-up, not part of this PR.
+
+- **Offline queueing of note saves.** v1 requires online. In-component draft state survives backgrounding but not app kill.
+- **Voice-only flow for challenge answers.** Reuses existing voice input; no special handling.
+- **Parent dashboard badge for challenge-verified mastery.** Schema lands; UI badge is v2.
+- **Multi-round per session.** One round per session in v1; cooldown is per topic per 24h.
+- **Rewards / streaks / badges.** Intentionally excluded — the reward is "I see what I now know."
+- **Ask-anything / freeform Challenge Round.** Requires a topic anchor for the note; deferred.
+- **Homework-mode Challenge Round.** Homework is explain+verify, not Socratic. Permanently excluded.
+- **Parent-challenges-child.** Deferred.
+- **Rename `learning_modes` DB table** to something matching its post-sunset contents (`user_preferences` or `profile_pace_settings`). Worthwhile cleanup; separate small PR.
+- **Repurpose the freed header button slot.** No replacement in this PR.
+- **Translated copy for `session.challenge.*` keys** in non-en locales. Stub with English fallback in v1; localization pass follows.

--- a/docs/plans/2026-05-18-challenge-round-into-note.md
+++ b/docs/plans/2026-05-18-challenge-round-into-note.md
@@ -38,7 +38,7 @@ This plan was adversarially reviewed before execution. The following findings sh
 - **MED-3** — `MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4` is a guess. Resolved by Task 6 calibration step + TODO marker.
 - **MED-4** — Inngest event-name registration must be cited, not assumed. Resolved in Task 9 Step 5.
 - **MED-5** — `topic-completion.ts` contract for the new column is not specified. Resolved in Task 9 Step 1.5.
-- **MED-6** — Decline-cooldown smoke is impractical with a hardcoded 24h. Resolved in Final Validation Smoke 5.
+- **MED-6** — Decline-cooldown smoke is impractical with a hardcoded 24h. Resolved in Final Validation Smoke 6.
 - **MED-7** — `verifyXp` / `verifyPendingXp` left-in-place fate clarified in Task 0.2 Step 7.
 - **LOW-1** — Rollback sections use the prescribed format even pre-launch (Task 0.1).
 - **LOW-2** — State→prompt mapping table added in Task 7 Step 3.
@@ -48,6 +48,9 @@ This plan was adversarially reviewed before execution. The following findings sh
 - **HIGH-8** — "Server-owned mastery" was overstated. The server owns policy and caps, but correctness still depends on LLM evaluation quality. Resolved by Task 5/7/11: add adversarial misconception false-positive tests and phrase the invariant as "server-owned conservative gating over structured LLM evidence."
 - **MED-8** — `retentionStatus === 'strong'` only would make Challenge Rounds too rare for learners who are doing well in a first session. Resolved by Task 3: permit a current-session high-confidence path (`new|strong` retention with longer correct streak and no struggle).
 - **MED-9** — Mid-round app close/session timeout was promised but not given an implementation task. Resolved by Task 8.5: persist pending draft recovery state and add an explicit integration test.
+- **CRIT-9** — Empty evaluation arrays must never mark mastery. The initial decision sketch treated `solid.length === evals.length` as verified, which is true for `0 === 0`. Resolved in Task 5 with an explicit empty-evaluation test and `outcome: 'invalid'`.
+- **HIGH-9** — Tests were scattered through tasks but there was no acceptance-level coverage contract. Resolved by adding "Test Coverage Contract" below; implementation is not complete unless every row has a passing test or an explicit follow-up ID.
+- **MED-10** — The lexical-overlap guard used ASCII tokenization, which rejects accented Latin and non-spaced scripts unfairly. Resolved in Task 6: use Unicode-aware tokenization with a character n-gram fallback and add accented Latin + Japanese regression tests.
 
 ---
 
@@ -182,6 +185,32 @@ This plan was adversarially reviewed before execution. The following findings sh
 
 ---
 
+### Test Coverage Contract
+
+This feature is not complete until every row below is covered by a passing test or has an explicit tracked follow-up ID approved before implementation continues.
+
+| Layer | Required coverage | Test location |
+|---|---|---|
+| Sunset DB/schema | `learningModes.mode`, `consecutiveSummarySkips`, learning-mode API schemas/routes/hooks/UI/i18n are removed; XP writer always writes immediate `verified` while existing `pending|decayed` reads still work. | Task 0.1-0.6 unit + integration tests |
+| Envelope schema | `challenge_round_offer`, per-concept evaluation with `answerEventId`/`learnerQuote`, `challenge_round`, and `note_draft` with source answer event ids parse and reject malformed shapes. | `packages/schemas/src/llm-envelope.test.ts` |
+| Session metadata schema | `challengeRound` accepts valid states, defaults optional fields safely, accumulates evaluations, accepts pending draft recovery state, rejects invalid states/evaluation shapes. | `packages/schemas/src/sessions.test.ts` |
+| Trigger evaluator | Hard-gates homework/freeform/practice/quiz, struggling states, low quota, cooldown, duplicate/in-flight states; allows strong retention path and current-session-new-topic path. | `apps/api/src/services/challenge-round/trigger.test.ts` |
+| State machine | Valid transitions, illegal transitions, one-round cap, question cap, evaluation accumulation, abort from any active state, no duplicate offer race. | `apps/api/src/services/challenge-round/state.test.ts` |
+| Mastery decision | all solid → verified; mixed → no mastery + review targets + solid quotes only; all missing → reteach; empty eval → invalid/no mastery; any misconception blocks mastery. | `apps/api/src/services/challenge-round/evaluation.test.ts` |
+| Note draft guard | Accepts solid learner quotes, rejects hallucinated/low-overlap drafts, rejects drafts that overlap only with non-solid quotes, handles accented Latin and non-spaced scripts, preserves short drafts, never validates empty. | `apps/api/src/services/challenge-round/note-draft.test.ts` |
+| Prompt/eval harness | Offer only when eligible/confident; no offer when confused/homework; active round emits structured eval; known misconception must not be solid; draft uses learner words; no draft on all missing. | `apps/api/eval-llm/scenarios/challenge-round.ts`, `pnpm eval:llm`, `pnpm eval:llm --live` |
+| `processExchange` integration | Strips ineligible offer signals, transitions offered/active/drafting, persists accumulated evaluations, sends completed event once, handles malformed envelopes without UI advancement. | `apps/api/src/services/exchanges.integration.test.ts` |
+| Routes | `maybe-offer`, `accept`, `decline`, `abort` are profile-scoped, reject cross-profile/cross-topic mismatch, persist cooldown, handle already-offered race as 200 no-op, reject invalid state transitions cleanly. | `apps/api/src/routes/challenge-round.test.ts` |
+| Inngest fan-out | Verified sets mastery flag only on complete all-solid evidence; partial writes review targets and no mastery; reteach/no-solid writes no note and no mastery; empty eval invalid path is observable. | `apps/api/src/inngest/functions/challenge-round-completed.test.ts` + integration |
+| Notes provenance | `source: 'challenge_round'` is accepted, stored, returned, defaults existing/user-created notes to `user`, and coexists with exact-session dedupe. | `packages/schemas/src/notes.test.ts`, `apps/api/src/services/notes.test.ts`, route tests |
+| Mobile hook/UI | Hook calls correct endpoints, saves note with source/session/topic, offer card buttons call the right actions, draft review preserves edit state and surfaces save errors/retry. | Mobile Jest tests in Task 10 |
+| Mobile streaming | New signals/ui_hints are detected only after valid envelope parse, stripped from visible text, reset/cleared after save/skip, and do not flash when server strips ineligible offers. | `use-session-streaming.test.tsx`, `strip-envelope.test.ts` |
+| Quick chip | `Too easy` eligible path shows offer; ineligible path preserves old prompt; chip hidden/disabled during offered/accepted/active/drafting; rapid taps dedupe. | `SessionAccessories.test.tsx`, `session-types.test.ts` |
+| End-to-end | all-solid happy path; partial note path; homework never offers; mid-round recovery; decline cooldown; duplicate offer race. | `tests/integration/challenge-round.integration.test.ts` |
+| Manual smoke | Sunset, system offer, `Too easy`, partial outcome, mid-round recovery, cooldown. | Final Validation |
+
+---
+
 ## File Structure
 
 ### Phase 0 — Sunset Files
@@ -227,7 +256,7 @@ This plan was adversarially reviewed before execution. The following findings sh
 - `apps/api/src/services/challenge-round/caps.ts` + `.test.ts` — `MAX_CHALLENGE_QUESTIONS = 3`, cooldown const, overlap threshold.
 - `apps/api/src/routes/challenge-round.ts` + `.test.ts` — accept/decline/abort/maybe-offer endpoints.
 - `apps/api/src/inngest/functions/challenge-round-completed.ts` + `.test.ts` + `.integration.test.ts` — fan-out for metrics + review-target writes.
-- `apps/api/eval-llm/scenarios/challenge-round.ts` — 6-scenario matrix.
+- `apps/api/eval-llm/scenarios/challenge-round.ts` — 7-scenario matrix.
 - `packages/database/src/schema/challenge-round-cooldowns.ts` — per-profile/per-topic cooldown rows.
 - `packages/database/src/migrations/####_challenge_round_cooldowns.sql` — generated.
 - `packages/database/src/migrations/####_notes_source.sql` — generated.
@@ -783,6 +812,7 @@ describe('challenge round envelope fields', () => {
         note_draft: {
           content: 'Photosynthesis uses light to convert CO2 and water into glucose...',
           source_concepts: ['photosynthesis vs respiration', 'role of ATP'],
+          source_answer_event_ids: ['event-solid-1', 'event-solid-2'],
         },
       },
       confidence: 'high',
@@ -828,6 +858,7 @@ note_draft: z
   .object({
     content: z.string().min(1).max(2000),
     source_concepts: z.array(z.string()).min(1).max(10),
+    source_answer_event_ids: z.array(z.string()).min(1).max(10),
   })
   .optional(),
 ```
@@ -892,6 +923,9 @@ describe('sessionMetadata.challengeRound', () => {
 
 ```typescript
 // packages/schemas/src/sessions.ts (additions)
+// Import challengeRoundEvaluationItemSchema from ./llm-envelope. If that creates
+// a barrel cycle, extract the evaluation item schema to
+// packages/schemas/src/challenge-round.ts and import it from both modules.
 
 export const challengeRoundStateEnum = z.enum([
   'offered',
@@ -911,6 +945,7 @@ export const challengeRoundSessionStateSchema = z.object({
   offerCount: z.number().int().min(0).default(0),
   topicId: z.string().uuid().optional(),
   declinedDontAskAgain: z.boolean().default(false),
+  evaluations: z.array(challengeRoundEvaluationItemSchema).max(10).default([]),
 });
 
 // extend existing sessionMetadataSchema:
@@ -1008,6 +1043,7 @@ const baseInput = {
   retentionStatus: 'strong' as const,
   struggleStatus: 'normal' as const,
   recentCorrectStreak: 2,
+  currentSessionSolidAnswerCount: 2,
   quotaFractionRemaining: 0.5,
   challengeRoundState: undefined,
   cooldownLastOfferedAt: null,
@@ -1041,6 +1077,30 @@ describe('evaluateChallengeReadiness', () => {
     for (const status of ['fading', 'weak', 'forgotten'] as const) {
       expect(evaluateChallengeReadiness({ ...baseInput, retentionStatus: status }).eligible).toBe(false);
     }
+  });
+
+  it('allows a new topic when the current session shows sustained solid answers', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        retentionStatus: 'new',
+        recentCorrectStreak: 4,
+        currentSessionSolidAnswerCount: 4,
+        exchangeCount: 7,
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('does not allow a new topic on only a short lucky streak', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        retentionStatus: 'new',
+        recentCorrectStreak: 2,
+        currentSessionSolidAnswerCount: 2,
+        exchangeCount: 5,
+      }).eligible,
+    ).toBe(false);
   });
 
   it('hard-gates when streak below 2', () => {
@@ -1114,6 +1174,9 @@ import {
 const CHALLENGE_OFFER_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const MIN_EXCHANGES = 5;
 const MIN_CORRECT_STREAK = 2;
+const MIN_NEW_TOPIC_EXCHANGES = 7;
+const MIN_NEW_TOPIC_SOLID_ANSWERS = 4;
+const MIN_NEW_TOPIC_CORRECT_STREAK = 4;
 const MIN_QUOTA_FRACTION = 0.05;
 
 export interface ChallengeReadinessInput {
@@ -1122,6 +1185,7 @@ export interface ChallengeReadinessInput {
   retentionStatus: z.infer<typeof retentionStatusSchema>;
   struggleStatus: z.infer<typeof struggleStatusSchema>;
   recentCorrectStreak: number;
+  currentSessionSolidAnswerCount: number;
   quotaFractionRemaining: number;
   challengeRoundState: z.infer<typeof challengeRoundSessionStateSchema> | undefined;
   cooldownLastOfferedAt: Date | null;
@@ -1140,8 +1204,14 @@ export function evaluateChallengeReadiness(input: ChallengeReadinessInput): Chal
   }
   if (input.struggleStatus !== 'normal') return { eligible: false, reason: 'struggle' };
   if (input.exchangeCount < MIN_EXCHANGES) return { eligible: false, reason: 'exchanges_below_min' };
-  if (input.retentionStatus !== 'strong') return { eligible: false, reason: 'retention' };
   if (input.recentCorrectStreak < MIN_CORRECT_STREAK) return { eligible: false, reason: 'streak' };
+  const retentionEligible =
+    input.retentionStatus === 'strong' ||
+    (input.retentionStatus === 'new' &&
+      input.exchangeCount >= MIN_NEW_TOPIC_EXCHANGES &&
+      input.recentCorrectStreak >= MIN_NEW_TOPIC_CORRECT_STREAK &&
+      input.currentSessionSolidAnswerCount >= MIN_NEW_TOPIC_SOLID_ANSWERS);
+  if (!retentionEligible) return { eligible: false, reason: 'retention' };
   if (input.quotaFractionRemaining < MIN_QUOTA_FRACTION) return { eligible: false, reason: 'quota' };
   if (input.challengeRoundState && input.challengeRoundState.state !== 'complete' && input.challengeRoundState.state !== 'aborted') {
     if (input.challengeRoundState.declinedDontAskAgain) return { eligible: false, reason: 'session_decline' };
@@ -1241,20 +1311,22 @@ describe('challenge-round state transitions', () => {
     expect(next?.questionIndex).toBe(0);
     expect(next?.totalQuestions).toBe(3);
   });
-  it('active -> drafting when last question answered', () => {
+  it('active -> drafting when last question answered and preserves all evaluations', () => {
     const next = transitionChallengeState(
-      { state: 'active', offerCount: 1, questionIndex: 2, totalQuestions: 3 },
-      { type: 'answer_complete' },
+      { state: 'active', offerCount: 1, questionIndex: 2, totalQuestions: 3, evaluations: [{ concept: 'a', result: 'solid', evidence: 'x', answerEventId: 'e1', learnerQuote: 'a' }] },
+      { type: 'answer_complete', evaluation: [{ concept: 'b', result: 'solid', evidence: 'y', answerEventId: 'e2', learnerQuote: 'b' }] },
     );
     expect(next?.state).toBe('drafting');
+    expect(next?.evaluations).toHaveLength(2);
   });
   it('active -> active advances when more questions remain', () => {
     const next = transitionChallengeState(
       { state: 'active', offerCount: 1, questionIndex: 0, totalQuestions: 3 },
-      { type: 'answer_complete' },
+      { type: 'answer_complete', evaluation: [{ concept: 'a', result: 'solid', evidence: 'x', answerEventId: 'e1', learnerQuote: 'a' }] },
     );
     expect(next?.state).toBe('active');
     expect(next?.questionIndex).toBe(1);
+    expect(next?.evaluations).toHaveLength(1);
   });
   it('rejects illegal transition (complete -> active)', () => {
     expect(() =>
@@ -1272,17 +1344,21 @@ describe('challenge-round state transitions', () => {
 ```typescript
 // apps/api/src/services/challenge-round/state.ts
 import type { z } from 'zod';
-import { challengeRoundSessionStateSchema } from '@eduagent/schemas';
+import {
+  challengeRoundEvaluationItemSchema,
+  challengeRoundSessionStateSchema,
+} from '@eduagent/schemas';
 import { enforceChallengeQuestionCap, MAX_CHALLENGE_QUESTIONS } from './caps';
 
 type State = z.infer<typeof challengeRoundSessionStateSchema>;
+type Eval = z.infer<typeof challengeRoundEvaluationItemSchema>;
 
 export type StateTransition =
   | { type: 'offer'; topicId: string }
   | { type: 'accept' }
   | { type: 'decline'; dontAskAgain: boolean }
   | { type: 'start'; totalQuestions: number }
-  | { type: 'answer_complete' }
+  | { type: 'answer_complete'; evaluation: Eval[] }
   | { type: 'draft_ready' }
   | { type: 'complete' }
   | { type: 'abort' };
@@ -1317,8 +1393,9 @@ export function transitionChallengeState(prev: State | undefined, ev: StateTrans
     case 'answer_complete': {
       if (prev?.state !== 'active') throw new Error('illegal: answer_complete requires active');
       const next = (prev.questionIndex ?? 0) + 1;
-      if (next >= (prev.totalQuestions ?? MAX_CHALLENGE_QUESTIONS)) return { ...prev, state: 'drafting' };
-      return { ...prev, questionIndex: next };
+      const evaluations = [...(prev.evaluations ?? []), ...ev.evaluation];
+      if (next >= (prev.totalQuestions ?? MAX_CHALLENGE_QUESTIONS)) return { ...prev, state: 'drafting', evaluations };
+      return { ...prev, questionIndex: next, evaluations };
     }
     case 'draft_ready':
       if (prev?.state !== 'drafting') throw new Error('illegal: draft_ready requires drafting');
@@ -1360,18 +1437,18 @@ cd apps/api && pnpm exec jest src/services/challenge-round/caps.test.ts src/serv
 import { decideMasteryAndReview, summarizeEvaluation } from './evaluation';
 
 const allSolid = [
-  { concept: 'a', result: 'solid' as const, evidence: 'x' },
-  { concept: 'b', result: 'solid' as const, evidence: 'y' },
-  { concept: 'c', result: 'solid' as const, evidence: 'z' },
+  { concept: 'a', result: 'solid' as const, evidence: 'x', answerEventId: 'e1', learnerQuote: 'I said a clearly' },
+  { concept: 'b', result: 'solid' as const, evidence: 'y', answerEventId: 'e2', learnerQuote: 'I said b clearly' },
+  { concept: 'c', result: 'solid' as const, evidence: 'z', answerEventId: 'e3', learnerQuote: 'I said c clearly' },
 ];
 const mixed = [
-  { concept: 'a', result: 'solid' as const, evidence: 'x' },
-  { concept: 'b', result: 'partial' as const, evidence: 'y' },
-  { concept: 'c', result: 'misconception' as const, evidence: 'z', correction: 'C' },
+  { concept: 'a', result: 'solid' as const, evidence: 'x', answerEventId: 'e1', learnerQuote: 'I said a clearly' },
+  { concept: 'b', result: 'partial' as const, evidence: 'y', answerEventId: 'e2', learnerQuote: 'I partly said b' },
+  { concept: 'c', result: 'misconception' as const, evidence: 'z', correction: 'C', answerEventId: 'e3', learnerQuote: 'I said c incorrectly' },
 ];
 const allMissing = [
-  { concept: 'a', result: 'missing' as const, evidence: 'x' },
-  { concept: 'b', result: 'missing' as const, evidence: 'y' },
+  { concept: 'a', result: 'missing' as const, evidence: 'x', answerEventId: 'e1', learnerQuote: 'idk' },
+  { concept: 'b', result: 'missing' as const, evidence: 'y', answerEventId: 'e2', learnerQuote: 'pass' },
 ];
 
 describe('decideMasteryAndReview', () => {
@@ -1381,6 +1458,7 @@ describe('decideMasteryAndReview', () => {
     expect(d.markMasteryVerified).toBe(true);
     expect(d.reviewTargets).toEqual([]);
     expect(d.solidConcepts).toEqual(['a', 'b', 'c']);
+    expect(d.solidAnswerQuotes).toEqual(['I said a clearly', 'I said b clearly', 'I said c clearly']);
   });
   it('mixed -> partial, review targets for partial+misconception, NOT mastered', () => {
     const d = decideMasteryAndReview(mixed);
@@ -1388,6 +1466,7 @@ describe('decideMasteryAndReview', () => {
     expect(d.markMasteryVerified).toBe(false);
     expect(d.reviewTargets.map(r => r.concept).sort()).toEqual(['b', 'c']);
     expect(d.solidConcepts).toEqual(['a']);
+    expect(d.solidAnswerQuotes).toEqual(['I said a clearly']);
   });
   it('all missing -> reteach, no note, no review targets', () => {
     const d = decideMasteryAndReview(allMissing);
@@ -1395,13 +1474,27 @@ describe('decideMasteryAndReview', () => {
     expect(d.solidConcepts).toEqual([]);
     expect(d.markMasteryVerified).toBe(false);
   });
+  it('empty evaluation -> invalid, no note, no mastery (CRIT-9)', () => {
+    const d = decideMasteryAndReview([]);
+    expect(d.outcome).toBe('invalid');
+    expect(d.markMasteryVerified).toBe(false);
+    expect(d.solidConcepts).toEqual([]);
+    expect(d.solidAnswerQuotes).toEqual([]);
+    expect(d.reviewTargets).toEqual([]);
+  });
   it('any misconception blocks mastery even if majority solid', () => {
     const mostlySolid = [
-      { concept: 'a', result: 'solid' as const, evidence: 'x' },
-      { concept: 'b', result: 'solid' as const, evidence: 'y' },
-      { concept: 'c', result: 'misconception' as const, evidence: 'z', correction: 'C' },
+      { concept: 'a', result: 'solid' as const, evidence: 'x', answerEventId: 'e1', learnerQuote: 'solid a' },
+      { concept: 'b', result: 'solid' as const, evidence: 'y', answerEventId: 'e2', learnerQuote: 'solid b' },
+      { concept: 'c', result: 'misconception' as const, evidence: 'z', correction: 'C', answerEventId: 'e3', learnerQuote: 'wrong c' },
     ];
     expect(decideMasteryAndReview(mostlySolid).markMasteryVerified).toBe(false);
+  });
+  it('does not expose partial or misconception quotes for note drafting', () => {
+    const d = decideMasteryAndReview(mixed);
+    expect(d.solidAnswerQuotes).toEqual(['I said a clearly']);
+    expect(d.solidAnswerQuotes).not.toContain('I partly said b');
+    expect(d.solidAnswerQuotes).not.toContain('I said c incorrectly');
   });
 });
 
@@ -1423,20 +1516,28 @@ type Eval = z.infer<typeof challengeRoundEvaluationItemSchema>;
 
 export interface ReviewTarget {
   concept: string;
+  answerEventId: string;
   misconception?: string;
   correction?: string;
   source: 'challenge_round';
 }
 
 export interface MasteryDecision {
-  outcome: 'verified' | 'partial' | 'reteach';
+  outcome: 'verified' | 'partial' | 'reteach' | 'invalid';
   markMasteryVerified: boolean;
   solidConcepts: string[];
+  solidAnswerQuotes: string[];
   reviewTargets: ReviewTarget[];
 }
 
 export function decideMasteryAndReview(evals: Eval[]): MasteryDecision {
-  const solid = evals.filter(e => e.result === 'solid').map(e => e.concept);
+  if (evals.length === 0) {
+    return { outcome: 'invalid', markMasteryVerified: false, solidConcepts: [], solidAnswerQuotes: [], reviewTargets: [] };
+  }
+
+  const solidItems = evals.filter(e => e.result === 'solid');
+  const solid = solidItems.map(e => e.concept);
+  const solidAnswerQuotes = solidItems.map(e => e.learnerQuote);
   const hasMisconception = evals.some(e => e.result === 'misconception');
   const hasPartial = evals.some(e => e.result === 'partial');
   const allMissing = evals.length > 0 && evals.every(e => e.result === 'missing');
@@ -1444,16 +1545,17 @@ export function decideMasteryAndReview(evals: Eval[]): MasteryDecision {
     .filter(e => e.result === 'partial' || e.result === 'misconception')
     .map(e => ({
       concept: e.concept,
+      answerEventId: e.answerEventId,
       misconception: e.result === 'misconception' ? e.evidence : undefined,
       correction: e.correction,
       source: 'challenge_round' as const,
     }));
 
-  if (allMissing) return { outcome: 'reteach', markMasteryVerified: false, solidConcepts: [], reviewTargets };
+  if (allMissing) return { outcome: 'reteach', markMasteryVerified: false, solidConcepts: [], solidAnswerQuotes: [], reviewTargets };
   if (solid.length === evals.length && !hasMisconception && !hasPartial) {
-    return { outcome: 'verified', markMasteryVerified: true, solidConcepts: solid, reviewTargets: [] };
+    return { outcome: 'verified', markMasteryVerified: true, solidConcepts: solid, solidAnswerQuotes, reviewTargets: [] };
   }
-  return { outcome: 'partial', markMasteryVerified: false, solidConcepts: solid, reviewTargets };
+  return { outcome: 'partial', markMasteryVerified: false, solidConcepts: solid, solidAnswerQuotes, reviewTargets };
 }
 
 export function summarizeEvaluation(evals: Eval[]) {
@@ -1489,7 +1591,7 @@ cd apps/api && pnpm exec jest src/services/challenge-round/evaluation.test.ts
 // apps/api/src/services/challenge-round/note-draft.test.ts
 import { validateNoteDraft } from './note-draft';
 
-const learnerAnswers = [
+const solidLearnerQuotes = [
   'Photosynthesis happens in chloroplasts. The plant uses light energy to convert carbon dioxide and water into glucose.',
   'ATP is the energy currency of the cell.',
 ];
@@ -1497,19 +1599,38 @@ const learnerAnswers = [
 describe('validateNoteDraft', () => {
   it('accepts draft that overlaps with learner content', () => {
     const draft = 'Photosynthesis takes place in chloroplasts. Light energy converts carbon dioxide and water into glucose. ATP is the cell energy currency.';
-    expect(validateNoteDraft(draft, learnerAnswers).ok).toBe(true);
+    expect(validateNoteDraft(draft, solidLearnerQuotes).ok).toBe(true);
   });
   it('rejects draft that invents content with low overlap', () => {
     const draft = 'The Krebs cycle is essential for cellular respiration and produces NADH and FADH2 electron carriers.';
-    expect(validateNoteDraft(draft, learnerAnswers).ok).toBe(false);
+    expect(validateNoteDraft(draft, solidLearnerQuotes).ok).toBe(false);
   });
   it('rejects empty draft', () => {
-    expect(validateNoteDraft('', learnerAnswers).ok).toBe(false);
+    expect(validateNoteDraft('', solidLearnerQuotes).ok).toBe(false);
   });
   it('reports overlap ratio in result', () => {
-    const r = validateNoteDraft('Photosynthesis happens in chloroplasts. ATP is energy currency.', learnerAnswers);
+    const r = validateNoteDraft('Photosynthesis happens in chloroplasts. ATP is energy currency.', solidLearnerQuotes);
     expect(r.ok).toBe(true);
     expect(r.overlapRatio).toBeGreaterThan(0.4);
+  });
+  it('accepts short but meaningful drafts', () => {
+    expect(validateNoteDraft('ATP stores energy.', ['ATP stores energy.']).ok).toBe(true);
+  });
+  it('rejects draft that only overlaps with non-solid answer text', () => {
+    const partialOrWrongQuotes = ['photosynthesis happens in the nucleus', 'ATP means atomic transfer power'];
+    const draft = 'Photosynthesis happens in the nucleus and ATP means atomic transfer power.';
+    expect(validateNoteDraft(draft, solidLearnerQuotes)).toMatchObject({ ok: false });
+    expect(validateNoteDraft(draft, partialOrWrongQuotes)).toMatchObject({ ok: true });
+  });
+  it('handles accented Latin learner text (MED-10)', () => {
+    const quotes = ['Fotosyntéza probíhá v chloroplastech a vytváří glukózu.'];
+    const draft = 'Fotosyntéza probíhá v chloroplastech a vytváří glukózu.';
+    expect(validateNoteDraft(draft, quotes).ok).toBe(true);
+  });
+  it('handles non-spaced learner text with character n-gram fallback (MED-10)', () => {
+    const quotes = ['光合成は葉緑体で行われます'];
+    const draft = '光合成は葉緑体で行われます';
+    expect(validateNoteDraft(draft, quotes).ok).toBe(true);
   });
 });
 ```
@@ -1526,14 +1647,28 @@ const STOPWORDS = new Set([
   'has', 'have', 'had', 'do', 'does', 'did', 'i', 'you', 'they', 'we', 'he', 'she',
 ]);
 
-function tokenize(text: string): Set<string> {
-  return new Set(
+function characterNgrams(text: string, n = 2): Set<string> {
+  const chars = Array.from(
     text
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
+      .normalize('NFKC')
+      .toLocaleLowerCase()
+      .replace(/[^\p{L}\p{N}]/gu, ''),
+  );
+  const grams = new Set<string>();
+  for (let i = 0; i <= chars.length - n; i += 1) grams.add(chars.slice(i, i + n).join(''));
+  return grams;
+}
+
+function tokenize(text: string): Set<string> {
+  const wordTokens = new Set(
+    text
+      .normalize('NFKC')
+      .toLocaleLowerCase()
+      .replace(/[^\p{L}\p{N}\s]/gu, ' ')
       .split(/\s+/)
       .filter(t => t.length > 2 && !STOPWORDS.has(t)),
   );
+  return wordTokens.size > 1 ? wordTokens : characterNgrams(text);
 }
 
 export interface DraftValidationResult {
@@ -1542,10 +1677,10 @@ export interface DraftValidationResult {
   reason?: string;
 }
 
-export function validateNoteDraft(draft: string, learnerAnswers: string[]): DraftValidationResult {
+export function validateNoteDraft(draft: string, solidLearnerQuotes: string[]): DraftValidationResult {
   if (!draft.trim()) return { ok: false, overlapRatio: 0, reason: 'empty' };
   const draftTokens = tokenize(draft);
-  const learnerTokens = tokenize(learnerAnswers.join(' '));
+  const learnerTokens = tokenize(solidLearnerQuotes.join(' '));
   if (draftTokens.size === 0) return { ok: false, overlapRatio: 0, reason: 'no_content_tokens' };
   let overlap = 0;
   for (const tok of draftTokens) if (learnerTokens.has(tok)) overlap += 1;
@@ -1554,6 +1689,8 @@ export function validateNoteDraft(draft: string, learnerAnswers: string[]): Draf
   return { ok: true, overlapRatio: ratio };
 }
 ```
+
+**HIGH-6 implementation rule:** callers must pass `decision.solidAnswerQuotes`, not the full transcript and not all challenge answers. If `solidAnswerQuotes.length === 0`, do not call the drafter and do not emit `ui_hints.note_draft`.
 
 - [ ] **Step 3: Run green + commit**
 
@@ -1564,7 +1701,7 @@ cd apps/api && pnpm exec jest src/services/challenge-round/note-draft.test.ts
 
 - [ ] **Step 4: Calibrate `MIN_LEXICAL_OVERLAP_NOTE_DRAFT` against the eval harness (MED-3)**
 
-The 0.4 threshold in `caps.ts` is a guess. After Task 8 (Tier 2 eval harness wired), run the 6-scenario suite and emit the overlap ratio for each `note_draft`. Log a histogram. If 0.4 produces false rejects on the `draft-note-uses-learner-words` scenario, lower; if it accepts the obviously-hallucinated drafts in adversarial scenarios (add 2 such scenarios to `challenge-round.ts` for this calibration), raise.
+The 0.4 threshold in `caps.ts` is a guess. After Task 8 (Tier 2 eval harness wired), run the 7-scenario suite and emit the overlap ratio for each `note_draft`. Log a histogram. If 0.4 produces false rejects on the `draft-note-uses-learner-words` scenario, lower; if it accepts the obviously-hallucinated drafts in adversarial scenarios (add 2 such scenarios to `challenge-round.ts` for this calibration), raise.
 
 Annotate the constant in `caps.ts`:
 
@@ -1613,7 +1750,7 @@ Constraints:
 - Maximum ${MAX_CHALLENGE_QUESTIONS} questions per round (do not exceed; the server will cap).
 - One question per turn. No multi-part questions.
 - Match the learner's age and energy. Do not use academic jargon.
-- After EACH learner answer, emit "signals.challenge_round_evaluation" with ONE item describing the concept assessed and result in {solid, partial, missing, misconception}.
+- After EACH learner answer, emit "signals.challenge_round_evaluation" with ONE item describing the concept assessed, result in {solid, partial, missing, misconception}, the learner answer event id, and a short `learnerQuote` copied from the learner's answer.
 - When all questions are answered, set "ui_hints.challenge_round.active": false and proceed to drafting.
 
 Failure framing is banned. Never use "failed", "wrong", "incorrect", "struggle", "weak". Use "got it", "close", "let's tighten this", "not quite yet".
@@ -1624,7 +1761,8 @@ The Challenge Round is complete. Draft a learner-owned note in "ui_hints.note_dr
 
 Hard rules:
 - Use ONLY content the learner actually said in their challenge answers. Do not invent facts they did not state.
-- Pull from concepts the evaluation marked "solid". Do NOT include partial or misconception concepts.
+- Pull from the `learnerQuote` values attached to concepts the evaluation marked "solid". Do NOT include partial, missing, or misconception concepts.
+- If a concept is marked solid but its `learnerQuote` is vague ("yes", "got it", "I know"), exclude it from the draft rather than inventing detail.
 - 2-5 short sentences. Written in the learner's voice ("I learned that...", "in my own words...").
 - Title is NOT included; the note system handles that.
 
@@ -1739,6 +1877,21 @@ export const challengeRoundScenarios: Scenario[] = [
     ],
     sessionMetadata: { challengeRound: { state: 'active', offerCount: 1, questionIndex: 1, totalQuestions: 3 } },
     expected: { signalsMustInclude: ['challenge_round_evaluation'], evaluationResultIn: ['solid', 'partial'] },
+  },
+  {
+    name: 'misconception-must-not-be-solid',
+    profileAge: 15,
+    sessionType: 'learning',
+    history: [
+      { role: 'assistant', content: 'Where does photosynthesis happen, and why does that location matter?' },
+      { role: 'user', content: 'Photosynthesis happens in the nucleus because that is where the plant stores instructions.' },
+    ],
+    sessionMetadata: { challengeRound: { state: 'active', offerCount: 1, questionIndex: 1, totalQuestions: 3 } },
+    expected: {
+      signalsMustInclude: ['challenge_round_evaluation'],
+      evaluationResultForConceptMustNotBe: { conceptIncludes: 'where', result: 'solid' },
+      evaluationResultMustInclude: ['misconception'],
+    },
   },
   {
     name: 'draft-note-uses-learner-words',
@@ -1878,6 +2031,7 @@ const readiness = evaluateChallengeReadiness({
   retentionStatus: topicProgress?.retentionStatus ?? 'forgotten',
   struggleStatus: topicProgress?.struggleStatus ?? 'normal',
   recentCorrectStreak: computeRecentCorrectStreak(session),
+  currentSessionSolidAnswerCount: computeCurrentSessionSolidAnswerCount(session),
   quotaFractionRemaining: quota.fractionRemaining,
   challengeRoundState: session.metadata?.challengeRound,
   cooldownLastOfferedAt: cooldown?.lastOfferedAt ?? null,
@@ -1915,14 +2069,18 @@ if (envelope.signals?.challenge_round_offer && topicProgress?.topicId) {
 
 // state transition on each evaluation in active state
 if (envelope.signals?.challenge_round_evaluation && session.metadata?.challengeRound?.state === 'active') {
+  const previousChallengeRound = session.metadata.challengeRound;
   session.metadata = {
     ...session.metadata,
-    challengeRound: transitionChallengeState(session.metadata.challengeRound, { type: 'answer_complete' }),
+    challengeRound: transitionChallengeState(previousChallengeRound, {
+      type: 'answer_complete',
+      evaluation: envelope.signals.challenge_round_evaluation,
+    }),
   };
   await persistSessionMetadata(session.id, session.metadata);
 }
 
-// dispatch Inngest fan-out on completion (drafting -> with evaluation array)
+// dispatch Inngest fan-out on completion (full accumulated evaluation array)
 if (
   envelope.signals?.challenge_round_evaluation &&
   session.metadata?.challengeRound?.state === 'drafting'
@@ -1931,7 +2089,7 @@ if (
     sessionId: session.id,
     profileId: session.profileId,
     topicId: session.metadata.challengeRound.topicId!,
-    evaluation: envelope.signals.challenge_round_evaluation,
+    evaluation: session.metadata.challengeRound.evaluations ?? [],
   });
 }
 ```
@@ -1972,9 +2130,51 @@ describe('processExchange — challenge round dispatch', () => {
 pnpm eval:llm --live
 ```
 
-Expected: all 6 challenge-round scenarios pass schema validation.
+Expected: all 7 challenge-round scenarios pass schema validation.
 
 - [ ] **Step 7: Commit**
+
+```bash
+/commit
+```
+
+---
+
+### Task 8.5 — Mid-round recovery and pending draft handoff (MED-9)
+
+**Files:**
+- Modify: `apps/api/src/services/session/session-crud.ts` — close/auto-close handling
+- Modify: `apps/api/src/services/session/session-exchange.ts` — next-session/post-session handoff
+- Modify: `packages/schemas/src/sessions.ts` — optional `challengeRound.pendingDraft` metadata if needed
+- Modify/Create tests near session close + exchange services
+
+- [ ] **Step 1: Define recovery state**
+
+When a session ends while `challengeRound.state ∈ {'active','drafting'}`, inspect `challengeRound.evaluations`:
+
+- If there is at least one `solid` item, compute `decision = decideMasteryAndReview(evaluations)` and persist:
+  - the weak-spot review targets via the chosen durable target from Task 0.0.
+  - `challengeRound.pendingDraft = { solidAnswerQuotes, solidConcepts, createdAt }` in session metadata, or an equivalent durable row if Task 0.0 chose a table.
+- If there are zero `solid` items, persist weak spots if present, set `challengeRound.state = 'aborted'`, and do not create a note draft.
+- Never mark `masteryChallengeVerifiedAt` from an auto-closed/incomplete round unless the round reached `drafting` with all expected questions answered and every evaluation is `solid`.
+
+- [ ] **Step 2: Surface pending draft explicitly**
+
+On next app open/session resume/post-session summary, if a pending challenge draft exists, show the same `DraftedNoteReview` component with copy:
+
+> "You explained a few strong pieces before we stopped. Want to save those as a note?"
+
+Actions remain explicit: `Save note`, `Edit first`, `Skip`. No auto-save.
+
+- [ ] **Step 3: Tests**
+
+Add tests for:
+- active round + one solid answer + app close → pending draft exists, no mastery flag, weak spots persisted.
+- active round + zero solid answers + app close → no draft, no mastery flag.
+- drafting round + all solid + app close before save → pending draft exists; mastery flag only if the round had all expected evaluations.
+- saving recovered draft writes `source: 'challenge_round'` and links `sessionId`.
+
+- [ ] **Step 4: Commit**
 
 ```bash
 /commit
@@ -2084,13 +2284,14 @@ export const challengeRoundRoutes = new Hono()
   })
   .post('/decline', async (c) => {
     const body = declineSchema.parse(await c.req.json());
+    const db = c.get('db');
     const session = await getSessionById(body.sessionId, c.get('profileId'));
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'decline', dontAskAgain: body.dontAskAgain }),
     };
     await persistSessionMetadata(session.id, session.metadata);
-    await recordCooldown({ profileId: c.get('profileId'), topicId: body.topicId, outcome: 0 });
+    await recordCooldown(db, { profileId: c.get('profileId'), topicId: body.topicId, outcome: 0 });
     await safeSend('challenge.round.declined', { sessionId: body.sessionId, topicId: body.topicId });
     return c.json({ ok: true });
   })
@@ -2112,10 +2313,12 @@ Helper `loadReadinessInput` queries the same data `processExchange` uses (sessio
 
 ```typescript
 // apps/api/src/services/challenge-round/cooldown.ts
-import { db } from '@/db';
-import { challengeRoundCooldowns } from '@eduagent/database';
+import { challengeRoundCooldowns, type Database } from '@eduagent/database';
 
-export async function recordCooldown(input: { profileId: string; topicId: string; outcome: number }): Promise<void> {
+export async function recordCooldown(
+  db: Database,
+  input: { profileId: string; topicId: string; outcome: number },
+): Promise<void> {
   await db
     .insert(challengeRoundCooldowns)
     .values({ profileId: input.profileId, topicId: input.topicId, lastOutcome: input.outcome })
@@ -2135,19 +2338,21 @@ import { decideMasteryAndReview } from '@/services/challenge-round/evaluation';
 import { upsertReviewTargets } from '@/services/retention-data';
 import { markMasteryChallengeVerified } from '@/services/topic-completion';
 import { recordCooldown } from '@/services/challenge-round/cooldown';
+import { getStepDatabase } from '../db';
 
 export const challengeRoundCompleted = inngest.createFunction(
   { id: 'challenge-round-completed', name: 'Challenge Round Completed' },
   { event: 'challenge.round.completed' },
   async ({ event, step }) => {
     const { sessionId, profileId, topicId, evaluation } = event.data;
+    const db = getStepDatabase();
     const decision = decideMasteryAndReview(evaluation);
-    await step.run('persist-review-targets', () => upsertReviewTargets(profileId, topicId, decision.reviewTargets));
+    await step.run('persist-review-targets', () => upsertReviewTargets(db, profileId, topicId, decision.reviewTargets));
     if (decision.markMasteryVerified) {
-      await step.run('mark-mastery-verified', () => markMasteryChallengeVerified(profileId, topicId, new Date()));
+      await step.run('mark-mastery-verified', () => markMasteryChallengeVerified(db, profileId, topicId, new Date()));
     }
     await step.run('record-cooldown', () =>
-      recordCooldown({
+      recordCooldown(db, {
         profileId,
         topicId,
         outcome: decision.markMasteryVerified ? 2 : decision.outcome === 'reteach' ? 3 : 1,
@@ -2175,8 +2380,8 @@ Expected: only the call sites added in this PR. If anything else exists (unlikel
 - [ ] **Step 6: Tests**
 
 Write tests for:
-- Routes: accept/decline/maybe-offer/abort all transition session metadata correctly, decline persists cooldown.
-- Inngest function: verified outcome → mastery flag set, no review targets; partial outcome → review targets, no mastery flag; reteach outcome → cooldown=3, no review targets.
+- Routes: accept/decline/maybe-offer/abort all transition session metadata correctly; decline persists cooldown; cross-profile and cross-topic session mismatches are rejected; already-offered race returns a 200 no-op; illegal transitions return a typed client-safe error.
+- Inngest function: verified outcome → mastery flag set, no review targets; partial outcome → review targets, no mastery flag; reteach outcome → cooldown=3, no review targets; empty evaluation → `invalid`, no mastery flag, no note, no review targets, observable structured log/metric.
 
 ```bash
 pnpm exec nx run api:test
@@ -2500,9 +2705,17 @@ describe('challenge round end-to-end', () => {
       const isLast = i === 2;
       mockRouteAndCall({
         reply: isLast ? 'great' : 'next question',
-        signals: { challenge_round_evaluation: [{ concept: `c${i}`, result: 'solid', evidence: 'said it correctly' }] },
+        signals: {
+          challenge_round_evaluation: [{
+            concept: `c${i}`,
+            result: 'solid',
+            evidence: 'said it correctly',
+            answerEventId: `event-${i}`,
+            learnerQuote: `correct learner answer ${i}`,
+          }],
+        },
         ui_hints: isLast
-          ? { note_draft: { content: 'I learned that X, Y, and Z based on what I said.', source_concepts: ['c0', 'c1', 'c2'] } }
+          ? { note_draft: { content: 'I learned that X, Y, and Z based on what I said.', source_concepts: ['c0', 'c1', 'c2'], source_answer_event_ids: ['e0', 'e1', 'e2'] } }
           : { challenge_round: { active: true, question_index: i + 1, total_questions: 3 } },
         confidence: 'high',
       });
@@ -2522,9 +2735,9 @@ describe('challenge round end-to-end', () => {
       profileId: profile.id,
       topicId: topic.id,
       evaluation: [
-        { concept: 'c0', result: 'solid', evidence: 'x' },
-        { concept: 'c1', result: 'solid', evidence: 'y' },
-        { concept: 'c2', result: 'solid', evidence: 'z' },
+        { concept: 'c0', result: 'solid', evidence: 'x', answerEventId: 'e0', learnerQuote: 'correct learner answer 0' },
+        { concept: 'c1', result: 'solid', evidence: 'y', answerEventId: 'e1', learnerQuote: 'correct learner answer 1' },
+        { concept: 'c2', result: 'solid', evidence: 'z', answerEventId: 'e2', learnerQuote: 'correct learner answer 2' },
       ],
     });
 
@@ -2540,17 +2753,30 @@ describe('challenge round end-to-end', () => {
   });
 
   it('partial: 2 solid + 1 misconception saves only the 2 concepts, persists 1 review target, no mastery flip', async () => {
-    const { db, profile, topic } = await seedEligibleSession();
+    const { db, app, profile, topic, session } = await seedEligibleSession();
     await runInngestEvent('challenge.round.completed', {
-      sessionId: 'sid', profileId: profile.id, topicId: topic.id,
+      sessionId: session.id, profileId: profile.id, topicId: topic.id,
       evaluation: [
-        { concept: 'c0', result: 'solid', evidence: 'x' },
-        { concept: 'c1', result: 'solid', evidence: 'y' },
-        { concept: 'c2', result: 'misconception', evidence: 'said wrong thing', correction: 'right thing' },
+        { concept: 'c0', result: 'solid', evidence: 'x', answerEventId: 'e0', learnerQuote: 'solid learner wording one' },
+        { concept: 'c1', result: 'solid', evidence: 'y', answerEventId: 'e1', learnerQuote: 'solid learner wording two' },
+        { concept: 'c2', result: 'misconception', evidence: 'said wrong thing', correction: 'right thing', answerEventId: 'e2', learnerQuote: 'wrong learner wording' },
       ],
     });
+    const saveRes = await app.request(`/subjects/${topic.subjectId}/topics/${topic.id}/notes`, {
+      method: 'POST',
+      body: JSON.stringify({
+        content: 'solid learner wording one\nsolid learner wording two',
+        sessionId: session.id,
+        source: 'challenge_round',
+      }),
+    });
+    expect(saveRes.status).toBe(200);
     const tp = await db.query.topicProgress.findFirst({ where: and(eq(topicProgress.profileId, profile.id), eq(topicProgress.topicId, topic.id)) });
     expect(tp?.masteryChallengeVerifiedAt).toBeNull();
+    const notes = await db.query.topicNotes.findMany({ where: and(eq(topicNotes.profileId, profile.id), eq(topicNotes.topicId, topic.id)) });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].content).toContain('solid learner wording one');
+    expect(notes[0].content).not.toContain('wrong learner wording');
     const rts = await db.query.reviewTargets.findMany({ where: and(eq(reviewTargets.profileId, profile.id), eq(reviewTargets.topicId, topic.id), eq(reviewTargets.source, 'challenge_round')) });
     expect(rts).toHaveLength(1);
     expect(rts[0].correction).toBe('right thing');
@@ -2589,7 +2815,7 @@ pnpm exec jest tests/integration/challenge-round.integration.test.ts
 - [ ] **Step 1: Append to CLAUDE.md "Non-Negotiable Engineering Rules"**
 
 ```markdown
-- Challenge Round mastery decisions are server-owned and conservative. The LLM proposes per-concept evaluations via `signals.challenge_round_evaluation`; the server runs `decideMasteryAndReview()` and sets `masteryChallengeVerifiedAt` only when EVERY concept evaluates `solid`. Any `partial`, `missing`, or `misconception` blocks mastery and routes the weak concepts to review targets with `source: 'challenge_round'`. Notes drafted from Challenge Rounds must pass the lexical-overlap hallucination guard in `services/challenge-round/note-draft.ts` before being shown to the learner. The Challenge mode toggle (`learningMode: 'serious' | 'casual'`) was removed; today's `casual` is the single default tone and rigor is now expressed per-Challenge-Round rather than globally.
+- Challenge Round mastery policy is server-owned and conservative over structured LLM evidence. The LLM proposes per-concept evaluations via `signals.challenge_round_evaluation`; each item must include `answerEventId` and `learnerQuote`. The server runs `decideMasteryAndReview()` and sets `masteryChallengeVerifiedAt` only when EVERY concept evaluates `solid`. Any `partial`, `missing`, or `misconception` blocks mastery and routes the weak concepts to durable review targets with `source: 'challenge_round'`. Notes drafted from Challenge Rounds must use only `solidAnswerQuotes` and pass the lexical-overlap hallucination guard in `services/challenge-round/note-draft.ts` before being shown to the learner. The Challenge mode toggle (`learningMode: 'serious' | 'casual'`) was removed; today's `casual` is the single default tone and rigor is now expressed per-Challenge-Round rather than globally.
 ```
 
 - [ ] **Step 2: Add a short section to `docs/project_context.md`**
@@ -2611,13 +2837,14 @@ After Task 12, run the full validation matrix before declaring the feature compl
 - [ ] `pnpm exec nx run-many -t lint` — green
 - [ ] `pnpm exec nx run-many -t typecheck` — green
 - [ ] `pnpm exec nx run-many -t test` — green
-- [ ] `pnpm eval:llm --live` — all 6 challenge-round scenarios pass schema validation
+- [ ] `pnpm eval:llm --live` — all 7 challenge-round scenarios pass schema validation
 - [ ] `pnpm exec jest tests/integration/challenge-round.integration.test.ts` — green
 - [ ] **Manual smoke 1 — sunset:** Launch the app on emulator. Open a session. Confirm: no Explorer/Challenge mode header button; no Learning Mode section in More; tone is consistent.
 - [ ] **Manual smoke 2 — system-initiated CR:** Complete a learning session with 6+ exchanges, strong answers, in `strong` retention. Accept the offer. Answer 3 challenge questions correctly. Save the drafted note. Verify it appears under the topic in Library with `source: 'challenge_round'`. Verify mastery shows challenge-verified.
 - [ ] **Manual smoke 3 — Too easy chip path:** In an eligible session, tap "Too easy". Verify the offer card appears immediately. Accept. In an ineligible session (e.g., exchange 3 of 5), tap "Too easy". Verify the chip behaves as before (LLM nudges harder).
 - [ ] **Manual smoke 4 — partial outcome:** Run a Challenge Round with 1 solid + 1 misconception. Verify saved note contains only the solid concept text; verify a review target was persisted with the correction.
-- [ ] **Manual smoke 5 — decline cooldown (MED-6 — impractical at 24h, manually expire):** Decline an offer with "Don't ask again". Finish the session. In Postgres (`db:studio:dev`), manually UPDATE the `challenge_round_cooldowns` row for that profile+topic, setting `last_offered_at = NOW() - INTERVAL '23 hours'`. Start a new session on the same topic with the same readiness conditions — verify no offer appears. Then UPDATE `last_offered_at = NOW() - INTERVAL '25 hours'` and verify the offer DOES appear. Alternatively, gate `CHALLENGE_OFFER_COOLDOWN_HOURS` on `process.env.NODE_ENV === 'test' ? 0.01 : 24` for smokes — but the manual UPDATE is simpler and doesn't change production code.
+- [ ] **Manual smoke 5 — mid-round recovery:** Accept a Challenge Round, answer one question solidly, then close/end the session before the round finishes. Re-open the app. Verify the pending draft offer appears, saving it creates a `source: 'challenge_round'` note, and mastery is NOT marked.
+- [ ] **Manual smoke 6 — decline cooldown (MED-6 — impractical at 24h, manually expire):** Decline an offer with "Don't ask again". Finish the session. In Postgres (`db:studio:dev`), manually UPDATE the `challenge_round_cooldowns` row for that profile+topic, setting `last_offered_at = NOW() - INTERVAL '23 hours'`. Start a new session on the same topic with the same readiness conditions — verify no offer appears. Then UPDATE `last_offered_at = NOW() - INTERVAL '25 hours'` and verify the offer DOES appear. Alternatively, gate `CHALLENGE_OFFER_COOLDOWN_HOURS` on `process.env.NODE_ENV === 'test' ? 0.01 : 24` for smokes — but the manual UPDATE is simpler and doesn't change production code.
 - [ ] Sentry: zero errors tagged `challenge.envelope_parse` or `challenge.state_illegal` in smoke runs.
 
 ---

--- a/docs/plans/2026-05-18-challenge-round-into-note.md
+++ b/docs/plans/2026-05-18-challenge-round-into-note.md
@@ -737,9 +737,28 @@ describe('challenge round envelope fields', () => {
       reply: 'Strong work.',
       signals: {
         challenge_round_evaluation: [
-          { concept: 'photosynthesis vs respiration', result: 'solid', evidence: 'learner described both directions of energy flow' },
-          { concept: 'role of ATP', result: 'partial', evidence: 'mentioned energy currency, missed structure' },
-          { concept: 'where it happens', result: 'misconception', evidence: 'said nucleus instead of chloroplast', correction: 'occurs in chloroplasts' },
+          {
+            concept: 'photosynthesis vs respiration',
+            result: 'solid',
+            evidence: 'learner described both directions of energy flow',
+            answerEventId: 'event-solid-1',
+            learnerQuote: 'photosynthesis stores energy in glucose and respiration releases it',
+          },
+          {
+            concept: 'role of ATP',
+            result: 'partial',
+            evidence: 'mentioned energy currency, missed structure',
+            answerEventId: 'event-partial-1',
+            learnerQuote: 'ATP is like energy money',
+          },
+          {
+            concept: 'where it happens',
+            result: 'misconception',
+            evidence: 'said nucleus instead of chloroplast',
+            correction: 'occurs in chloroplasts',
+            answerEventId: 'event-misconception-1',
+            learnerQuote: 'photosynthesis happens in the nucleus',
+          },
         ],
       },
       confidence: 'high',
@@ -788,6 +807,8 @@ export const challengeRoundEvaluationItemSchema = z.object({
   concept: z.string().min(1).max(200),
   result: z.enum(['solid', 'partial', 'missing', 'misconception']),
   evidence: z.string().min(1).max(500),
+  answerEventId: z.string().min(1).max(120),
+  learnerQuote: z.string().min(1).max(500),
   correction: z.string().min(1).max(500).optional(),
 });
 
@@ -810,6 +831,8 @@ note_draft: z
   })
   .optional(),
 ```
+
+**HIGH-6 invariant:** `answerEventId` and `learnerQuote` are required because note drafting must be grounded in the learner's exact words. Downstream code must pass only `learnerQuote` values from `result === 'solid'` items to the drafter. The full challenge transcript is not an acceptable draft source because it may contain partial answers or misconceptions.
 
 - [ ] **Step 4: Run test green**
 

--- a/docs/specs/2026-05-18-trial-intent-save-onboarding.md
+++ b/docs/specs/2026-05-18-trial-intent-save-onboarding.md
@@ -1,0 +1,667 @@
+---
+title: 'Trial Intent Save Onboarding'
+slug: 'trial-intent-save-onboarding'
+created: '2026-05-18'
+status: 'draft'
+tech_stack:
+  - Expo Router
+  - React Native
+  - Clerk
+  - Hono API
+  - Drizzle
+  - LLM router
+files_to_modify:
+  - apps/mobile/src/app/preview/index.tsx
+  - apps/mobile/src/app/preview/intent.tsx
+  - apps/mobile/src/app/preview/topic.tsx
+  - apps/mobile/src/app/preview/lesson.tsx
+  - apps/mobile/src/app/preview/parent.tsx
+  - apps/mobile/src/app/(app)/preview/save.tsx
+  - apps/mobile/src/app/(auth)/sign-up.tsx
+  - apps/mobile/src/app/(auth)/_layout.tsx
+  - apps/mobile/src/app/(app)/_layout.tsx
+  - apps/mobile/src/app/create-profile.tsx
+  - apps/mobile/src/app/(app)/session/index.tsx
+  - apps/mobile/src/components/session/ChatShell.tsx
+  - apps/mobile/src/components/home/ParentHomeScreen.tsx
+  - apps/mobile/src/lib/preview-onboarding-state.ts
+  - apps/mobile/src/lib/pending-auth-redirect.ts
+  - apps/mobile/src/lib/profile.ts
+  - apps/mobile/src/lib/sign-out-cleanup.ts
+  - apps/api/src/index.ts
+  - apps/api/src/middleware/auth.ts
+  - apps/api/src/routes/preview-onboarding.ts
+  - apps/api/src/routes/profiles.ts
+  - apps/api/src/services/profile.ts
+  - apps/api/src/services/preview-onboarding.ts
+  - apps/api/src/routes/subjects.ts
+  - apps/api/src/services/subject.ts
+  - packages/schemas/src/preview-onboarding.ts
+  - packages/schemas/src/profiles.ts
+  - packages/schemas/src/subjects.ts
+code_patterns:
+  - Pre-signup intent is routing context, not account identity.
+  - Post-signup save target creates the real profile shape.
+  - Parent-intent users land in parent setup/home, not learner chat.
+  - Preview lessons are constrained and make no saved-memory claim.
+test_patterns:
+  - Co-located React Native Jest tests for routing and wizard state.
+  - API service/route tests for preview claim, profile creation, and access rules.
+  - E2E smoke for learner, parent, both, and not-sure onboarding branches.
+---
+
+# Spec: Trial Intent Save Onboarding
+
+**Date:** 2026-05-18
+
+## Overview
+
+### Problem
+
+The fastest way to prove MentoMate's value is a short lesson, but not every new user is primarily a learner. Some users arrive as parents who want to monitor and support a child. If every "try it" path drops users into the full app or a learner chat, monitoring parents misread the product as a student-only chat app.
+
+The app needs to do two things at once:
+
+- Let self-learners experience a focused lesson immediately.
+- Route parent-intent users toward child setup, linking, and the parent home before they feel misplaced.
+
+### Product Rule
+
+Intent first, identity later.
+
+A pre-signup answer routes the preview. A post-signup save choice creates the account/profile model.
+
+### Solution
+
+Add a lightweight pre-signup intent question and a constrained preview path. After signup, do not restart onboarding. Show a short save-and-personalize wizard that asks where to save the thing the user just tried: my learning, my child's learning, or both. The wizard creates the correct profile structure and lands the user on the correct home surface.
+
+## Scope
+
+### In Scope
+
+- A pre-signup intent screen:
+  - Me
+  - My child
+  - Both
+  - Not sure yet
+- A contained learner preview lesson for "Me" and optionally "Not sure yet".
+- A parent-oriented preview/setup path for "My child".
+- A "Both" branch that asks which setup to do first.
+- Signup handoff that preserves preview state.
+- Post-signup save wizard:
+  - Save to my learning
+  - Save to my child's learning
+  - Save to both
+- Profile creation rules for self, child, and both.
+- Session style and normal-session length preferences.
+- Landing rules after the wizard.
+- Failure modes for auth handoff, abandoned preview state, parent/child ambiguity, and consent.
+
+### Out of Scope
+
+- Replacing the full app onboarding system.
+- Showing the full tab shell during preview.
+- Homework photo upload during preview.
+- Profile switching during preview.
+- Library, progress, settings, reports, or saved memory during preview.
+- Free-text parent-to-child messages.
+- A separate subscription or billing trial change. This spec's "trial lesson" is a product preview, not `services/trial.ts` billing trial state.
+- Long subject-list onboarding.
+- Making the preview lesson an unlimited support chat.
+- Child-to-parent account invite/linking if no existing family-invite backend exists. V1 should support creating a child profile on the parent's account; separate-device invite/link can be a follow-up unless an invite service already exists by implementation time.
+
+## User Journeys
+
+### Self Learner
+
+1. User taps "Try a quick lesson".
+2. App asks: "Who are you setting this up for?"
+3. User chooses "Me".
+4. App asks: "What should we help with?"
+5. User enters a topic, for example "fractions".
+6. App opens a full-screen preview lesson.
+7. Header shows "Trial lesson: 3 questions left".
+8. First mentor message starts teaching immediately:
+
+   > Great, let's start with fractions. I'll explain one idea, then ask you a quick question.
+
+9. After 3 to 5 meaningful turns, the lesson stops with:
+
+   > Want me to save this and build your next lesson? Create a profile.
+
+10. User signs up.
+11. Save wizard asks where to save the lesson.
+12. User chooses "My learning".
+13. Wizard asks name, birth date/year, session style, and normal session length.
+14. App creates the learner profile, saves the preview topic/lesson, and lands in the learner continuation path.
+
+### Parent Monitoring A Child
+
+1. User taps "Try MentoMate".
+2. App asks: "Who are you setting this up for?"
+3. User chooses "My child".
+4. App does not open learner chat by default.
+5. App shows parent-oriented setup preview:
+   - Set up your parent account
+   - Add a child profile
+   - Link a child who has their own device, if supported
+   - Preview what a weekly insight looks like
+6. Primary CTA is "Create or link child".
+7. User signs up.
+8. Save wizard asks whether to create a child profile now.
+9. Wizard creates parent owner profile first, then child profile.
+10. App lands on parent home, not learner home.
+
+### Both
+
+1. User chooses "Both".
+2. App asks: "What do you want to set up first?"
+3. Options:
+   - My child first
+   - My learning first
+4. Default/recommended option is "My child first".
+5. If child first, route through parent setup and land on parent home.
+6. If my learning first, route through learner preview and later offer "Add child now" or "Later" in the save wizard.
+
+### Not Sure Yet
+
+1. User chooses "Not sure yet".
+2. App gives a low-commitment choice:
+   - Try a quick lesson
+   - See how parent setup works
+3. If they try a lesson, the post-signup save screen still asks where to save it.
+4. Their preview answer never locks them into a profile shape.
+
+## UX Requirements
+
+### Pre-Signup Intent Screen
+
+Copy:
+
+> Who are you setting this up for?
+
+Options:
+
+- Me
+- My child
+- Both
+- Not sure yet
+
+Rules:
+
+- This screen is not a legal identity decision.
+- Do not say "profile" yet.
+- Do not mention account structure.
+- Store this as preview routing context only.
+- The user can correct it later on the save screen.
+
+### Learner Preview Lesson
+
+The preview lesson looks like chat, but behaves like a guided demo lane.
+
+Required constraints:
+
+- Full-screen surface.
+- No tab bar.
+- No library, progress, More, settings, profile switching, or saved notes.
+- No homework photo upload in v1.
+- No mentor memory claims.
+- No "I will remember this" copy.
+- No open-ended forever chat.
+- Counter visible in the header, for example "Trial lesson: 3 questions left".
+- Maximum 5 assistant turns.
+- Maximum 5 user turns.
+- End with a save/signup CTA after 3 to 5 useful turns.
+
+Teaching rules:
+
+- The first assistant message teaches immediately.
+- Do not start with "Tell me about your goals."
+- The lesson should explain one idea, ask one quick question, respond to the answer, and show a small win.
+- The preview should prefer text-first. Voice can be added later after consent and account state are clear.
+
+### Parent Preview Path
+
+The parent preview is not a learner chat by default.
+
+It should show:
+
+- What setup does:
+  - create parent account
+  - add or link a child
+  - see progress and reports after learning happens
+- A sample weekly insight with clearly marked sample data.
+- A "Create or link child" CTA.
+- A secondary "Try a sample lesson first" CTA for parents who want to inspect the learner experience.
+
+Do not show:
+
+- A fake full dashboard that looks live.
+- Child data claims before a child profile exists.
+- Surveillance-flavored copy.
+- A prompt implying the parent must add a child before continuing forever.
+
+### Signup Handoff
+
+When the user starts signup from a preview, the app must preserve:
+
+- intent answer
+- preview path: learner, parent, both, not_sure
+- entered topic, if any
+- preview lesson id, if any
+- selected priority for both, if any
+- desired save target if already selected
+
+Existing auth redirect behavior lives in `apps/mobile/src/lib/pending-auth-redirect.ts`. Extend or pair it with a preview-onboarding store so signup returns to the save wizard instead of the generic profile gate.
+
+### Post-Signup Save Wizard
+
+Header copy:
+
+> Great, let's save this and make the next session fit.
+
+First wizard step:
+
+> Where should we save this?
+
+Options:
+
+- My learning
+- My child's learning
+- Both
+
+Rules:
+
+- Preselect based on pre-signup intent, but allow changing.
+- If there was a preview topic, show it in the summary, for example "Fractions".
+- If there was no preview topic, ask for one first subject only.
+- Do not ask for a long subject list.
+- Do not call this a new onboarding questionnaire.
+
+### Profile Basics
+
+If saving to my learning:
+
+- Ask display name.
+- Ask birth date or birth year, matching current create-profile requirements.
+- Create the owner profile.
+- Save/import preview to that profile.
+
+If saving to my child's learning:
+
+- Create parent owner profile first:
+  - parent display name
+  - parent birth date/year
+- Then create child profile:
+  - child nickname/display name
+  - child birth date/year
+  - consent-safe copy from the existing child create-profile flow
+- Keep active profile as parent after child creation.
+- Save/import preview to the child profile only after the child profile exists and consent state allows it.
+- Land on parent home.
+
+If saving to both:
+
+- Create the parent/adult learner profile first.
+- Ask whether to add the child now or later.
+- If add child now, create child profile and save/import the preview to both profiles only if the user explicitly chose "Both".
+- If later, save to the owner profile and land on parent-capable home with an "Add child" action.
+
+### Session Preferences
+
+After profile basics, ask only practical preferences:
+
+> How should sessions work?
+
+Options:
+
+- Audio-first
+- Text-first
+- Step-by-step
+- No preference
+
+Copy rule:
+
+- Do not label this "accommodations" in the wizard.
+- Later settings may call it "Learning preferences" or "Support needs".
+
+Then ask:
+
+For self:
+
+> How long do you usually want to study?
+
+For child:
+
+> How long do you usually study together?
+
+For both:
+
+> What should a normal session feel like?
+
+Options:
+
+- 10 min
+- 20 min
+- 30 min
+- 40+
+
+### Confirmation
+
+Show a concise plan:
+
+> Your first plan: 20-minute step-by-step sessions for fractions.
+
+CTA variants:
+
+- Self learner: "Continue lesson"
+- Parent with child: "Go to parent home"
+- Both child-first: "Open parent home"
+- Both self-first: "Continue lesson"
+
+## Routing And Landing Rules
+
+| Pre-signup intent | Preview route | Save default | Final landing |
+| --- | --- | --- | --- |
+| Me | Learner preview lesson | My learning | Learner continuation or Home learner surface |
+| My child | Parent setup preview | My child's learning | Parent home |
+| Both, child first | Parent setup preview | My child's learning | Parent home |
+| Both, me first | Learner preview lesson | Both | Continue lesson, then parent add-child prompt if not added |
+| Not sure, lesson | Learner preview lesson | Ask explicitly | Based on save target |
+| Not sure, parent preview | Parent setup preview | Ask explicitly | Based on save target |
+
+If the final account has an owner profile but zero linked children, existing app logic should treat the user as a solo learner unless they are in the middle of the child-first wizard. Do not use raw `isOwner` alone to show parent home.
+
+## Data And Architecture
+
+### Existing Surfaces To Reuse
+
+| Surface | Current file |
+| --- | --- |
+| Signup | `apps/mobile/src/app/(auth)/sign-up.tsx` |
+| Auth redirect handoff | `apps/mobile/src/app/(auth)/_layout.tsx`, `apps/mobile/src/lib/pending-auth-redirect.ts` |
+| No-profile authenticated gate | `apps/mobile/src/app/(app)/_layout.tsx` |
+| Profile creation | `apps/mobile/src/app/create-profile.tsx` |
+| Profile context and linked-child helpers | `apps/mobile/src/lib/profile.ts` |
+| Learner home and parent home | `apps/mobile/src/components/home/LearnerScreen.tsx`, `ParentHomeScreen.tsx` |
+| Session chat | `apps/mobile/src/app/(app)/session/index.tsx`, `apps/mobile/src/components/session/ChatShell.tsx` |
+| Profile API | `apps/api/src/routes/profiles.ts`, `apps/api/src/services/profile.ts` |
+| Subject creation | `apps/api/src/routes/subjects.ts`, `apps/api/src/services/subject.ts` |
+| Current onboarding dimensions | `apps/mobile/src/app/(app)/onboarding/*`, `apps/api/src/routes/onboarding.ts` |
+
+### New Mobile State
+
+Add a small preview onboarding state module, for example:
+
+`apps/mobile/src/lib/preview-onboarding-state.ts`
+
+State shape:
+
+```ts
+type PreviewIntent = 'self' | 'child' | 'both' | 'not_sure';
+type PreviewPath = 'learner_lesson' | 'parent_setup';
+type SaveTarget = 'self' | 'child' | 'both';
+
+interface PreviewOnboardingState {
+  intent: PreviewIntent;
+  path: PreviewPath;
+  topicText?: string;
+  previewSessionId?: string;
+  bothPriority?: 'child_first' | 'self_first';
+  preferredSaveTarget?: SaveTarget;
+  createdAt: string;
+}
+```
+
+Storage:
+
+- Use an Expo-safe key such as `mentomate_preview_onboarding_state`.
+- TTL: 24 hours.
+- Clear after successful save/import.
+- Clear on sign-out cleanup.
+- Do not store raw child names before signup unless the user typed one in the wizard.
+
+### New Mobile Routes
+
+Suggested route files:
+
+- `apps/mobile/src/app/preview/index.tsx`
+- `apps/mobile/src/app/preview/intent.tsx`
+- `apps/mobile/src/app/preview/topic.tsx`
+- `apps/mobile/src/app/preview/lesson.tsx`
+- `apps/mobile/src/app/preview/parent.tsx`
+- `apps/mobile/src/app/(app)/preview/save.tsx`
+
+The pre-auth `preview/*` routes live outside `(app)` so they are reachable before auth. The post-auth save route lives inside `(app)`, but `apps/mobile/src/app/(app)/_layout.tsx` must route no-profile users with preview state to the save wizard instead of the generic `CreateProfileGate`.
+
+### Preview Lesson API
+
+Use the internal term "preview lesson", not "billing trial".
+
+Two acceptable implementation modes:
+
+1. Preferred v1 if abuse controls are ready: server-backed preview lesson.
+2. Fallback v1 if public LLM risk is too high: deterministic scripted lesson with the same UI and save wizard.
+
+If server-backed, add:
+
+- `packages/schemas/src/preview-onboarding.ts`
+- `apps/api/src/routes/preview-onboarding.ts`
+- `apps/api/src/services/preview-onboarding.ts`
+
+Public endpoints:
+
+- `POST /v1/preview-onboarding/start`
+- `POST /v1/preview-onboarding/:previewId/messages`
+
+Authenticated endpoint:
+
+- `POST /v1/preview-onboarding/:previewId/claim`
+
+Auth middleware:
+
+- Add `/v1/preview-onboarding/` to `PUBLIC_PATHS` only for `start` and `messages`.
+- `claim` must require auth.
+- If route-level public matching cannot distinguish claim safely, split public and authenticated route prefixes.
+
+Preview lesson constraints:
+
+- Server hard cap: maximum 5 user messages per preview id.
+- Server hard cap: maximum 5 assistant responses per preview id.
+- Server hard cap: response text length.
+- Server hard cap: no tool/upload/image inputs.
+- No memory retrieval or memory writes.
+- No session, subject, retention, XP, streak, dashboard, or summary writes before claim.
+- LLM calls go through `services/llm/router.ts`.
+- Prompt and parser live in a dedicated preview service, not in route handlers.
+- Public preview calls require rate limiting by hashed device id plus IP fallback.
+
+Preview storage:
+
+- Store only what is needed to continue and claim:
+  - preview id
+  - intent/path
+  - topic text
+  - bounded transcript
+  - question count
+  - createdAt/expiresAt
+  - claimedAt
+- Do not write to profile-scoped tables until authenticated claim.
+- Do not store raw IP addresses.
+
+### Claim And Import
+
+`POST /preview-onboarding/:previewId/claim` receives:
+
+- targetProfileId
+- saveTarget
+- sessionStyle
+- sessionLengthMinutes
+
+It should:
+
+1. Verify the preview exists, is unexpired, and is not already claimed.
+2. Verify the target profile belongs to the authenticated account.
+3. For child targets, verify the parent owns or is linked to the child.
+4. If consent is required and not active, save the topic intent but do not import transcript into learning state until consent is active.
+5. Create or reuse a subject using existing subject creation patterns:
+   - use `subjectCreateSchema`
+   - preserve `rawInput`
+   - use `createSubjectWithStructure()` for actual subject setup
+6. Optionally create a real learning session with metadata:
+
+```ts
+{
+  source: 'preview_onboarding',
+  previewSessionId: string,
+  importedPreview: true,
+  saveTarget: 'self' | 'child' | 'both'
+}
+```
+
+7. Mark preview as claimed.
+8. Return next route:
+   - continue lesson/session
+   - parent home
+   - child setup continuation
+
+If the transcript import is deferred, the user-facing copy should say:
+
+> We'll use this topic for the first lesson once setup is complete.
+
+Do not claim that the full chat was saved when it was not.
+
+## Implementation Plan
+
+### Phase 1: Routing And Wizard Shell
+
+1. Add preview intent screens under `apps/mobile/src/app/preview/`.
+2. Add `preview-onboarding-state.ts` with TTL and sign-out cleanup.
+3. Add signup CTA wiring so preview starts signup with a pending save redirect.
+4. Modify `(app)/_layout.tsx` no-profile gate:
+   - if preview state exists, render/push the save wizard
+   - otherwise keep existing `CreateProfileGate`
+5. Add save wizard screens/components.
+6. Use existing `/profiles` POST to create owner and child profiles in sequence.
+7. Land self users in learner continuation and parent users in parent home.
+
+### Phase 2: Preview Lesson Engine
+
+1. Add schema definitions for preview intent, messages, and claim.
+2. Add public preview start/message routes with strict caps.
+3. Add preview service with prompt rules and LLM router use.
+4. Add rate limiting and observability for public preview calls.
+5. Add claim/import endpoint.
+6. Import preview topic into subject setup after profile creation.
+7. If transcript import is chosen, create a real session only after auth and target profile resolution.
+
+### Phase 3: Parent Link/Invite Upgrade
+
+1. If a separate-device child linking service exists, integrate it into the child-first wizard.
+2. If it does not exist, add a future family-invite spec.
+3. Keep "Create child profile on this device/account" as the v1 supported path.
+
+## Acceptance Criteria
+
+1. Given a signed-out user taps "Try a quick lesson", when the preview starts, then the first screen asks who they are setting it up for.
+2. Given the user chooses "Me", when they enter "fractions", then they enter a full-screen constrained preview lesson with no tab bar and a visible remaining-question counter.
+3. Given the user chooses "My child", when the next screen appears, then the default path is parent setup preview, not learner chat.
+4. Given the user chooses "Both", when asked what to set up first, then "My child first" is available and recommended.
+5. Given a preview lesson reaches its turn cap, when the mentor responds, then it stops with a create-profile/save CTA and does not keep accepting open-ended chat.
+6. Given the user signs up from a preview, when auth completes, then the app returns to the save wizard rather than the generic create-profile gate.
+7. Given a self learner chooses "Save to my learning", when they complete profile basics, then the owner profile is created and the preview topic is attached to that profile.
+8. Given a parent chooses "Save to my child's learning", when they complete setup, then the owner profile is created first, the child profile second, and the active profile remains the parent.
+9. Given a parent completes child setup, when the wizard finishes, then the app lands on parent home.
+10. Given the user changes their mind on the save screen, when they choose a different save target, then the app creates the profile structure implied by the save target, not by the original pre-signup answer.
+11. Given preview state is older than 24 hours, when signup completes, then the app falls back to normal profile creation with a friendly message instead of crashing or looping.
+12. Given no preview state exists, when a new signed-in account has no profile, then existing `CreateProfileGate` behavior remains unchanged.
+
+## Failure Modes
+
+| State | Trigger | User sees | Recovery |
+| --- | --- | --- | --- |
+| Preview state expires during signup | User starts preview, leaves, returns after TTL, then signs up | "That preview expired, but we can set up your first lesson now." | Fall back to normal save wizard asking for one topic, or normal create-profile gate if no topic is known |
+| User chose child pre-signup but now wants self | Save screen target changes from child to self | Self profile setup | Use save target as source of truth; discard child-first routing context |
+| Parent creates first child under free tier | First child profile is allowed by existing profile creation exception | Child setup succeeds | Existing `createProfileWithLimitCheck()` first-child allowance remains source of truth |
+| Parent tries to import preview to child with restricted consent | Child profile consent is `PENDING`, `PARENTAL_CONSENT_REQUESTED`, or `WITHDRAWN` | Topic is saved as setup intent, transcript is not imported as learning data | Import after consent if supported; otherwise start fresh lesson from saved topic |
+| Preview lesson API is abused | Public endpoint receives many starts/messages from same device/IP | Rate-limited preview error | Show "Try again later" and offer signup; log structured metric |
+| Public LLM route bypasses quota | Preview routes are public by design | No paid quota decrement happens | Dedicated preview cap/rate limit is mandatory; do not add preview routes to normal metering without an account/profile |
+| User refreshes web during preview | Browser loses in-memory state | Preview can restore from session storage if fresh | If restore fails, show intent screen again |
+| OAuth signup returns before profiles load | Auth completes but profile query is still loading | Neutral loading state | Existing profile loading timeout remains; save wizard waits for auth/account readiness |
+| Duplicate claim request | User double-taps continue or network retries | One claim wins, second gets idempotent claimed response | Claim endpoint is idempotent by preview id plus account id |
+| Both save target creates one profile then fails on second | Parent profile created, child creation fails | Wizard shows retryable child setup error | Keep parent profile; retry child creation; do not import preview to child until child exists |
+| Parent lands in learner home after child setup | Linked-child query stale after creating child | Parent briefly sees learner home or wrong CTA | Optimistically update profiles cache, invalidate `profiles`, and route to `/(app)/home` after child link exists |
+| "Trial" confused with subscription trial | Copy says "trial" near billing screens | User thinks payment trial started | Use internal "preview" in code; visible "Trial lesson" only in lesson header, not subscription surfaces |
+| No separate-device child link exists | Parent selects "link child" but backend is absent | Unsupported dead end | V1 should hide or mark link-own-device as "coming soon"; supported path is create child profile |
+
+## Testing Strategy
+
+### Mobile Unit Tests
+
+- `preview-onboarding-state.test.ts`
+  - saves, restores, expires, and clears state
+  - uses Expo-safe key
+  - clears on sign-out cleanup
+- `preview/intent.test.tsx`
+  - each intent routes to the correct preview path
+- `preview/lesson.test.tsx`
+  - no tab bar
+  - counter visible
+  - save CTA appears at cap
+  - upload/profile/library controls absent
+- `preview/parent.test.tsx`
+  - parent intent shows parent setup preview
+  - learner chat is not the default CTA
+- `(app)/_layout.test.tsx`
+  - no-profile plus preview state shows save wizard path
+  - no-profile without preview state keeps existing create-profile gate
+- `preview/save.test.tsx`
+  - save target overrides pre-signup intent
+  - child target creates parent then child
+  - both target offers add child now/later
+
+### API Tests
+
+If server-backed preview is implemented:
+
+- `preview-onboarding.test.ts`
+  - public start route accepts valid intent/topic
+  - message route enforces turn cap
+  - message route rejects upload/image input
+  - rate limit rejects abusive public requests
+  - preview messages use LLM router, not direct provider SDK
+- `preview-onboarding.claim.test.ts`
+  - claim requires auth
+  - claim rejects expired preview
+  - claim is idempotent
+  - self target verifies profile ownership
+  - child target verifies parent/child relationship
+  - restricted-consent child does not import transcript as learning data
+
+### E2E Smoke
+
+- Self learner: preview lesson -> signup -> save to my learning -> continue lesson.
+- Parent: intent child -> signup -> create parent + child -> parent home.
+- Both child-first: intent both -> child first -> parent home.
+- Not sure: intent not sure -> lesson -> signup -> choose child -> parent home.
+- Expired state: seed expired preview state -> signup -> friendly fallback.
+
+## Verification Before Done
+
+- Small-screen pass on Galaxy S10e dimensions for every preview and wizard step.
+- Confirm preview surfaces hide the tab bar.
+- Confirm no saved-memory copy appears before signup and save.
+- Confirm final landing by profile shape:
+  - self only -> learner
+  - child linked -> parent home
+  - both -> according to chosen priority and created profiles
+- Confirm `services/trial.ts` billing behavior is untouched.
+- Confirm no direct LLM provider call was added.
+- If prompt files are added or changed, run `pnpm eval:llm` and stage snapshots.
+
+## Decision Log
+
+- **2026-05-18:** Chosen pattern is "intent first, identity later." The pre-signup answer routes the preview. The post-signup save target creates the actual profile model.
+- **2026-05-18:** Parent-intent users do not default into learner chat. They see parent setup/child-link value first, with sample lesson as a secondary path.
+- **2026-05-18:** The preview lesson is internally named "preview" to avoid coupling to billing trial state, even if the visible lesson header can say "Trial lesson".
+- **2026-05-18:** Post-signup wizard should feel like saving the thing the user just did, not starting over with a generic onboarding questionnaire.

--- a/docs/specs/2026-05-18-trial-intent-save-onboarding.md
+++ b/docs/specs/2026-05-18-trial-intent-save-onboarding.md
@@ -75,6 +75,20 @@ A pre-signup answer routes the preview. A post-signup save choice creates the ac
 
 Add a lightweight pre-signup intent question and a constrained preview path. After signup, do not restart onboarding. Show a short save-and-personalize wizard that asks where to save the thing the user just tried: my learning, my child's learning, or both. The wizard creates the correct profile structure and lands the user on the correct home surface.
 
+### Reuse-First Constraint
+
+This is not a new app shell, a replacement Home, or a second full onboarding system. Reuse the existing auth, profile creation, session, subject, learner Home, and parent Home machinery wherever possible.
+
+New work should be a thin layer around the current product:
+
+- Signed-out preview routes.
+- Preview state handoff through signup.
+- Post-auth save wizard.
+- Optional bounded preview lesson API.
+- Small Parent Home hierarchy adjustments if the current ordering still feels noisy.
+
+Do not create a parallel profile model, a new bottom navigation system, a duplicate parent dashboard, a second subject-creation pipeline, or a broad feature-reveal framework for this spec.
+
 ## Scope
 
 ### In Scope
@@ -96,6 +110,7 @@ Add a lightweight pre-signup intent question and a constrained preview path. Aft
 - Session style and normal-session length preferences.
 - Landing rules after the wizard.
 - Failure modes for auth handoff, abandoned preview state, parent/child ambiguity, and consent.
+- Reuse of existing Home surfaces, with only a light Parent Home clarity pass if needed.
 
 ### Out of Scope
 
@@ -109,6 +124,8 @@ Add a lightweight pre-signup intent question and a constrained preview path. Aft
 - Long subject-list onboarding.
 - Making the preview lesson an unlimited support chat.
 - Child-to-parent account invite/linking if no existing family-invite backend exists. V1 should support creating a child profile on the parent's account; separate-device invite/link can be a follow-up unless an invite service already exists by implementation time.
+- Replacing learner Home, parent Home, the bottom nav, or the current parent dashboard.
+- Creating a new progressive feature-unlock system. Existing tabs/features can remain; this spec only changes entry, save, and first-landing emphasis.
 
 ## User Journeys
 
@@ -359,6 +376,34 @@ CTA variants:
 - Both child-first: "Open parent home"
 - Both self-first: "Continue lesson"
 
+### Account Shell And Overwhelm
+
+Current Home already contains much of the command-center behavior:
+
+- Learner Home already exposes homework help, ask anything, practice, study-new actions, and subject continuation.
+- Parent Home already exposes add-child setup, child cards, progress, reports, nudges, and tonight prompts.
+
+This spec should not rebuild those surfaces. The overwhelm fix is narrower:
+
+- Route users to the correct existing Home branch earlier.
+- Preserve stable bottom-nav anchors after account creation.
+- Emphasize one relevant primary action in Home instead of making every feature feel equally urgent.
+- Keep secondary actions available but quieter.
+
+For V1, do not hide or unlock major features dynamically. If an area is not useful yet, its empty state should point to an existing next action, such as continuing the first lesson or adding a child.
+
+### Parent Home Clarity Pass
+
+If parent-intent users still land on a visually busy Home after the new front door, adjust `ParentHomeScreen` by reordering and reweighting existing sections rather than adding new parent features.
+
+Preferred hierarchy:
+
+1. **Today**: one primary family action, such as add first child, help a child start, read a report, send a nudge, or inspect an attention item.
+2. **Children**: existing child cards with one obvious primary action per child.
+3. **Family**: existing family management and account-adjacent actions, quieter than the daily command area.
+
+The goal is a clearer parent Home, not a new dashboard.
+
 ## Routing And Landing Rules
 
 | Pre-signup intent | Preview route | Save default | Final landing |
@@ -388,6 +433,8 @@ If the final account has an owner profile but zero linked children, existing app
 | Profile API | `apps/api/src/routes/profiles.ts`, `apps/api/src/services/profile.ts` |
 | Subject creation | `apps/api/src/routes/subjects.ts`, `apps/api/src/services/subject.ts` |
 | Current onboarding dimensions | `apps/mobile/src/app/(app)/onboarding/*`, `apps/api/src/routes/onboarding.ts` |
+
+Reuse rule: prefer adapting these surfaces over creating preview-specific duplicates. Add new components only when the current component cannot safely be used because preview is signed out, intentionally constrained, or must avoid saved-memory/account claims.
 
 ### New Mobile State
 
@@ -544,6 +591,7 @@ Do not claim that the full chat was saved when it was not.
 5. Add save wizard screens/components.
 6. Use existing `/profiles` POST to create owner and child profiles in sequence.
 7. Land self users in learner continuation and parent users in parent home.
+8. Confirm existing learner Home and parent Home cover the target landing jobs before adding any new Home components.
 
 ### Phase 2: Preview Lesson Engine
 
@@ -561,6 +609,15 @@ Do not claim that the full chat was saved when it was not.
 2. If it does not exist, add a future family-invite spec.
 3. Keep "Create child profile on this device/account" as the v1 supported path.
 
+### Phase 4: Parent Home Clarity Pass, If Needed
+
+Only run this phase if implementation review or usability testing shows parent Home remains overwhelming after the new routing/save flow.
+
+1. Reorder existing `ParentHomeScreen` sections toward Today -> Children -> Family.
+2. Reuse existing child cards, reports, nudge actions, family summary, and add-child actions.
+3. Avoid adding new data dependencies unless an existing query already exposes the needed state.
+4. Keep learner Home unchanged unless trial/save routing reveals a concrete first-use bug.
+
 ## Acceptance Criteria
 
 1. Given a signed-out user taps "Try a quick lesson", when the preview starts, then the first screen asks who they are setting it up for.
@@ -575,6 +632,9 @@ Do not claim that the full chat was saved when it was not.
 10. Given the user changes their mind on the save screen, when they choose a different save target, then the app creates the profile structure implied by the save target, not by the original pre-signup answer.
 11. Given preview state is older than 24 hours, when signup completes, then the app falls back to normal profile creation with a friendly message instead of crashing or looping.
 12. Given no preview state exists, when a new signed-in account has no profile, then existing `CreateProfileGate` behavior remains unchanged.
+13. Given a user completes signup and profile setup, when they enter the full app, then the existing bottom navigation remains the stable account shell.
+14. Given a parent-intent user completes child setup, when they land on Home, then existing parent Home actions are reused and the top area presents one clear next family action.
+15. Given an area has no useful data yet, when the user opens it, then it shows a helpful empty state pointing to an existing next action rather than introducing a new feature gate.
 
 ## Failure Modes
 
@@ -655,6 +715,8 @@ If server-backed preview is implemented:
   - self only -> learner
   - child linked -> parent home
   - both -> according to chosen priority and created profiles
+- Confirm no duplicate Home, bottom nav, parent dashboard, profile model, or subject-creation path was introduced.
+- Confirm Parent Home changes, if any, reuse existing data and actions.
 - Confirm `services/trial.ts` billing behavior is untouched.
 - Confirm no direct LLM provider call was added.
 - If prompt files are added or changed, run `pnpm eval:llm` and stage snapshots.
@@ -665,3 +727,4 @@ If server-backed preview is implemented:
 - **2026-05-18:** Parent-intent users do not default into learner chat. They see parent setup/child-link value first, with sample lesson as a secondary path.
 - **2026-05-18:** The preview lesson is internally named "preview" to avoid coupling to billing trial state, even if the visible lesson header can say "Trial lesson".
 - **2026-05-18:** Post-signup wizard should feel like saving the thing the user just did, not starting over with a generic onboarding questionnaire.
+- **2026-05-18:** Current learner Home and parent Home already contain the main command-center ingredients. This spec should reuse them and change front-door routing, save handoff, and first-landing emphasis before adding new Home surfaces.


### PR DESCRIPTION
## Summary
- harden homework OCR escalation and add camera-permission bypass to type or record instead
- fix session wrap-up so filing prompts appear instead of leaving users stuck on Wrapping
- refine note/library behavior and add product docs for challenge rounds plus trial-intent onboarding

## Validation
- pre-commit hooks passed for mobile TypeScript changes, including related Jest suites
- pre-push validation passed
- docs-only commit ran prettier and skipped TS tests as expected