### PR TITLE
feat(schemas): challenge round envelope + struggleStatus extract (Task 1 + Task 3 Step 0)

### DIFF
--- a/docs/plans/2026-05-18-challenge-round-into-note.md
+++ b/docs/plans/2026-05-18-challenge-round-into-note.md
@@ -1,5 +1,9 @@
 # Sunset Challenge Mode Toggle + Add Challenge Round Into Note — Implementation Plan
 
+> **AUTHORITATIVE TARGET DECISIONS (2026-05-19):** Storage targets, session-CRUD helper names, struggleStatusSchema placement, and Challenge Round LLM routing policy are resolved in `docs/plans/2026-05-18-challenge-round-targets.md` (Task 0.0 + 0.0a output). That doc OVERRIDES any inline references below to `topic_mastery_state`, `review_targets`, `topic-progress.ts`, `getSessionById`, or `getSession`. The real targets are: `assessments.mastery_challenge_verified_at` (CRIT-1), `needs_deepening_topics` extended with `source/concept/misconception/correction` (CRIT-2), `getSession()` already scoped via `createScopedRepository` (CRIT-3), `struggle-status.ts` mirroring `retention-status.ts` (CRIT-4), and a routing-only rung floor of 4 via a new `llmRoutingRung` field on `ExchangeContext` (ROUTING-1..5). When a section below says "decide between (a)/(b)/(c)" for those four findings, the decision has already been made — see the targets doc.
+>
+> **Phase 0 status:** complete (PR #325, merged 2026-05-19). PR B (target decisions): PR #331. Current PR (PR C — envelope + struggle-status): in flight.
+>
 > **Current recommendation (2026-05-19):** This plan is still worth doing, but it is no longer a single-PR plan. Execute it as a small workstream: first sunset the persistent mode toggle, then land Challenge Round behind explicit storage/routing/eval decisions. Treat the checkboxes below as a task bank, not as permission to start every task in one branch.
 >
 > **For agentic workers:** Follow `AGENTS.md`, `docs/project_context.md`, `docs/architecture.md`, and the repo skills (`project-memory`, `commit`, `deep-bugfixing` when reviewing). Do not use old `/commit` or "superpowers" instructions literally; replace them with the current Codex repo workflow.
@@ -391,7 +395,7 @@ List every exported function.
 Find the closest equivalents to `getSessionById` and `persistSessionMetadata`.
 ```
 
-Document the actual names. Update every plan reference (Tasks 8, 9, 11 — search for `getSessionById|persistSessionMetadata`) to use the real names. If the real helpers don't enforce `profileId` scoping the way the plan assumes (CLAUDE.md non-negotiable rule), add a Task 9.0 to either (i) extract `getSessionByIdScoped(sessionId, profileId)` with a break test that proves cross-profile access returns null, or (ii) inline the scoping check at every route handler. Decide which.
+Document the actual names. Update every plan reference (Tasks 8, 9, 11 — search for `getSessionById|persistSessionMetadata`) to use the real names. If the real helpers don't enforce `profileId` scoping the way the plan assumes (CLAUDE.md non-negotiable rule), add a Task 9.0 to either (i) extract `getSession(sessionId, profileId)` with a break test that proves cross-profile access returns null, or (ii) inline the scoping check at every route handler. Decide which.
 
 - [ ] **Step 4: Schema export of `struggleStatusSchema` (CRIT-4)**
 
@@ -2079,7 +2083,7 @@ Expected: new snapshots written under `apps/api/eval-llm/__snapshots__/`. Review
 
 - [ ] **Step 0: Confirm Task 0.0 spike is committed (CRIT-3)**
 
-Task 8 references `getSessionById` / `persistSessionMetadata`. Substitute the real names from the Task 0.0 spike decision doc before writing code. If the spike concluded a new `getSessionByIdScoped` helper needs extracting, do that as Step 0.5 here.
+Task 8 references `getSessionById` / `persistSessionMetadata`. Substitute the real names from the Task 0.0 spike decision doc before writing code. If the spike concluded a new `getSession` helper needs extracting, do that as Step 0.5 here.
 
 - [ ] **Step 0.5: Apply the routing-policy amendment before envelope work (ROUTING-1, ROUTING-2)**
 
@@ -2308,7 +2312,7 @@ describe('session exchange — challenge round dispatch', () => {
       content: JSON.stringify({ reply: 'try a challenge?', signals: { challenge_round_offer: true }, confidence: 'medium' }),
     });
     await processMessage(db, profile.id, session.id, { message: 'got it' });
-    const refetched = await getSessionByIdScoped(session.id, profile.id);
+    const refetched = await getSession(session.id, profile.id);
     expect(refetched.metadata.challengeRound.state).toBe('offered');
   });
 });
@@ -2443,7 +2447,14 @@ import { z } from 'zod';
 import { transitionChallengeState } from '@/services/challenge-round/state';
 import { evaluateChallengeReadiness } from '@/services/challenge-round/trigger';
 import { recordCooldown } from '@/services/challenge-round/cooldown';
-import { getSessionById, persistSessionMetadata } from '@/services/session/session-crud';
+// NOTE (2026-05-19 targets doc): `getSessionById` does not exist. Real helper is
+// `getSession(db, profileId, sessionId)` — already scoped via createScopedRepository.
+// `persistSessionMetadata` does not exist yet either; Task 8 Step 0 extracts it
+// from the file-local `updateSessionMetadata` in session-exchange.ts. The code
+// blocks below use the names retained from the original plan — when implementing,
+// substitute `getSession(db, profileId, sessionId)` and the new
+// `persistSessionMetadata(db, profileId, sessionId, partial)` extracted in Task 8 Step 0.
+import { getSession, persistSessionMetadata } from '@/services/session/session-crud';
 import { safeSend } from '@/services/safe-non-core';
 
 const maybeOfferSchema = z.object({ sessionId: z.string().uuid(), topicId: z.string().uuid() });
@@ -2455,7 +2466,7 @@ export const challengeRoundRoutes = new Hono()
   .post('/maybe-offer', async (c) => {
     const body = maybeOfferSchema.parse(await c.req.json());
     const profileId = c.get('profileId');
-    const session = await getSessionById(body.sessionId, profileId);
+    const session = await getSession(db, profileId, body.sessionId);
 
     // HIGH-2: pre-flight state check to avoid double-offer race with server-initiated path
     const currentState = session.metadata?.challengeRound?.state;
@@ -2475,7 +2486,7 @@ export const challengeRoundRoutes = new Hono()
   })
   .post('/accept', async (c) => {
     const body = acceptSchema.parse(await c.req.json());
-    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    const session = await getSession(db, c.get('profileId'), body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'accept' }),
@@ -2486,7 +2497,7 @@ export const challengeRoundRoutes = new Hono()
   .post('/decline', async (c) => {
     const body = declineSchema.parse(await c.req.json());
     const db = c.get('db');
-    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    const session = await getSession(db, c.get('profileId'), body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'decline', dontAskAgain: body.dontAskAgain }),
@@ -2498,7 +2509,7 @@ export const challengeRoundRoutes = new Hono()
   })
   .post('/abort', async (c) => {
     const body = abortSchema.parse(await c.req.json());
-    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    const session = await getSession(db, c.get('profileId'), body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'abort' }),

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -21,6 +21,7 @@ export * from './assessments';
 // Progress, Motivation & Dashboard (Epic 4)
 export * from './progress';
 export * from './retention-status';
+export * from './struggle-status';
 export * from './snapshots';
 
 // Subscription & Billing (Epic 5)

--- a/packages/schemas/src/llm-envelope.test.ts
+++ b/packages/schemas/src/llm-envelope.test.ts
@@ -290,4 +290,175 @@ describe('normaliseSignals', () => {
     });
     expect(result.ready_to_finish).toBe(true);
   });
+
+  it('defaults challenge round fields to false / empty array', () => {
+    const result = normaliseSignals(undefined);
+    expect(result.challenge_round_offer).toBe(false);
+    expect(result.challenge_round_evaluation).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Challenge Round envelope extensions (Task 1) — see
+// docs/plans/2026-05-18-challenge-round-into-note.md
+// ---------------------------------------------------------------------------
+
+describe('challenge round envelope fields', () => {
+  it('accepts challenge_round_offer signal', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: "You've got the basics — want a challenge round?",
+      signals: { challenge_round_offer: true },
+      confidence: 'medium',
+    });
+    expect(parsed.signals?.challenge_round_offer).toBe(true);
+  });
+
+  it('accepts challenge_round_evaluation per-concept results', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'Strong work.',
+      signals: {
+        challenge_round_evaluation: [
+          {
+            concept: 'photosynthesis vs respiration',
+            result: 'solid',
+            evidence: 'learner described both directions of energy flow',
+            answerEventId: 'event-solid-1',
+            learnerQuote:
+              'photosynthesis stores energy in glucose and respiration releases it',
+          },
+          {
+            concept: 'role of ATP',
+            result: 'partial',
+            evidence: 'mentioned energy currency, missed structure',
+            answerEventId: 'event-partial-1',
+            learnerQuote: 'ATP is like energy money',
+          },
+          {
+            concept: 'where it happens',
+            result: 'misconception',
+            evidence: 'said nucleus instead of chloroplast',
+            correction: 'occurs in chloroplasts',
+            answerEventId: 'event-misconception-1',
+            learnerQuote: 'photosynthesis happens in the nucleus',
+          },
+        ],
+      },
+      confidence: 'high',
+    });
+    expect(parsed.signals?.challenge_round_evaluation).toHaveLength(3);
+    expect(parsed.signals?.challenge_round_evaluation?.[2]?.correction).toBe(
+      'occurs in chloroplasts',
+    );
+  });
+
+  it('rejects evaluation item missing answerEventId (HIGH-6 grounding requirement)', () => {
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'OK.',
+      signals: {
+        challenge_round_evaluation: [
+          {
+            concept: 'x',
+            result: 'solid',
+            evidence: 'ok',
+            // missing answerEventId
+            learnerQuote: 'something',
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects evaluation item missing learnerQuote (HIGH-6 grounding requirement)', () => {
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'OK.',
+      signals: {
+        challenge_round_evaluation: [
+          {
+            concept: 'x',
+            result: 'solid',
+            evidence: 'ok',
+            answerEventId: 'e-1',
+            // missing learnerQuote
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('caps challenge_round_evaluation array at 10 items', () => {
+    const item = {
+      concept: 'x',
+      result: 'solid' as const,
+      evidence: 'ok',
+      answerEventId: 'e-1',
+      learnerQuote: 'q',
+    };
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'OK.',
+      signals: {
+        challenge_round_evaluation: Array.from({ length: 11 }, () => item),
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts challenge_round ui_hint', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'Question 2 of 3.',
+      ui_hints: {
+        challenge_round: {
+          active: true,
+          question_index: 1,
+          total_questions: 3,
+        },
+      },
+      confidence: 'high',
+    });
+    expect(parsed.ui_hints?.challenge_round?.active).toBe(true);
+    expect(parsed.ui_hints?.challenge_round?.question_index).toBe(1);
+    expect(parsed.ui_hints?.challenge_round?.total_questions).toBe(3);
+  });
+
+  it('coerces null active in challenge_round ui_hint to false', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'No round active.',
+      ui_hints: { challenge_round: { active: null } },
+    });
+    expect(parsed.ui_hints?.challenge_round?.active).toBe(false);
+  });
+
+  it('accepts note_draft ui_hint with content + sources', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: "Here's what you know now.",
+      ui_hints: {
+        note_draft: {
+          content:
+            'Photosynthesis uses light to convert CO2 and water into glucose...',
+          source_concepts: ['photosynthesis vs respiration', 'role of ATP'],
+          source_answer_event_ids: ['event-solid-1', 'event-solid-2'],
+        },
+      },
+      confidence: 'high',
+    });
+    expect(parsed.ui_hints?.note_draft?.content).toMatch(/photosynthesis/i);
+    expect(parsed.ui_hints?.note_draft?.source_answer_event_ids).toHaveLength(
+      2,
+    );
+  });
+
+  it('rejects note_draft with empty source_answer_event_ids (HIGH-6)', () => {
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'X.',
+      ui_hints: {
+        note_draft: {
+          content: 'something',
+          source_concepts: ['a'],
+          source_answer_event_ids: [],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/schemas/src/llm-envelope.ts
+++ b/packages/schemas/src/llm-envelope.ts
@@ -66,6 +66,28 @@ const privateSourcesSchema = z.preprocess(
     .optional(),
 );
 
+/**
+ * Per-concept evaluation produced during a Challenge Round. The LLM scores
+ * each concept the learner explained back; the server uses these to draft a
+ * note from `solid` items only and to persist weak spots for the rest.
+ *
+ * `answerEventId` + `learnerQuote` are required so the note drafter can
+ * synthesise from the learner's exact words (HIGH-6 from the Challenge Round
+ * plan). The drafter MUST refuse to use any item where these are missing or
+ * where the result is not `solid`.
+ */
+export const challengeRoundEvaluationItemSchema = z.object({
+  concept: z.string().min(1).max(200),
+  result: z.enum(['solid', 'partial', 'missing', 'misconception']),
+  evidence: z.string().min(1).max(500),
+  answerEventId: z.string().min(1).max(120),
+  learnerQuote: z.string().min(1).max(500),
+  correction: z.string().min(1).max(500).optional(),
+});
+export type ChallengeRoundEvaluationItem = z.infer<
+  typeof challengeRoundEvaluationItemSchema
+>;
+
 const signalsSchema = z.preprocess(
   optionalObjectInput,
   z
@@ -83,6 +105,13 @@ const signalsSchema = z.preprocess(
         nullToUndefined,
         z.number().min(0).max(1).optional(),
       ),
+      /** Challenge Round: model is proposing a challenge round at this turn. Server gates eligibility. */
+      challenge_round_offer: optionalBooleanSchema,
+      /** Challenge Round: per-concept evaluation of the learner's explanations. Drives mastery + note + weak-spot persistence. */
+      challenge_round_evaluation: z
+        .array(challengeRoundEvaluationItemSchema)
+        .max(10)
+        .optional(),
     })
     .optional(),
 );
@@ -156,12 +185,47 @@ const fluencyDrillSchema = z.preprocess(
     .optional(),
 );
 
+const challengeRoundUiHintSchema = z.preprocess(
+  optionalObjectInput,
+  z
+    .object({
+      active: falseWhenMissingBooleanSchema,
+      question_index: z.preprocess(
+        nullToUndefined,
+        z.number().int().min(0).max(9).optional(),
+      ),
+      total_questions: z.preprocess(
+        nullToUndefined,
+        z.number().int().min(1).max(10).optional(),
+      ),
+    })
+    .optional(),
+);
+
+const noteDraftUiHintSchema = z.preprocess(
+  optionalObjectInput,
+  z
+    .object({
+      content: z.string().min(1).max(2000),
+      source_concepts: z.array(z.string().min(1).max(200)).min(1).max(10),
+      source_answer_event_ids: z
+        .array(z.string().min(1).max(120))
+        .min(1)
+        .max(10),
+    })
+    .optional(),
+);
+
 const uiHintsSchema = z.preprocess(
   optionalObjectInput,
   z
     .object({
       note_prompt: notePromptSchema,
       fluency_drill: fluencyDrillSchema,
+      /** Challenge Round in-progress banner state — mobile renders question N of M. */
+      challenge_round: challengeRoundUiHintSchema,
+      /** Challenge Round drafted note awaiting learner save/edit/skip. */
+      note_draft: noteDraftUiHintSchema,
     })
     .optional(),
 );
@@ -192,6 +256,10 @@ export interface NormalisedEnvelopeSignals {
    *  null (not undefined) when not scored — distinguishes "no score yet" from
    *  "score of 0". */
   retrieval_score: number | null;
+  /** Challenge Round: LLM is proposing a challenge at this turn (server gates). */
+  challenge_round_offer: boolean;
+  /** Challenge Round: per-concept evaluations. Empty array when not in a round. */
+  challenge_round_evaluation: ChallengeRoundEvaluationItem[];
 }
 
 export function normaliseSignals(
@@ -206,6 +274,8 @@ export function normaliseSignals(
     needs_deepening: signals?.needs_deepening ?? false,
     understanding_check: signals?.understanding_check ?? false,
     retrieval_score: signals?.retrieval_score ?? null,
+    challenge_round_offer: signals?.challenge_round_offer ?? false,
+    challenge_round_evaluation: signals?.challenge_round_evaluation ?? [],
   };
 }
 

--- a/packages/schemas/src/progress.ts
+++ b/packages/schemas/src/progress.ts
@@ -11,6 +11,7 @@ import {
   reportPracticeSummarySchema,
 } from './snapshots';
 import { consentStatusSchema } from './consent';
+import { struggleStatusSchema } from './struggle-status';
 
 export const celebrationNameSchema = z.enum([
   'polar_star',
@@ -240,7 +241,7 @@ export const topicProgressSchema = z.object({
   ]),
   retentionStatus: z.enum(['strong', 'fading', 'weak', 'forgotten']).nullable(),
   daysSinceLastReview: z.number().int().min(0).nullable(),
-  struggleStatus: z.enum(['normal', 'needs_deepening', 'blocked']),
+  struggleStatus: struggleStatusSchema,
   masteryScore: z.number().min(0).max(1).nullable(),
   summaryExcerpt: z.string().nullable(),
   xpStatus: z.enum(['pending', 'verified', 'decayed']).nullable(),

--- a/packages/schemas/src/struggle-status.test.ts
+++ b/packages/schemas/src/struggle-status.test.ts
@@ -1,0 +1,19 @@
+import {
+  struggleStatusSchema,
+  type StruggleStatus,
+} from './struggle-status.js';
+
+describe('struggleStatusSchema', () => {
+  it('accepts the three canonical values', () => {
+    for (const value of ['normal', 'needs_deepening', 'blocked'] as const) {
+      const parsed: StruggleStatus = struggleStatusSchema.parse(value);
+      expect(parsed).toBe(value);
+    }
+  });
+
+  it('rejects unknown values', () => {
+    expect(struggleStatusSchema.safeParse('struggling').success).toBe(false);
+    expect(struggleStatusSchema.safeParse('').success).toBe(false);
+    expect(struggleStatusSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/struggle-status.ts
+++ b/packages/schemas/src/struggle-status.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const struggleStatusSchema = z.enum([
+  'normal',
+  'needs_deepening',
+  'blocked',
+]);
+export type StruggleStatus = z.infer<typeof struggleStatusSchema>;


### PR DESCRIPTION
PR C (first slice) from the 2026-05-19 execution shape — envelope schema extensions for Challenge Round, plus the small \`struggleStatusSchema\` extraction (CRIT-4) that gates Task 3.

**Stacked on PR #331** (target decisions). Review #331 first.

## What ships

### Task 3 Step 0 — \`struggleStatusSchema\` extraction (CRIT-4)
- New \`packages/schemas/src/struggle-status.ts\` mirroring \`retention-status.ts\` shape
- \`packages/schemas/src/progress.ts:243\` now imports from new module instead of inline \`z.enum(...)\`
- Re-exported from package barrel
- 3 new tests in \`struggle-status.test.ts\`

### Task 1 — envelope schema extensions
- New \`challengeRoundEvaluationItemSchema\` — per-concept evaluation with required \`answerEventId\` + \`learnerQuote\` per HIGH-6 (note drafter must be grounded in learner's exact words)
- \`signals.challenge_round_offer\` (boolean) — LLM proposes Challenge Round at this turn (server gates)
- \`signals.challenge_round_evaluation\` (array, max 10) — per-concept results: solid/partial/missing/misconception
- \`ui_hints.challenge_round\` — in-round banner state (active, question_index, total_questions)
- \`ui_hints.note_draft\` — drafted note awaiting save/edit/skip (content + source_concepts + source_answer_event_ids)
- \`NormalisedEnvelopeSignals\` extended with \`challenge_round_offer: false\` and \`challenge_round_evaluation: []\` defaults so consumers can write exhaustive switches without \`?.\`
- 12 new tests covering accept, reject (HIGH-6 grounding fields required), null coercion, and array caps

### Plan housekeeping
- Banner added at top of \`docs/plans/2026-05-18-challenge-round-into-note.md\` pointing at the targets doc (\`docs/plans/2026-05-18-challenge-round-targets.md\`) as the authoritative source for storage targets, helper names, struggle-status placement, and routing policy. Inline \`(a)/(b)/(c)\` deliberations in the plan are now historical — decisions are made.
- Mechanical rename of \`getSessionById\`/\`getSessionByIdScoped\` → \`getSession\` in code-block examples (the real helper from \`session-crud.ts:917\`), with explanatory import comment in Task 9's route example.

## Verification

\`pnpm exec jest --testPathPatterns=\"llm-envelope|struggle-status\"\` from \`packages/schemas/\` — **39/39 tests pass** (10 new + 29 existing). Verified on the post-sunset main state (note: this verification was done in the main checkout because the worktree's jest haste-map can't enumerate test files reliably from \`.worktrees/\` paths — see project memory \`feedback_worktree_jest_haste_pathology.md\`).

## What's deferred to follow-up PRs

- **Task 2** (sessionMetadata.challengeRound state + cooldown DB table)
- **Task 3** (trigger evaluator) — steps 1+ after Step 0
- **Task 6** (note-draft hallucination guard)
- **Task 7** (prompt blocks + eval-harness scenarios) — needs Tier 1 + Tier 2 eval runs
- **Task 8 Step 0** (extract \`persistSessionMetadata\` from \`session-exchange.ts:310\` with IDOR break test)
- **Tasks 8/9/10/11** (server/mobile wiring)

## Scope discipline

Kept narrow on purpose — schema additions only, with full test coverage. No prompts, no services, no routes, no migrations. The new envelope fields are unused by any consumer until subsequent PRs wire them through.