### PR TITLE
feat(api): challenge round trigger evaluator + sessionMetadata state + cooldown table (Task 2 + Task 3)

### DIFF
--- a/apps/api/drizzle/0080_slippery_groot.rollback.md
+++ b/apps/api/drizzle/0080_slippery_groot.rollback.md
@@ -1,0 +1,36 @@
+## Rollback — 0080 challenge_round_cooldowns
+
+### Rollback possible?
+
+Yes. The migration is purely additive — it creates a new standalone table for
+the Challenge Round per-`(profile_id, topic_id)` decline cooldown. No data is
+altered on any existing table, and no other table references this one yet.
+
+### Data loss
+
+Dropping the table loses any accumulated cooldown rows. Functional impact: a
+learner who previously declined a Challenge Round offer for a given topic
+could be re-offered the round before the 24h cooldown window naturally
+elapses. This is user-visible but non-destructive — no learning state, no
+mastery, no notes are affected. The trigger evaluator falls back to its
+non-cooldown gates (struggle, retention, streak, quota) when the cooldown
+row is absent.
+
+Pre-launch, no real user data exists.
+
+### Recovery procedure
+
+```sql
+DROP TABLE IF EXISTS "challenge_round_cooldowns";
+```
+
+The FKs cascade with the table drop. No additional cleanup needed.
+
+### Caveats
+
+- Any service or route that writes to `challenge_round_cooldowns` (added in
+  subsequent Task 9 work — `recordCooldown` helper and `/decline` route) must
+  be reverted in the same deploy as the table drop; otherwise the writer will
+  500 with `relation "challenge_round_cooldowns" does not exist`. In this PR
+  the table is added without any reader/writer wiring yet, so the rollback
+  surface is currently nil.

--- a/apps/api/drizzle/0080_slippery_groot.sql
+++ b/apps/api/drizzle/0080_slippery_groot.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "challenge_round_cooldowns" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"profile_id" uuid NOT NULL,
+	"topic_id" uuid NOT NULL,
+	"last_offered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_outcome" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "challenge_round_cooldowns_profile_topic_unique" UNIQUE("profile_id","topic_id")
+);
+--> statement-breakpoint
+ALTER TABLE "challenge_round_cooldowns" ADD CONSTRAINT "challenge_round_cooldowns_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "challenge_round_cooldowns" ADD CONSTRAINT "challenge_round_cooldowns_topic_id_curriculum_topics_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."curriculum_topics"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/api/drizzle/0080_slippery_groot.sql
+++ b/apps/api/drizzle/0080_slippery_groot.sql
@@ -6,8 +6,10 @@ CREATE TABLE "challenge_round_cooldowns" (
 	"last_outcome" integer,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "challenge_round_cooldowns_last_outcome_range" CHECK ("last_outcome" IS NULL OR ("last_outcome" >= 0 AND "last_outcome" <= 3)),
 	CONSTRAINT "challenge_round_cooldowns_profile_topic_unique" UNIQUE("profile_id","topic_id")
 );
 --> statement-breakpoint
 ALTER TABLE "challenge_round_cooldowns" ADD CONSTRAINT "challenge_round_cooldowns_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "challenge_round_cooldowns" ADD CONSTRAINT "challenge_round_cooldowns_topic_id_curriculum_topics_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."curriculum_topics"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "challenge_round_cooldowns" ADD CONSTRAINT "challenge_round_cooldowns_topic_id_curriculum_topics_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."curriculum_topics"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "challenge_round_cooldowns" ENABLE ROW LEVEL SECURITY;

--- a/apps/api/drizzle/meta/0080_snapshot.json
+++ b/apps/api/drizzle/meta/0080_snapshot.json
@@ -1292,8 +1292,13 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
+      "checkConstraints": {
+        "challenge_round_cooldowns_last_outcome_range": {
+          "name": "challenge_round_cooldowns_last_outcome_range",
+          "value": "\"challenge_round_cooldowns\".\"last_outcome\" IS NULL OR (\"challenge_round_cooldowns\".\"last_outcome\" >= 0 AND \"challenge_round_cooldowns\".\"last_outcome\" <= 3)"
+        }
+      },
+      "isRLSEnabled": true
     },
     "public.dictation_results": {
       "name": "dictation_results",

--- a/apps/api/drizzle/meta/0080_snapshot.json
+++ b/apps/api/drizzle/meta/0080_snapshot.json
@@ -1,0 +1,7346 @@
+{
+  "id": "ddd2ea60-c609-411a-a23c-3119fa38fe8d",
+  "prevId": "831b880d-bc95-43c6-8b0e-d4a086bb7a43",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assessments": {
+      "name": "assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_depth": {
+          "name": "verification_depth",
+          "type": "verification_depth",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recall'"
+        },
+        "status": {
+          "name": "status",
+          "type": "assessment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "mastery_score": {
+          "name": "mastery_score",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_rating": {
+          "name": "quality_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_history": {
+          "name": "exchange_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assessments_profile_topic_idx": {
+          "name": "assessments_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assessments_topic_id_idx": {
+          "name": "assessments_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assessments_profile_id_profiles_id_fk": {
+          "name": "assessments_profile_id_profiles_id_fk",
+          "tableFrom": "assessments",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessments_subject_id_subjects_id_fk": {
+          "name": "assessments_subject_id_subjects_id_fk",
+          "tableFrom": "assessments",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessments_topic_id_curriculum_topics_id_fk": {
+          "name": "assessments_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "assessments",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assessments_session_id_learning_sessions_id_fk": {
+          "name": "assessments_session_id_learning_sessions_id_fk",
+          "tableFrom": "assessments",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "assessments_mastery_score_range": {
+          "name": "assessments_mastery_score_range",
+          "value": "\"assessments\".\"mastery_score\" IS NULL OR (\"assessments\".\"mastery_score\" >= 0 AND \"assessments\".\"mastery_score\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.needs_deepening_topics": {
+      "name": "needs_deepening_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "needs_deepening_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "consecutive_success_count": {
+          "name": "consecutive_success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "needs_deepening_profile_topic_idx": {
+          "name": "needs_deepening_profile_topic_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "needs_deepening_topic_id_idx": {
+          "name": "needs_deepening_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "needs_deepening_topics_profile_id_profiles_id_fk": {
+          "name": "needs_deepening_topics_profile_id_profiles_id_fk",
+          "tableFrom": "needs_deepening_topics",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "needs_deepening_topics_subject_id_subjects_id_fk": {
+          "name": "needs_deepening_topics_subject_id_subjects_id_fk",
+          "tableFrom": "needs_deepening_topics",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "needs_deepening_topics_topic_id_curriculum_topics_id_fk": {
+          "name": "needs_deepening_topics_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "needs_deepening_topics",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_cards": {
+      "name": "retention_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consecutive_successes": {
+          "name": "consecutive_successes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "xp_status": {
+          "name": "xp_status",
+          "type": "xp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "evaluate_difficulty_rung": {
+          "name": "evaluate_difficulty_rung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_cards_review_idx": {
+          "name": "retention_cards_review_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_cards_profile_id_profiles_id_fk": {
+          "name": "retention_cards_profile_id_profiles_id_fk",
+          "tableFrom": "retention_cards",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_cards_topic_id_curriculum_topics_id_fk": {
+          "name": "retention_cards_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "retention_cards",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "retention_cards_profile_topic_unique": {
+          "name": "retention_cards_profile_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "topic_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "retention_cards_interval_days_positive": {
+          "name": "retention_cards_interval_days_positive",
+          "value": "\"retention_cards\".\"interval_days\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teaching_preferences": {
+      "name": "teaching_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "teaching_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analogy_domain": {
+          "name": "analogy_domain",
+          "type": "analogy_domain",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "native_language": {
+          "name": "native_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teaching_preferences_profile_id_profiles_id_fk": {
+          "name": "teaching_preferences_profile_id_profiles_id_fk",
+          "tableFrom": "teaching_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teaching_preferences_subject_id_subjects_id_fk": {
+          "name": "teaching_preferences_subject_id_subjects_id_fk",
+          "tableFrom": "teaching_preferences",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teaching_preferences_profile_subject_unique": {
+          "name": "teaching_preferences_profile_subject_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "subject_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_waitlist": {
+      "name": "byok_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "byok_waitlist_email_unique": {
+          "name": "byok_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_pools": {
+      "name": "quota_pools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_limit": {
+          "name": "monthly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "used_this_month": {
+          "name": "used_this_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_today": {
+          "name": "used_today",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cycle_reset_at": {
+          "name": "cycle_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quota_pools_subscription_id_subscriptions_id_fk": {
+          "name": "quota_pools_subscription_id_subscriptions_id_fk",
+          "tableFrom": "quota_pools",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quota_pools_subscription_id_unique": {
+          "name": "quota_pools_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "quota_pools_used_this_month_non_negative": {
+          "name": "quota_pools_used_this_month_non_negative",
+          "value": "\"quota_pools\".\"used_this_month\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "subscription_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trial'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_stripe_event_timestamp": {
+          "name": "last_stripe_event_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_original_app_user_id": {
+          "name": "revenuecat_original_app_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_revenuecat_event_id": {
+          "name": "last_revenuecat_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_revenuecat_event_timestamp_ms": {
+          "name": "last_revenuecat_event_timestamp_ms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_account_revenuecat_event_id_idx": {
+          "name": "subscriptions_account_revenuecat_event_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_revenuecat_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"last_revenuecat_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_account_id_accounts_id_fk": {
+          "name": "subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_account_id_unique": {
+          "name": "subscriptions_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["account_id"]
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_customer_id"]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["stripe_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.top_up_credits": {
+      "name": "top_up_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_transaction_id": {
+          "name": "revenuecat_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "top_up_credits_subscription_id_idx": {
+          "name": "top_up_credits_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "top_up_credits_rc_txn_id_idx": {
+          "name": "top_up_credits_rc_txn_id_idx",
+          "columns": [
+            {
+              "expression": "revenuecat_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "top_up_credits_subscription_id_subscriptions_id_fk": {
+          "name": "top_up_credits_subscription_id_subscriptions_id_fk",
+          "tableFrom": "top_up_credits",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "top_up_credits_remaining_non_negative": {
+          "name": "top_up_credits_remaining_non_negative",
+          "value": "\"top_up_credits\".\"remaining\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_events": {
+      "name": "usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delta": {
+          "name": "delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "usage_events_subscription_occurred_idx": {
+          "name": "usage_events_subscription_occurred_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_events_profile_occurred_idx": {
+          "name": "usage_events_profile_occurred_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_events_subscription_id_subscriptions_id_fk": {
+          "name": "usage_events_subscription_id_subscriptions_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_events_profile_id_profiles_id_fk": {
+          "name": "usage_events_profile_id_profiles_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "usage_events_delta_range": {
+          "name": "usage_events_delta_range",
+          "value": "\"usage_events\".\"delta\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_profile_id_idx": {
+          "name": "bookmarks_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_session_id_idx": {
+          "name": "bookmarks_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_profile_event_unique": {
+          "name": "bookmarks_profile_event_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_profile_id_profiles_id_fk": {
+          "name": "bookmarks_profile_id_profiles_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_subject_id_subjects_id_fk": {
+          "name": "bookmarks_subject_id_subjects_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_topic_id_curriculum_topics_id_fk": {
+          "name": "bookmarks_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_round_cooldowns": {
+      "name": "challenge_round_cooldowns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_offered_at": {
+          "name": "last_offered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_round_cooldowns_profile_id_profiles_id_fk": {
+          "name": "challenge_round_cooldowns_profile_id_profiles_id_fk",
+          "tableFrom": "challenge_round_cooldowns",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenge_round_cooldowns_topic_id_curriculum_topics_id_fk": {
+          "name": "challenge_round_cooldowns_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "challenge_round_cooldowns",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenge_round_cooldowns_profile_topic_unique": {
+          "name": "challenge_round_cooldowns_profile_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "topic_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dictation_results": {
+      "name": "dictation_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentence_count": {
+          "name": "sentence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mistake_count": {
+          "name": "mistake_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "dictation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_dictation_results_profile_date_mode": {
+          "name": "uniq_dictation_results_profile_date_mode",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictation_results_profile_id_profiles_id_fk": {
+          "name": "dictation_results_profile_id_profiles_id_fk",
+          "tableFrom": "dictation_results",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_embeddings": {
+      "name": "session_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_embeddings_session_profile_uq": {
+          "name": "session_embeddings_session_profile_uq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embeddings_hnsw_idx": {
+          "name": "embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_embeddings_session_id_learning_sessions_id_fk": {
+          "name": "session_embeddings_session_id_learning_sessions_id_fk",
+          "tableFrom": "session_embeddings",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_embeddings_profile_id_profiles_id_fk": {
+          "name": "session_embeddings_profile_id_profiles_id_fk",
+          "tableFrom": "session_embeddings",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_embeddings_topic_id_curriculum_topics_id_fk": {
+          "name": "session_embeddings_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_embeddings",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletion_scheduled_at": {
+          "name": "deletion_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_cancelled_at": {
+          "name": "deletion_cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_clerk_user_id_unique": {
+          "name": "accounts_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clerk_user_id"]
+        },
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_states": {
+      "name": "consent_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "consent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "parent_email": {
+          "name": "parent_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_token": {
+          "name": "consent_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_count": {
+          "name": "resend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "consent_states_profile_id_profiles_id_fk": {
+          "name": "consent_states_profile_id_profiles_id_fk",
+          "tableFrom": "consent_states",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consent_states_profile_type_unique": {
+          "name": "consent_states_profile_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "consent_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_links": {
+      "name": "family_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_profile_id": {
+          "name": "parent_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_profile_id": {
+          "name": "child_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "family_links_child_profile_id_idx": {
+          "name": "family_links_child_profile_id_idx",
+          "columns": [
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "family_links_parent_profile_id_profiles_id_fk": {
+          "name": "family_links_parent_profile_id_profiles_id_fk",
+          "tableFrom": "family_links",
+          "tableTo": "profiles",
+          "columnsFrom": ["parent_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "family_links_child_profile_id_profiles_id_fk": {
+          "name": "family_links_child_profile_id_profiles_id_fk",
+          "tableFrom": "family_links",
+          "tableTo": "profiles",
+          "columnsFrom": ["child_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "family_links_parent_child_unique": {
+          "name": "family_links_parent_child_unique",
+          "nullsNotDistinct": false,
+          "columns": ["parent_profile_id", "child_profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "family_links_no_self_link": {
+          "name": "family_links_no_self_link",
+          "value": "\"family_links\".\"parent_profile_id\" != \"family_links\".\"child_profile_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.family_preferences": {
+      "name": "family_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_breakdown_shared": {
+          "name": "pool_breakdown_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "family_preferences_owner_profile_id_idx": {
+          "name": "family_preferences_owner_profile_id_idx",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "family_preferences_owner_profile_id_profiles_id_fk": {
+          "name": "family_preferences_owner_profile_id_profiles_id_fk",
+          "tableFrom": "family_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": ["owner_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "family_preferences_owner_profile_id_unique": {
+          "name": "family_preferences_owner_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["owner_profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_notices": {
+      "name": "pending_notices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pending_notices_owner_unseen_idx": {
+          "name": "pending_notices_owner_unseen_idx",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notices_owner_profile_id_profiles_id_fk": {
+          "name": "pending_notices_owner_profile_id_profiles_id_fk",
+          "tableFrom": "pending_notices",
+          "tableTo": "profiles",
+          "columnsFrom": ["owner_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_notices_type_check": {
+          "name": "pending_notices_type_check",
+          "value": "\"pending_notices\".\"type\" in ('consent_deleted', 'consent_archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_year_set_by": {
+          "name": "birth_year_set_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "location_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_premium_llm": {
+          "name": "has_premium_llm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "conversation_language": {
+          "name": "conversation_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profiles_account_id_idx": {
+          "name": "profiles_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_account_id_accounts_id_fk": {
+          "name": "profiles_account_id_accounts_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profiles_birth_year_set_by_profiles_id_fk": {
+          "name": "profiles_birth_year_set_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": ["birth_year_set_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profiles_conversation_language_check": {
+          "name": "profiles_conversation_language_check",
+          "value": "\"profiles\".\"conversation_language\" IN ('en','cs','es','fr','de','it','pt','pl','ja','nb')"
+        },
+        "profiles_pronouns_length_check": {
+          "name": "profiles_pronouns_length_check",
+          "value": "\"profiles\".\"pronouns\" IS NULL OR char_length(\"profiles\".\"pronouns\") <= 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.withdrawal_archive_preferences": {
+      "name": "withdrawal_archive_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_profile_id": {
+          "name": "owner_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference": {
+          "name": "preference",
+          "type": "withdrawal_archive_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "withdrawal_archive_preferences_owner_profile_id_idx": {
+          "name": "withdrawal_archive_preferences_owner_profile_id_idx",
+          "columns": [
+            {
+              "expression": "owner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "withdrawal_archive_preferences_owner_profile_id_profiles_id_fk": {
+          "name": "withdrawal_archive_preferences_owner_profile_id_profiles_id_fk",
+          "tableFrom": "withdrawal_archive_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": ["owner_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "withdrawal_archive_preferences_owner_profile_id_unique": {
+          "name": "withdrawal_archive_preferences_owner_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["owner_profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_suggestions": {
+      "name": "book_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "book_suggestion_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "picked_at": {
+          "name": "picked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "book_suggestions_subject_id_idx": {
+          "name": "book_suggestions_subject_id_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_suggestions_subject_id_subjects_id_fk": {
+          "name": "book_suggestions_subject_id_subjects_id_fk",
+          "tableFrom": "book_suggestions",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curricula": {
+      "name": "curricula",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curricula_subject_version_idx": {
+          "name": "curricula_subject_version_idx",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curricula_subject_id_subjects_id_fk": {
+          "name": "curricula_subject_id_subjects_id_fk",
+          "tableFrom": "curricula",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_adaptations": {
+      "name": "curriculum_adaptations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "curriculum_adaptations_profile_id_profiles_id_fk": {
+          "name": "curriculum_adaptations_profile_id_profiles_id_fk",
+          "tableFrom": "curriculum_adaptations",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curriculum_adaptations_subject_id_subjects_id_fk": {
+          "name": "curriculum_adaptations_subject_id_subjects_id_fk",
+          "tableFrom": "curriculum_adaptations",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curriculum_adaptations_topic_id_curriculum_topics_id_fk": {
+          "name": "curriculum_adaptations_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "curriculum_adaptations",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_books": {
+      "name": "curriculum_books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics_generated": {
+          "name": "topics_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curriculum_books_subject_sort_order_uq": {
+          "name": "curriculum_books_subject_sort_order_uq",
+          "columns": [
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_books_subject_id_subjects_id_fk": {
+          "name": "curriculum_books_subject_id_subjects_id_fk",
+          "tableFrom": "curriculum_books",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_topics": {
+      "name": "curriculum_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "topic_relevance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'core'"
+        },
+        "source": {
+          "name": "source",
+          "type": "curriculum_topic_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generated'"
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cefr_level": {
+          "name": "cefr_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cefr_sublevel": {
+          "name": "cefr_sublevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_word_count": {
+          "name": "target_word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chunk_count": {
+          "name": "target_chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filed_from": {
+          "name": "filed_from",
+          "type": "filed_from",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pre_generated'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curriculum_topics_book_sort_order_uq": {
+          "name": "curriculum_topics_book_sort_order_uq",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curriculum_topics_book_id_idx": {
+          "name": "curriculum_topics_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_topics_curriculum_id_curricula_id_fk": {
+          "name": "curriculum_topics_curriculum_id_curricula_id_fk",
+          "tableFrom": "curriculum_topics",
+          "tableTo": "curricula",
+          "columnsFrom": ["curriculum_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curriculum_topics_book_id_curriculum_books_id_fk": {
+          "name": "curriculum_topics_book_id_curriculum_books_id_fk",
+          "tableFrom": "curriculum_topics",
+          "tableTo": "curriculum_books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subjects": {
+      "name": "subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_input": {
+          "name": "raw_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "subject_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pedagogy_mode": {
+          "name": "pedagogy_mode",
+          "type": "pedagogy_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'socratic'"
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "urgency_boost_until": {
+          "name": "urgency_boost_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency_boost_reason": {
+          "name": "urgency_boost_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_suggestions_last_generation_attempted_at": {
+          "name": "book_suggestions_last_generation_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "subjects_profile_id_idx": {
+          "name": "subjects_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subjects_profile_id_profiles_id_fk": {
+          "name": "subjects_profile_id_profiles_id_fk",
+          "tableFrom": "subjects",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_connections": {
+      "name": "topic_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_a_id": {
+          "name": "topic_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_b_id": {
+          "name": "topic_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_connections_topic_a_id_curriculum_topics_id_fk": {
+          "name": "topic_connections_topic_a_id_curriculum_topics_id_fk",
+          "tableFrom": "topic_connections",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_connections_topic_b_id_curriculum_topics_id_fk": {
+          "name": "topic_connections_topic_b_id_curriculum_topics_id_fk",
+          "tableFrom": "topic_connections",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_suggestions": {
+      "name": "topic_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "topic_suggestions_book_id_idx": {
+          "name": "topic_suggestions_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_suggestions_book_id_curriculum_books_id_fk": {
+          "name": "topic_suggestions_book_id_curriculum_books_id_fk",
+          "tableFrom": "topic_suggestions",
+          "tableTo": "curriculum_books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.learning_sessions": {
+      "name": "learning_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "session_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "verification_type": {
+          "name": "verification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_mode": {
+          "name": "input_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "escalation_rung": {
+          "name": "escalation_rung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "exchange_count": {
+          "name": "exchange_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wall_clock_seconds": {
+          "name": "wall_clock_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "raw_input": {
+          "name": "raw_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_status": {
+          "name": "filing_status",
+          "type": "filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filing_retry_count": {
+          "name": "filing_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "learning_sessions_profile_id_idx": {
+          "name": "learning_sessions_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_profile_subject_exchange_idx": {
+          "name": "learning_sessions_profile_subject_exchange_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "exchange_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "learning_sessions_filing_status_idx": {
+          "name": "learning_sessions_filing_status_idx",
+          "columns": [
+            {
+              "expression": "filing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"learning_sessions\".\"filing_status\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learning_sessions_profile_id_profiles_id_fk": {
+          "name": "learning_sessions_profile_id_profiles_id_fk",
+          "tableFrom": "learning_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_sessions_subject_id_subjects_id_fk": {
+          "name": "learning_sessions_subject_id_subjects_id_fk",
+          "tableFrom": "learning_sessions",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_sessions_topic_id_curriculum_topics_id_fk": {
+          "name": "learning_sessions_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "learning_sessions",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_drafts": {
+      "name": "onboarding_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange_history": {
+          "name": "exchange_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extracted_signals": {
+          "name": "extracted_signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "onboarding_drafts_profile_id_profiles_id_fk": {
+          "name": "onboarding_drafts_profile_id_profiles_id_fk",
+          "tableFrom": "onboarding_drafts",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_drafts_subject_id_subjects_id_fk": {
+          "name": "onboarding_drafts_subject_id_subjects_id_fk",
+          "tableFrom": "onboarding_drafts",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parking_lot_items": {
+      "name": "parking_lot_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explored": {
+          "name": "explored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parking_lot_items_session_id_learning_sessions_id_fk": {
+          "name": "parking_lot_items_session_id_learning_sessions_id_fk",
+          "tableFrom": "parking_lot_items",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parking_lot_items_profile_id_profiles_id_fk": {
+          "name": "parking_lot_items_profile_id_profiles_id_fk",
+          "tableFrom": "parking_lot_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parking_lot_items_topic_id_curriculum_topics_id_fk": {
+          "name": "parking_lot_items_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "parking_lot_items",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "session_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "structured_assessment": {
+          "name": "structured_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drill_correct": {
+          "name": "drill_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drill_total": {
+          "name": "drill_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphan_reason": {
+          "name": "orphan_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_events_session_id_idx": {
+          "name": "session_events_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_events_profile_event_created_idx": {
+          "name": "session_events_profile_event_created_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_events_session_client_id_uniq": {
+          "name": "session_events_session_client_id_uniq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"session_events\".\"client_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_events_session_id_learning_sessions_id_fk": {
+          "name": "session_events_session_id_learning_sessions_id_fk",
+          "tableFrom": "session_events",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_events_profile_id_profiles_id_fk": {
+          "name": "session_events_profile_id_profiles_id_fk",
+          "tableFrom": "session_events",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_events_subject_id_subjects_id_fk": {
+          "name": "session_events_subject_id_subjects_id_fk",
+          "tableFrom": "session_events",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_events_topic_id_curriculum_topics_id_fk": {
+          "name": "session_events_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_events",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_summaries": {
+      "name": "session_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_feedback": {
+          "name": "ai_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight": {
+          "name": "highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_prompt": {
+          "name": "conversation_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_signal": {
+          "name": "engagement_signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_line": {
+          "name": "closing_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learner_recap": {
+          "name": "learner_recap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_id": {
+          "name": "next_topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_topic_reason": {
+          "name": "next_topic_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "summary_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "llm_summary": {
+          "name": "llm_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_generated_at": {
+          "name": "summary_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_summaries_session_profile_idx": {
+          "name": "session_summaries_session_profile_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_summaries_purge_eligible_idx": {
+          "name": "session_summaries_purge_eligible_idx",
+          "columns": [
+            {
+              "expression": "summary_generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_summaries\".\"purged_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_summaries_session_id_learning_sessions_id_fk": {
+          "name": "session_summaries_session_id_learning_sessions_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_summaries_profile_id_profiles_id_fk": {
+          "name": "session_summaries_profile_id_profiles_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_summaries_topic_id_curriculum_topics_id_fk": {
+          "name": "session_summaries_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_summaries_next_topic_id_curriculum_topics_id_fk": {
+          "name": "session_summaries_next_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "session_summaries",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["next_topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_messages": {
+      "name": "support_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow": {
+          "name": "flow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_key": {
+          "name": "surface_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_attempted_at": {
+          "name": "first_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "support_messages_profile_idx": {
+          "name": "support_messages_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_messages_profile_client_id_uniq": {
+          "name": "support_messages_profile_client_id_uniq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_messages_profile_id_profiles_id_fk": {
+          "name": "support_messages_profile_id_profiles_id_fk",
+          "tableFrom": "support_messages",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coaching_card_cache": {
+      "name": "coaching_card_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_celebrations": {
+          "name": "pending_celebrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "celebrations_seen_by_child": {
+          "name": "celebrations_seen_by_child",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "celebrations_seen_by_parent": {
+          "name": "celebrations_seen_by_parent",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_hash": {
+          "name": "context_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coaching_card_cache_profile_id_profiles_id_fk": {
+          "name": "coaching_card_cache_profile_id_profiles_id_fk",
+          "tableFrom": "coaching_card_cache",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "coaching_card_cache_profile_id_unique": {
+          "name": "coaching_card_cache_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.learning_modes": {
+      "name": "learning_modes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_response_seconds": {
+          "name": "median_response_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "celebration_level": {
+          "name": "celebration_level",
+          "type": "celebration_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "learning_modes_profile_id_profiles_id_fk": {
+          "name": "learning_modes_profile_id_profiles_id_fk",
+          "tableFrom": "learning_modes",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "learning_modes_profile_id_unique": {
+          "name": "learning_modes_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_log_profile_sent_idx": {
+          "name": "notification_log_profile_sent_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_log_profile_id_profiles_id_fk": {
+          "name": "notification_log_profile_id_profiles_id_fk",
+          "tableFrom": "notification_log",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_reminders": {
+          "name": "review_reminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_reminders": {
+          "name": "daily_reminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "weekly_progress_push": {
+          "name": "weekly_progress_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_progress_email": {
+          "name": "weekly_progress_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "monthly_progress_email": {
+          "name": "monthly_progress_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_daily_push": {
+          "name": "max_daily_push",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "expo_push_token": {
+          "name": "expo_push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_profile_id_profiles_id_fk": {
+          "name": "notification_preferences_profile_id_profiles_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_profile_id_unique": {
+          "name": "notification_preferences_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streaks": {
+      "name": "streaks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_period_start_date": {
+          "name": "grace_period_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streaks_profile_id_profiles_id_fk": {
+          "name": "streaks_profile_id_profiles_id_fk",
+          "tableFrom": "streaks",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "streaks_profile_id_unique": {
+          "name": "streaks_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xp_ledger": {
+      "name": "xp_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "xp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reflection_multiplier_applied": {
+          "name": "reflection_multiplier_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reflection_applied_by_session_id": {
+          "name": "reflection_applied_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "xp_ledger_profile_id_idx": {
+          "name": "xp_ledger_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "xp_ledger_topic_id_idx": {
+          "name": "xp_ledger_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "xp_ledger_profile_topic_unique": {
+          "name": "xp_ledger_profile_topic_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "xp_ledger_profile_id_profiles_id_fk": {
+          "name": "xp_ledger_profile_id_profiles_id_fk",
+          "tableFrom": "xp_ledger",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "xp_ledger_topic_id_curriculum_topics_id_fk": {
+          "name": "xp_ledger_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "xp_ledger",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "xp_ledger_subject_id_subjects_id_fk": {
+          "name": "xp_ledger_subject_id_subjects_id_fk",
+          "tableFrom": "xp_ledger",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "xp_ledger_reflection_applied_by_session_id_learning_sessions_id_fk": {
+          "name": "xp_ledger_reflection_applied_by_session_id_learning_sessions_id_fk",
+          "tableFrom": "xp_ledger",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["reflection_applied_by_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_type": {
+          "name": "milestone_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "celebrated_at": {
+          "name": "celebrated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "milestones_scope_uq": {
+          "name": "milestones_scope_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"subject_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"book_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "milestones_profile_created_idx": {
+          "name": "milestones_profile_created_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestones_profile_id_profiles_id_fk": {
+          "name": "milestones_profile_id_profiles_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestones_subject_id_subjects_id_fk": {
+          "name": "milestones_subject_id_subjects_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestones_book_id_curriculum_books_id_fk": {
+          "name": "milestones_book_id_curriculum_books_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "curriculum_books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monthly_reports": {
+      "name": "monthly_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_profile_id": {
+          "name": "child_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_month": {
+          "name": "report_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_data": {
+          "name": "report_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monthly_reports_parent_child_month_uq": {
+          "name": "monthly_reports_parent_child_month_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monthly_reports_child_month_idx": {
+          "name": "monthly_reports_child_month_idx",
+          "columns": [
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "monthly_reports_profile_id_profiles_id_fk": {
+          "name": "monthly_reports_profile_id_profiles_id_fk",
+          "tableFrom": "monthly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monthly_reports_child_profile_id_profiles_id_fk": {
+          "name": "monthly_reports_child_profile_id_profiles_id_fk",
+          "tableFrom": "monthly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["child_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.progress_snapshots": {
+      "name": "progress_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "progress_snapshots_profile_date_uq": {
+          "name": "progress_snapshots_profile_date_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "progress_snapshots_profile_date_idx": {
+          "name": "progress_snapshots_profile_date_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "progress_snapshots_profile_id_profiles_id_fk": {
+          "name": "progress_snapshots_profile_id_profiles_id_fk",
+          "tableFrom": "progress_snapshots",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.progress_summaries": {
+      "name": "progress_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "based_on_last_session_at": {
+          "name": "based_on_last_session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_session_id": {
+          "name": "latest_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "progress_summaries_profile_uq": {
+          "name": "progress_summaries_profile_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "progress_summaries_profile_id_profiles_id_fk": {
+          "name": "progress_summaries_profile_id_profiles_id_fk",
+          "tableFrom": "progress_summaries",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "progress_summaries_latest_session_id_learning_sessions_id_fk": {
+          "name": "progress_summaries_latest_session_id_learning_sessions_id_fk",
+          "tableFrom": "progress_summaries",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["latest_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_reports": {
+      "name": "weekly_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_profile_id": {
+          "name": "child_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_week": {
+          "name": "report_week",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_data": {
+          "name": "report_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weekly_reports_parent_child_week_uq": {
+          "name": "weekly_reports_parent_child_week_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_reports_child_week_idx": {
+          "name": "weekly_reports_child_week_idx",
+          "columns": [
+            {
+              "expression": "child_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_reports_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weekly_reports_child_profile_id_profiles_id_fk": {
+          "name": "weekly_reports_child_profile_id_profiles_id_fk",
+          "tableFrom": "weekly_reports",
+          "tableTo": "profiles",
+          "columnsFrom": ["child_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_facts": {
+      "name": "memory_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_normalized": {
+          "name": "text_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_session_ids": {
+          "name": "source_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "source_event_ids": {
+          "name": "source_event_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_facts_profile_category_idx": {
+          "name": "memory_facts_profile_category_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_facts_profile_created_idx": {
+          "name": "memory_facts_profile_created_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_facts_active_idx": {
+          "name": "memory_facts_active_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"memory_facts\".\"superseded_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_facts_profile_text_normalized_idx": {
+          "name": "memory_facts_profile_text_normalized_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_facts_embedding_hnsw_idx": {
+          "name": "memory_facts_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"memory_facts\".\"superseded_by\" IS NULL",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "memory_facts_active_unique_idx": {
+          "name": "memory_facts_active_unique_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"metadata\"->>'subject', '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"metadata\"->>'context', '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"memory_facts\".\"superseded_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_facts_profile_id_profiles_id_fk": {
+          "name": "memory_facts_profile_id_profiles_id_fk",
+          "tableFrom": "memory_facts",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_facts_superseded_by_fk": {
+          "name": "memory_facts_superseded_by_fk",
+          "tableFrom": "memory_facts",
+          "tableTo": "memory_facts",
+          "columnsFrom": ["superseded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_dedup_decisions": {
+      "name": "memory_dedup_decisions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_key": {
+          "name": "pair_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_text": {
+          "name": "merged_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memory_dedup_decisions_profile_id_profiles_id_fk": {
+          "name": "memory_dedup_decisions_profile_id_profiles_id_fk",
+          "tableFrom": "memory_dedup_decisions",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memory_dedup_decisions_profile_id_pair_key_pk": {
+          "name": "memory_dedup_decisions_profile_id_pair_key_pk",
+          "columns": ["profile_id", "pair_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vocabulary": {
+      "name": "vocabulary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_normalized": {
+          "name": "term_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "vocab_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'word'"
+        },
+        "cefr_level": {
+          "name": "cefr_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mastered": {
+          "name": "mastered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vocabulary_profile_subject_idx": {
+          "name": "vocabulary_profile_subject_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vocabulary_profile_id_profiles_id_fk": {
+          "name": "vocabulary_profile_id_profiles_id_fk",
+          "tableFrom": "vocabulary",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vocabulary_subject_id_subjects_id_fk": {
+          "name": "vocabulary_subject_id_subjects_id_fk",
+          "tableFrom": "vocabulary",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vocabulary_milestone_id_curriculum_topics_id_fk": {
+          "name": "vocabulary_milestone_id_curriculum_topics_id_fk",
+          "tableFrom": "vocabulary",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["milestone_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vocabulary_profile_subject_term_unique": {
+          "name": "vocabulary_profile_subject_term_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "subject_id", "term_normalized"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vocabulary_retention_cards": {
+      "name": "vocabulary_retention_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vocabulary_id": {
+          "name": "vocabulary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consecutive_successes": {
+          "name": "consecutive_successes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vocab_retention_cards_review_idx": {
+          "name": "vocab_retention_cards_review_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vocabulary_retention_cards_profile_id_profiles_id_fk": {
+          "name": "vocabulary_retention_cards_profile_id_profiles_id_fk",
+          "tableFrom": "vocabulary_retention_cards",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk": {
+          "name": "vocabulary_retention_cards_vocabulary_id_vocabulary_id_fk",
+          "tableFrom": "vocabulary_retention_cards",
+          "tableTo": "vocabulary",
+          "columnsFrom": ["vocabulary_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vocab_retention_cards_vocabulary_unique": {
+          "name": "vocab_retention_cards_vocabulary_unique",
+          "nullsNotDistinct": false,
+          "columns": ["vocabulary_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "vocab_retention_cards_interval_days_positive": {
+          "name": "vocab_retention_cards_interval_days_positive",
+          "value": "\"vocabulary_retention_cards\".\"interval_days\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.topic_notes": {
+      "name": "topic_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topic_notes_topic_profile_idx": {
+          "name": "topic_notes_topic_profile_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_notes_session_id_idx": {
+          "name": "topic_notes_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_notes_content_trgm_idx": {
+          "name": "topic_notes_content_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"content\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_notes_topic_id_curriculum_topics_id_fk": {
+          "name": "topic_notes_topic_id_curriculum_topics_id_fk",
+          "tableFrom": "topic_notes",
+          "tableTo": "curriculum_topics",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_notes_profile_id_profiles_id_fk": {
+          "name": "topic_notes_profile_id_profiles_id_fk",
+          "tableFrom": "topic_notes",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_notes_session_id_learning_sessions_id_fk": {
+          "name": "topic_notes_session_id_learning_sessions_id_fk",
+          "tableFrom": "topic_notes",
+          "tableTo": "learning_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.learning_profiles": {
+      "name": "learning_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learning_style": {
+          "name": "learning_style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interests": {
+          "name": "interests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "struggles": {
+          "name": "struggles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "communication_notes": {
+          "name": "communication_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "suppressed_inferences": {
+          "name": "suppressed_inferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "interest_timestamps": {
+          "name": "interest_timestamps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "effectiveness_session_count": {
+          "name": "effectiveness_session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "memory_enabled": {
+          "name": "memory_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "memory_consent_status": {
+          "name": "memory_consent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consent_prompt_dismissed_at": {
+          "name": "consent_prompt_dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_collection_enabled": {
+          "name": "memory_collection_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory_injection_enabled": {
+          "name": "memory_injection_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "accommodation_mode": {
+          "name": "accommodation_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "celebration_level": {
+          "name": "celebration_level",
+          "type": "celebration_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'big_only'"
+        },
+        "recently_resolved_topics": {
+          "name": "recently_resolved_topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "memory_facts_backfilled_at": {
+          "name": "memory_facts_backfilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "learning_profiles_profile_id_idx": {
+          "name": "learning_profiles_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learning_profiles_profile_id_profiles_id_fk": {
+          "name": "learning_profiles_profile_id_profiles_id_fk",
+          "tableFrom": "learning_profiles",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "learning_profiles_profile_id_unique": {
+          "name": "learning_profiles_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_missed_items": {
+      "name": "quiz_missed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_round_id": {
+          "name": "source_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surfaced": {
+          "name": "surfaced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "converted_to_topic": {
+          "name": "converted_to_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_missed_items_profile": {
+          "name": "idx_quiz_missed_items_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surfaced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_missed_items_profile_id_profiles_id_fk": {
+          "name": "quiz_missed_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_missed_items_source_round_id_quiz_rounds_id_fk": {
+          "name": "quiz_missed_items_source_round_id_quiz_rounds_id_fk",
+          "tableFrom": "quiz_missed_items",
+          "tableTo": "quiz_rounds",
+          "columnsFrom": ["source_round_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_rounds": {
+      "name": "quiz_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "library_question_indices": {
+          "name": "library_question_indices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "quiz_round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_quiz_rounds_profile_activity": {
+          "name": "idx_quiz_rounds_profile_activity",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quiz_rounds_profile_subject": {
+          "name": "idx_quiz_rounds_profile_subject",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quiz_rounds_profile_status": {
+          "name": "idx_quiz_rounds_profile_status",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_rounds_profile_id_profiles_id_fk": {
+          "name": "quiz_rounds_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_rounds",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quiz_rounds_subject_id_subjects_id_fk": {
+          "name": "quiz_rounds_subject_id_subjects_id_fk",
+          "tableFrom": "quiz_rounds",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_mastery_items": {
+      "name": "quiz_mastery_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "quiz_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_answer": {
+          "name": "item_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mc_success_count": {
+          "name": "mc_success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_quiz_mastery_due": {
+          "name": "idx_quiz_mastery_due",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_mastery_items_profile_id_profiles_id_fk": {
+          "name": "quiz_mastery_items_profile_id_profiles_id_fk",
+          "tableFrom": "quiz_mastery_items",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quiz_mastery_profile_activity_key": {
+          "name": "uq_quiz_mastery_profile_activity_key",
+          "nullsNotDistinct": false,
+          "columns": ["profile_id", "activity_type", "item_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudges": {
+      "name": "nudges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_profile_id": {
+          "name": "from_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_profile_id": {
+          "name": "to_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "nudge_template",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nudges_to_profile_read_at_idx": {
+          "name": "nudges_to_profile_read_at_idx",
+          "columns": [
+            {
+              "expression": "to_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nudges_from_to_created_at_idx": {
+          "name": "nudges_from_to_created_at_idx",
+          "columns": [
+            {
+              "expression": "from_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nudges_from_profile_id_profiles_id_fk": {
+          "name": "nudges_from_profile_id_profiles_id_fk",
+          "tableFrom": "nudges",
+          "tableTo": "profiles",
+          "columnsFrom": ["from_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nudges_to_profile_id_profiles_id_fk": {
+          "name": "nudges_to_profile_id_profiles_id_fk",
+          "tableFrom": "nudges",
+          "tableTo": "profiles",
+          "columnsFrom": ["to_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.celebration_events": {
+      "name": "celebration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "celebrated_at": {
+          "name": "celebrated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "celebration_type": {
+          "name": "celebration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "celebration_events_profile_dedupe_uq": {
+          "name": "celebration_events_profile_dedupe_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "celebration_events_profile_celebrated_idx": {
+          "name": "celebration_events_profile_celebrated_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "celebrated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "celebration_events_profile_id_profiles_id_fk": {
+          "name": "celebration_events_profile_id_profiles_id_fk",
+          "tableFrom": "celebration_events",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "celebration_events_source_type_known": {
+          "name": "celebration_events_source_type_known",
+          "value": "\"celebration_events\".\"source_type\" IS NULL OR \"celebration_events\".\"source_type\" IN ('assessment', 'dictation_result', 'home_surface_pending_celebration', 'quiz_mastery_item', 'quiz_round', 'session_event', 'vocabulary_retention_card')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.practice_activity_events": {
+      "name": "practice_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "practice_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_subtype": {
+          "name": "activity_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "points_earned": {
+          "name": "points_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "practice_activity_events_profile_dedupe_uq": {
+          "name": "practice_activity_events_profile_dedupe_uq",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_activity_events_profile_completed_idx": {
+          "name": "practice_activity_events_profile_completed_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_activity_events_profile_type_completed_idx": {
+          "name": "practice_activity_events_profile_type_completed_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_activity_events_profile_subject_completed_idx": {
+          "name": "practice_activity_events_profile_subject_completed_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_activity_events_profile_id_profiles_id_fk": {
+          "name": "practice_activity_events_profile_id_profiles_id_fk",
+          "tableFrom": "practice_activity_events",
+          "tableTo": "profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "practice_activity_events_subject_id_subjects_id_fk": {
+          "name": "practice_activity_events_subject_id_subjects_id_fk",
+          "tableFrom": "practice_activity_events",
+          "tableTo": "subjects",
+          "columnsFrom": ["subject_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_idempotency_keys": {
+      "name": "webhook_idempotency_keys",
+      "schema": "",
+      "columns": {
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_idempotency_keys_received_at_idx": {
+          "name": "webhook_idempotency_keys_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "webhook_idempotency_keys_source_webhook_id_pk": {
+          "name": "webhook_idempotency_keys_source_webhook_id_pk",
+          "columns": ["source", "webhook_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.analogy_domain": {
+      "name": "analogy_domain",
+      "schema": "public",
+      "values": ["cooking", "sports", "building", "music", "nature", "gaming"]
+    },
+    "public.assessment_status": {
+      "name": "assessment_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "passed",
+        "failed",
+        "borderline",
+        "failed_exhausted"
+      ]
+    },
+    "public.needs_deepening_status": {
+      "name": "needs_deepening_status",
+      "schema": "public",
+      "values": ["active", "resolved"]
+    },
+    "public.teaching_method": {
+      "name": "teaching_method",
+      "schema": "public",
+      "values": [
+        "visual_diagrams",
+        "step_by_step",
+        "real_world_examples",
+        "practice_problems"
+      ]
+    },
+    "public.verification_depth": {
+      "name": "verification_depth",
+      "schema": "public",
+      "values": ["recall", "explain", "transfer"]
+    },
+    "public.xp_status": {
+      "name": "xp_status",
+      "schema": "public",
+      "values": ["pending", "verified", "decayed"]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": ["trial", "active", "past_due", "cancelled", "expired"]
+    },
+    "public.subscription_tier": {
+      "name": "subscription_tier",
+      "schema": "public",
+      "values": ["free", "plus", "family", "pro"]
+    },
+    "public.dictation_mode": {
+      "name": "dictation_mode",
+      "schema": "public",
+      "values": ["homework", "surprise"]
+    },
+    "public.consent_status": {
+      "name": "consent_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PARENTAL_CONSENT_REQUESTED",
+        "CONSENTED",
+        "WITHDRAWN"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": ["GDPR", "COPPA"]
+    },
+    "public.location_type": {
+      "name": "location_type",
+      "schema": "public",
+      "values": ["EU", "US", "OTHER"]
+    },
+    "public.withdrawal_archive_preference": {
+      "name": "withdrawal_archive_preference",
+      "schema": "public",
+      "values": ["auto", "always", "never"]
+    },
+    "public.book_suggestion_category": {
+      "name": "book_suggestion_category",
+      "schema": "public",
+      "values": ["related", "explore"]
+    },
+    "public.curriculum_topic_source": {
+      "name": "curriculum_topic_source",
+      "schema": "public",
+      "values": ["generated", "user"]
+    },
+    "public.filed_from": {
+      "name": "filed_from",
+      "schema": "public",
+      "values": ["pre_generated", "session_filing", "freeform_filing"]
+    },
+    "public.pedagogy_mode": {
+      "name": "pedagogy_mode",
+      "schema": "public",
+      "values": ["socratic", "four_strands"]
+    },
+    "public.subject_status": {
+      "name": "subject_status",
+      "schema": "public",
+      "values": ["active", "paused", "archived"]
+    },
+    "public.topic_relevance": {
+      "name": "topic_relevance",
+      "schema": "public",
+      "values": ["core", "recommended", "contemporary", "emerging"]
+    },
+    "public.draft_status": {
+      "name": "draft_status",
+      "schema": "public",
+      "values": ["in_progress", "completing", "completed", "failed", "expired"]
+    },
+    "public.filing_status": {
+      "name": "filing_status",
+      "schema": "public",
+      "values": ["filing_pending", "filing_failed", "filing_recovered"]
+    },
+    "public.session_event_type": {
+      "name": "session_event_type",
+      "schema": "public",
+      "values": [
+        "user_message",
+        "ai_response",
+        "system_prompt",
+        "quick_action",
+        "user_feedback",
+        "ocr_correction",
+        "understanding_check",
+        "session_start",
+        "session_end",
+        "hint",
+        "escalation",
+        "flag",
+        "check_response",
+        "summary_submission",
+        "parking_lot_add",
+        "homework_problem_started",
+        "homework_problem_completed",
+        "evaluate_challenge",
+        "teach_back_response"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": ["active", "paused", "completed", "auto_closed"]
+    },
+    "public.session_type": {
+      "name": "session_type",
+      "schema": "public",
+      "values": ["learning", "homework", "interleaved"]
+    },
+    "public.summary_status": {
+      "name": "summary_status",
+      "schema": "public",
+      "values": ["pending", "submitted", "accepted", "skipped", "auto_closed"]
+    },
+    "public.celebration_level": {
+      "name": "celebration_level",
+      "schema": "public",
+      "values": ["all", "big_only", "off"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "review_reminder",
+        "daily_reminder",
+        "trial_expiry",
+        "streak_warning",
+        "consent_request",
+        "consent_reminder",
+        "consent_warning",
+        "consent_expired",
+        "consent_archived",
+        "subscribe_request",
+        "recall_nudge",
+        "weekly_progress",
+        "monthly_report",
+        "progress_refresh",
+        "struggle_noticed",
+        "struggle_flagged",
+        "struggle_resolved",
+        "dictation_review",
+        "session_filing_failed",
+        "interview_ready",
+        "nudge"
+      ]
+    },
+    "public.vocab_type": {
+      "name": "vocab_type",
+      "schema": "public",
+      "values": ["word", "chunk"]
+    },
+    "public.quiz_activity_type": {
+      "name": "quiz_activity_type",
+      "schema": "public",
+      "values": ["capitals", "vocabulary", "guess_who"]
+    },
+    "public.quiz_round_status": {
+      "name": "quiz_round_status",
+      "schema": "public",
+      "values": ["active", "completed", "abandoned"]
+    },
+    "public.nudge_template": {
+      "name": "nudge_template",
+      "schema": "public",
+      "values": [
+        "you_got_this",
+        "proud_of_you",
+        "quick_session",
+        "thinking_of_you"
+      ]
+    },
+    "public.practice_activity_type": {
+      "name": "practice_activity_type",
+      "schema": "public",
+      "values": [
+        "quiz",
+        "review",
+        "assessment",
+        "dictation",
+        "recitation",
+        "fluency_drill"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -561,6 +561,13 @@
       "when": 1779214347987,
       "tag": "0079_webhook_idempotency_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 80,
+      "version": "7",
+      "when": 1779224585343,
+      "tag": "0080_slippery_groot",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/services/challenge-round/trigger.test.ts
+++ b/apps/api/src/services/challenge-round/trigger.test.ts
@@ -1,0 +1,320 @@
+import {
+  evaluateChallengeReadiness,
+  type ChallengeReadinessInput,
+} from './trigger';
+
+const baseInput: ChallengeReadinessInput = {
+  sessionType: 'learning',
+  exchangeCount: 6,
+  retentionStatus: 'strong',
+  struggleStatus: 'normal',
+  recentCorrectStreak: 2,
+  currentSessionSolidAnswerCount: 2,
+  subscriptionTier: 'plus',
+  quotaRemainingTurns: 6,
+  quotaFractionRemaining: 0.5,
+  challengeRoundState: undefined,
+  cooldownLastOfferedAt: null,
+  cooldownLastOutcome: null,
+  now: new Date('2026-05-19T12:00:00Z'),
+};
+
+describe('evaluateChallengeReadiness — hard gates', () => {
+  it('eligible when learning + strong + ≥5 exchanges + streak ≥2 + no cooldown', () => {
+    expect(evaluateChallengeReadiness(baseInput).eligible).toBe(true);
+  });
+
+  it('hard-gates homework sessions', () => {
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, sessionType: 'homework' })
+        .eligible,
+    ).toBe(false);
+  });
+
+  it('hard-gates interleaved sessions (v1 — not an entry point)', () => {
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, sessionType: 'interleaved' })
+        .eligible,
+    ).toBe(false);
+  });
+
+  it('hard-gates when struggling', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        struggleStatus: 'needs_deepening',
+      }).eligible,
+    ).toBe(false);
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, struggleStatus: 'blocked' })
+        .eligible,
+    ).toBe(false);
+  });
+
+  it('hard-gates under exchange threshold', () => {
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, exchangeCount: 4 }).eligible,
+    ).toBe(false);
+  });
+
+  it('hard-gates fading / weak / forgotten retention', () => {
+    for (const status of ['fading', 'weak', 'forgotten'] as const) {
+      expect(
+        evaluateChallengeReadiness({ ...baseInput, retentionStatus: status })
+          .eligible,
+      ).toBe(false);
+    }
+  });
+
+  it('hard-gates when streak below 2', () => {
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, recentCorrectStreak: 1 })
+        .eligible,
+    ).toBe(false);
+  });
+
+  it('returns specific reason codes for each gate', () => {
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, sessionType: 'homework' })
+        .reason,
+    ).toBe('session_type');
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, struggleStatus: 'blocked' })
+        .reason,
+    ).toBe('struggle');
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, exchangeCount: 2 }).reason,
+    ).toBe('exchanges_below_min');
+    expect(
+      evaluateChallengeReadiness({ ...baseInput, recentCorrectStreak: 0 })
+        .reason,
+    ).toBe('streak');
+  });
+});
+
+describe('evaluateChallengeReadiness — current-session new-topic path (MED-8)', () => {
+  it('allows a new topic when current session shows sustained solid answers', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        retentionStatus: 'new',
+        exchangeCount: 7,
+        recentCorrectStreak: 4,
+        currentSessionSolidAnswerCount: 4,
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('does not allow a new topic on only a short lucky streak', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        retentionStatus: 'new',
+        exchangeCount: 5,
+        recentCorrectStreak: 2,
+        currentSessionSolidAnswerCount: 2,
+      }).eligible,
+    ).toBe(false);
+  });
+
+  it('rejects a new topic when solid-answer count is short of threshold', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        retentionStatus: 'new',
+        exchangeCount: 8,
+        recentCorrectStreak: 5,
+        currentSessionSolidAnswerCount: 3,
+      }).eligible,
+    ).toBe(false);
+  });
+
+  it('rejects a new topic when exchange count is below new-topic threshold', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        retentionStatus: 'new',
+        exchangeCount: 6,
+        recentCorrectStreak: 5,
+        currentSessionSolidAnswerCount: 4,
+      }).eligible,
+    ).toBe(false);
+  });
+});
+
+describe('evaluateChallengeReadiness — quota budget (ROUTING-3)', () => {
+  it('hard-gates when fewer than 5 turns remain regardless of tier', () => {
+    for (const tier of ['free', 'plus', 'family', 'pro'] as const) {
+      expect(
+        evaluateChallengeReadiness({
+          ...baseInput,
+          subscriptionTier: tier,
+          quotaRemainingTurns: 4,
+        }).eligible,
+      ).toBe(false);
+    }
+  });
+
+  it('uses quota fraction only as a secondary free-tier guard', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        subscriptionTier: 'free',
+        quotaRemainingTurns: 6,
+        quotaFractionRemaining: 0.03,
+      }).eligible,
+    ).toBe(false);
+    // Plus tier with low fraction but plenty of turns left is still eligible
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        subscriptionTier: 'plus',
+        quotaRemainingTurns: 6,
+        quotaFractionRemaining: 0.03,
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('returns quota_remaining_turns reason when under absolute turn budget', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        quotaRemainingTurns: 2,
+      }).reason,
+    ).toBe('quota_remaining_turns');
+  });
+
+  it('returns quota_fraction_free_tier reason when free-tier fraction guard fires', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        subscriptionTier: 'free',
+        quotaRemainingTurns: 6,
+        quotaFractionRemaining: 0.01,
+      }).reason,
+    ).toBe('quota_fraction_free_tier');
+  });
+});
+
+describe('evaluateChallengeReadiness — in-session state + cooldown', () => {
+  it('hard-gates when already mid-round (offered/accepted/active/drafting)', () => {
+    for (const state of [
+      'offered',
+      'accepted',
+      'active',
+      'drafting',
+    ] as const) {
+      expect(
+        evaluateChallengeReadiness({
+          ...baseInput,
+          challengeRoundState: {
+            state,
+            offerCount: 1,
+            declinedDontAskAgain: false,
+            evaluations: [],
+          },
+        }).eligible,
+      ).toBe(false);
+    }
+  });
+
+  it("hard-gates 'don't ask again' for this session even when state == declined", () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        challengeRoundState: {
+          state: 'declined',
+          offerCount: 1,
+          declinedDontAskAgain: true,
+          evaluations: [],
+        },
+      }).eligible,
+    ).toBe(false);
+  });
+
+  it('hard-gates plain decline within session (no re-offer this session)', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        challengeRoundState: {
+          state: 'declined',
+          offerCount: 1,
+          declinedDontAskAgain: false,
+          evaluations: [],
+        },
+      }).reason,
+    ).toBe('session_decline');
+  });
+
+  it('allows offering again after a completed round (state === complete)', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        challengeRoundState: {
+          state: 'complete',
+          offerCount: 1,
+          declinedDontAskAgain: false,
+          evaluations: [],
+        },
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('allows offering again after an aborted round', () => {
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        challengeRoundState: {
+          state: 'aborted',
+          offerCount: 1,
+          declinedDontAskAgain: false,
+          evaluations: [],
+        },
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('hard-gates declined within 24h cooldown across sessions', () => {
+    const oneHourAgo = new Date('2026-05-19T11:00:00Z');
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        cooldownLastOfferedAt: oneHourAgo,
+        cooldownLastOutcome: 0,
+      }).eligible,
+    ).toBe(false);
+  });
+
+  it('allows again after 24h cooldown elapses', () => {
+    const yesterday = new Date('2026-05-18T11:00:00Z');
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        cooldownLastOfferedAt: yesterday,
+        cooldownLastOutcome: 0,
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('does not apply cooldown when last outcome was not a decline (outcome !== 0)', () => {
+    const oneHourAgo = new Date('2026-05-19T11:00:00Z');
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        cooldownLastOfferedAt: oneHourAgo,
+        cooldownLastOutcome: 2, // verified — re-offer allowed sooner
+      }).eligible,
+    ).toBe(true);
+  });
+
+  it('returns cooldown reason when within the window', () => {
+    const oneHourAgo = new Date('2026-05-19T11:00:00Z');
+    expect(
+      evaluateChallengeReadiness({
+        ...baseInput,
+        cooldownLastOfferedAt: oneHourAgo,
+        cooldownLastOutcome: 0,
+      }).reason,
+    ).toBe('cooldown');
+  });
+});

--- a/apps/api/src/services/challenge-round/trigger.ts
+++ b/apps/api/src/services/challenge-round/trigger.ts
@@ -1,0 +1,135 @@
+import type {
+  ChallengeRoundSessionState,
+  RetentionStatus,
+  SessionType,
+  StruggleStatus,
+} from '@eduagent/schemas';
+
+/**
+ * Challenge Round trigger evaluator — pure function. Decides whether the
+ * server may offer a Challenge Round at this turn given the learner's state
+ * and quota. The server is the source of truth; the LLM only proposes via
+ * `signals.challenge_round_offer` and is suppressed when this evaluator
+ * returns `eligible: false`.
+ *
+ * Decisions documented in
+ * `docs/plans/2026-05-18-challenge-round-into-note.md` (Task 3) and
+ * `docs/plans/2026-05-18-challenge-round-targets.md` (ROUTING-3 — absolute
+ * remaining-turn budget replaces percentage-only quota gate).
+ */
+
+const CHALLENGE_OFFER_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const MIN_EXCHANGES = 5;
+const MIN_CORRECT_STREAK = 2;
+const MIN_NEW_TOPIC_EXCHANGES = 7;
+const MIN_NEW_TOPIC_SOLID_ANSWERS = 4;
+const MIN_NEW_TOPIC_CORRECT_STREAK = 4;
+const MIN_CHALLENGE_REMAINING_TURNS = 5;
+const MIN_QUOTA_FRACTION_FREE = 0.05;
+
+/**
+ * Virtual retention input used by the trigger. The persisted
+ * `retentionStatusSchema` enumerates only the four post-card states
+ * (strong/fading/weak/forgotten); `'new'` is the caller's translation of
+ * "no retention card row exists for this topic yet" so the trigger can decide
+ * whether sustained current-session evidence justifies offering a Challenge
+ * Round on a brand-new topic.
+ */
+export type ChallengeReadinessRetentionInput = RetentionStatus | 'new';
+
+export interface ChallengeReadinessInput {
+  sessionType: SessionType;
+  exchangeCount: number;
+  retentionStatus: ChallengeReadinessRetentionInput;
+  struggleStatus: StruggleStatus;
+  recentCorrectStreak: number;
+  currentSessionSolidAnswerCount: number;
+  subscriptionTier?: 'free' | 'plus' | 'family' | 'pro' | 'trial';
+  quotaRemainingTurns: number;
+  quotaFractionRemaining: number;
+  challengeRoundState: ChallengeRoundSessionState | undefined;
+  cooldownLastOfferedAt: Date | null;
+  cooldownLastOutcome: number | null;
+  now: Date;
+}
+
+export type ChallengeReadinessReason =
+  | 'session_type'
+  | 'struggle'
+  | 'exchanges_below_min'
+  | 'streak'
+  | 'retention'
+  | 'quota_remaining_turns'
+  | 'quota_fraction_free_tier'
+  | 'session_decline'
+  | 'already_in_round'
+  | 'cooldown';
+
+export interface ChallengeReadinessResult {
+  eligible: boolean;
+  reason?: ChallengeReadinessReason;
+}
+
+export function evaluateChallengeReadiness(
+  input: ChallengeReadinessInput,
+): ChallengeReadinessResult {
+  if (input.sessionType !== 'learning') {
+    return { eligible: false, reason: 'session_type' };
+  }
+  if (input.struggleStatus !== 'normal') {
+    return { eligible: false, reason: 'struggle' };
+  }
+  if (input.exchangeCount < MIN_EXCHANGES) {
+    return { eligible: false, reason: 'exchanges_below_min' };
+  }
+  if (input.recentCorrectStreak < MIN_CORRECT_STREAK) {
+    return { eligible: false, reason: 'streak' };
+  }
+
+  const retentionEligible =
+    input.retentionStatus === 'strong' ||
+    (input.retentionStatus === 'new' &&
+      input.exchangeCount >= MIN_NEW_TOPIC_EXCHANGES &&
+      input.recentCorrectStreak >= MIN_NEW_TOPIC_CORRECT_STREAK &&
+      input.currentSessionSolidAnswerCount >= MIN_NEW_TOPIC_SOLID_ANSWERS);
+  if (!retentionEligible) {
+    return { eligible: false, reason: 'retention' };
+  }
+
+  if (input.quotaRemainingTurns < MIN_CHALLENGE_REMAINING_TURNS) {
+    return { eligible: false, reason: 'quota_remaining_turns' };
+  }
+  if (
+    input.subscriptionTier === 'free' &&
+    input.quotaFractionRemaining < MIN_QUOTA_FRACTION_FREE
+  ) {
+    return { eligible: false, reason: 'quota_fraction_free_tier' };
+  }
+
+  const round = input.challengeRoundState;
+  if (round) {
+    if (round.declinedDontAskAgain) {
+      return { eligible: false, reason: 'session_decline' };
+    }
+    if (
+      round.state === 'offered' ||
+      round.state === 'accepted' ||
+      round.state === 'active' ||
+      round.state === 'drafting'
+    ) {
+      return { eligible: false, reason: 'already_in_round' };
+    }
+    if (round.state === 'declined') {
+      return { eligible: false, reason: 'session_decline' };
+    }
+  }
+
+  if (input.cooldownLastOfferedAt && input.cooldownLastOutcome === 0) {
+    const elapsed = input.now.getTime() - input.cooldownLastOfferedAt.getTime();
+    if (elapsed < CHALLENGE_OFFER_COOLDOWN_MS) {
+      return { eligible: false, reason: 'cooldown' };
+    }
+  }
+
+  return { eligible: true };
+}

--- a/docs/plans/2026-05-18-challenge-round-into-note.md
+++ b/docs/plans/2026-05-18-challenge-round-into-note.md
@@ -1,5 +1,9 @@
 # Sunset Challenge Mode Toggle + Add Challenge Round Into Note — Implementation Plan
 
+> **AUTHORITATIVE TARGET DECISIONS (2026-05-19):** Storage targets, session-CRUD helper names, struggleStatusSchema placement, and Challenge Round LLM routing policy are resolved in `docs/plans/2026-05-18-challenge-round-targets.md` (Task 0.0 + 0.0a output). That doc OVERRIDES any inline references below to `topic_mastery_state`, `review_targets`, `topic-progress.ts`, `getSessionById`, or `getSession`. The real targets are: `assessments.mastery_challenge_verified_at` (CRIT-1), `needs_deepening_topics` extended with `source/concept/misconception/correction` (CRIT-2), `getSession()` already scoped via `createScopedRepository` (CRIT-3), `struggle-status.ts` mirroring `retention-status.ts` (CRIT-4), and a routing-only rung floor of 4 via a new `llmRoutingRung` field on `ExchangeContext` (ROUTING-1..5). When a section below says "decide between (a)/(b)/(c)" for those four findings, the decision has already been made — see the targets doc.
+>
+> **Phase 0 status:** complete (PR #325, merged 2026-05-19). PR B (target decisions): PR #331. Current PR (PR C — envelope + struggle-status): in flight.
+>
 > **Current recommendation (2026-05-19):** This plan is still worth doing, but it is no longer a single-PR plan. Execute it as a small workstream: first sunset the persistent mode toggle, then land Challenge Round behind explicit storage/routing/eval decisions. Treat the checkboxes below as a task bank, not as permission to start every task in one branch.
 >
 > **For agentic workers:** Follow `AGENTS.md`, `docs/project_context.md`, `docs/architecture.md`, and the repo skills (`project-memory`, `commit`, `deep-bugfixing` when reviewing). Do not use old `/commit` or "superpowers" instructions literally; replace them with the current Codex repo workflow.
@@ -391,7 +395,7 @@ List every exported function.
 Find the closest equivalents to `getSessionById` and `persistSessionMetadata`.
 ```
 
-Document the actual names. Update every plan reference (Tasks 8, 9, 11 — search for `getSessionById|persistSessionMetadata`) to use the real names. If the real helpers don't enforce `profileId` scoping the way the plan assumes (CLAUDE.md non-negotiable rule), add a Task 9.0 to either (i) extract `getSessionByIdScoped(sessionId, profileId)` with a break test that proves cross-profile access returns null, or (ii) inline the scoping check at every route handler. Decide which.
+Document the actual names. Update every plan reference (Tasks 8, 9, 11 — search for `getSessionById|persistSessionMetadata`) to use the real names. If the real helpers don't enforce `profileId` scoping the way the plan assumes (CLAUDE.md non-negotiable rule), add a Task 9.0 to either (i) extract `getSession(sessionId, profileId)` with a break test that proves cross-profile access returns null, or (ii) inline the scoping check at every route handler. Decide which.
 
 - [ ] **Step 4: Schema export of `struggleStatusSchema` (CRIT-4)**
 
@@ -2079,7 +2083,7 @@ Expected: new snapshots written under `apps/api/eval-llm/__snapshots__/`. Review
 
 - [ ] **Step 0: Confirm Task 0.0 spike is committed (CRIT-3)**
 
-Task 8 references `getSessionById` / `persistSessionMetadata`. Substitute the real names from the Task 0.0 spike decision doc before writing code. If the spike concluded a new `getSessionByIdScoped` helper needs extracting, do that as Step 0.5 here.
+Task 8 references `getSessionById` / `persistSessionMetadata`. Substitute the real names from the Task 0.0 spike decision doc before writing code. If the spike concluded a new `getSession` helper needs extracting, do that as Step 0.5 here.
 
 - [ ] **Step 0.5: Apply the routing-policy amendment before envelope work (ROUTING-1, ROUTING-2)**
 
@@ -2308,7 +2312,7 @@ describe('session exchange — challenge round dispatch', () => {
       content: JSON.stringify({ reply: 'try a challenge?', signals: { challenge_round_offer: true }, confidence: 'medium' }),
     });
     await processMessage(db, profile.id, session.id, { message: 'got it' });
-    const refetched = await getSessionByIdScoped(session.id, profile.id);
+    const refetched = await getSession(session.id, profile.id);
     expect(refetched.metadata.challengeRound.state).toBe('offered');
   });
 });
@@ -2443,7 +2447,14 @@ import { z } from 'zod';
 import { transitionChallengeState } from '@/services/challenge-round/state';
 import { evaluateChallengeReadiness } from '@/services/challenge-round/trigger';
 import { recordCooldown } from '@/services/challenge-round/cooldown';
-import { getSessionById, persistSessionMetadata } from '@/services/session/session-crud';
+// NOTE (2026-05-19 targets doc): `getSessionById` does not exist. Real helper is
+// `getSession(db, profileId, sessionId)` — already scoped via createScopedRepository.
+// `persistSessionMetadata` does not exist yet either; Task 8 Step 0 extracts it
+// from the file-local `updateSessionMetadata` in session-exchange.ts. The code
+// blocks below use the names retained from the original plan — when implementing,
+// substitute `getSession(db, profileId, sessionId)` and the new
+// `persistSessionMetadata(db, profileId, sessionId, partial)` extracted in Task 8 Step 0.
+import { getSession, persistSessionMetadata } from '@/services/session/session-crud';
 import { safeSend } from '@/services/safe-non-core';
 
 const maybeOfferSchema = z.object({ sessionId: z.string().uuid(), topicId: z.string().uuid() });
@@ -2455,7 +2466,7 @@ export const challengeRoundRoutes = new Hono()
   .post('/maybe-offer', async (c) => {
     const body = maybeOfferSchema.parse(await c.req.json());
     const profileId = c.get('profileId');
-    const session = await getSessionById(body.sessionId, profileId);
+    const session = await getSession(db, profileId, body.sessionId);
 
     // HIGH-2: pre-flight state check to avoid double-offer race with server-initiated path
     const currentState = session.metadata?.challengeRound?.state;
@@ -2475,7 +2486,7 @@ export const challengeRoundRoutes = new Hono()
   })
   .post('/accept', async (c) => {
     const body = acceptSchema.parse(await c.req.json());
-    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    const session = await getSession(db, c.get('profileId'), body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'accept' }),
@@ -2486,7 +2497,7 @@ export const challengeRoundRoutes = new Hono()
   .post('/decline', async (c) => {
     const body = declineSchema.parse(await c.req.json());
     const db = c.get('db');
-    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    const session = await getSession(db, c.get('profileId'), body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'decline', dontAskAgain: body.dontAskAgain }),
@@ -2498,7 +2509,7 @@ export const challengeRoundRoutes = new Hono()
   })
   .post('/abort', async (c) => {
     const body = abortSchema.parse(await c.req.json());
-    const session = await getSessionById(body.sessionId, c.get('profileId'));
+    const session = await getSession(db, c.get('profileId'), body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'abort' }),

--- a/docs/plans/2026-05-18-challenge-round-into-note.md
+++ b/docs/plans/2026-05-18-challenge-round-into-note.md
@@ -2312,7 +2312,7 @@ describe('session exchange — challenge round dispatch', () => {
       content: JSON.stringify({ reply: 'try a challenge?', signals: { challenge_round_offer: true }, confidence: 'medium' }),
     });
     await processMessage(db, profile.id, session.id, { message: 'got it' });
-    const refetched = await getSession(session.id, profile.id);
+    const refetched = await getSession(db, profile.id, session.id);
     expect(refetched.metadata.challengeRound.state).toBe('offered');
   });
 });
@@ -2449,12 +2449,11 @@ import { evaluateChallengeReadiness } from '@/services/challenge-round/trigger';
 import { recordCooldown } from '@/services/challenge-round/cooldown';
 // NOTE (2026-05-19 targets doc): `getSessionById` does not exist. Real helper is
 // `getSession(db, profileId, sessionId)` — already scoped via createScopedRepository.
-// `persistSessionMetadata` does not exist yet either; Task 8 Step 0 extracts it
-// from the file-local `updateSessionMetadata` in session-exchange.ts. The code
-// blocks below use the names retained from the original plan — when implementing,
-// substitute `getSession(db, profileId, sessionId)` and the new
-// `persistSessionMetadata(db, profileId, sessionId, partial)` extracted in Task 8 Step 0.
-import { getSession, persistSessionMetadata } from '@/services/session/session-crud';
+// `persistSessionMetadata` is a post-Task-8 extraction from the file-local
+// `updateSessionMetadata` in session-exchange.ts; keep it profile-scoped as
+// `persistSessionMetadata(db, profileId, sessionId, partial)`.
+import { persistSessionMetadata } from '@/services/session/session-metadata';
+import { getSession } from '@/services/session/session-crud';
 import { safeSend } from '@/services/safe-non-core';
 
 const maybeOfferSchema = z.object({ sessionId: z.string().uuid(), topicId: z.string().uuid() });
@@ -2465,6 +2464,7 @@ const abortSchema = z.object({ sessionId: z.string().uuid() });
 export const challengeRoundRoutes = new Hono()
   .post('/maybe-offer', async (c) => {
     const body = maybeOfferSchema.parse(await c.req.json());
+    const db = c.get('db');
     const profileId = c.get('profileId');
     const session = await getSession(db, profileId, body.sessionId);
 
@@ -2481,40 +2481,45 @@ export const challengeRoundRoutes = new Hono()
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'offer', topicId: body.topicId }),
     };
-    await persistSessionMetadata(session.id, session.metadata);
+    await persistSessionMetadata(db, profileId, session.id, session.metadata);
     return c.json({ offered: true });
   })
   .post('/accept', async (c) => {
     const body = acceptSchema.parse(await c.req.json());
-    const session = await getSession(db, c.get('profileId'), body.sessionId);
+    const db = c.get('db');
+    const profileId = c.get('profileId');
+    const session = await getSession(db, profileId, body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'accept' }),
     };
-    await persistSessionMetadata(session.id, session.metadata);
+    await persistSessionMetadata(db, profileId, session.id, session.metadata);
     return c.json({ ok: true });
   })
   .post('/decline', async (c) => {
     const body = declineSchema.parse(await c.req.json());
     const db = c.get('db');
-    const session = await getSession(db, c.get('profileId'), body.sessionId);
+    const profileId = c.get('profileId');
+    const session = await getSession(db, profileId, body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'decline', dontAskAgain: body.dontAskAgain }),
     };
-    await persistSessionMetadata(session.id, session.metadata);
-    await recordCooldown(db, { profileId: c.get('profileId'), topicId: body.topicId, outcome: 0 });
+    await persistSessionMetadata(db, profileId, session.id, session.metadata);
+    await recordCooldown(db, { profileId, topicId: body.topicId, outcome: 0 });
     await safeSend('challenge.round.declined', { sessionId: body.sessionId, topicId: body.topicId });
     return c.json({ ok: true });
   })
   .post('/abort', async (c) => {
     const body = abortSchema.parse(await c.req.json());
-    const session = await getSession(db, c.get('profileId'), body.sessionId);
+    const db = c.get('db');
+    const profileId = c.get('profileId');
+    const session = await getSession(db, profileId, body.sessionId);
     session.metadata = {
       ...session.metadata,
       challengeRound: transitionChallengeState(session.metadata?.challengeRound, { type: 'abort' }),
     };
-    await persistSessionMetadata(session.id, session.metadata);
+    await persistSessionMetadata(db, profileId, session.id, session.metadata);
     return c.json({ ok: true });
   });
 ```

--- a/packages/database/src/schema/challenge-round-cooldowns.ts
+++ b/packages/database/src/schema/challenge-round-cooldowns.ts
@@ -1,0 +1,53 @@
+import { pgTable, uuid, timestamp, integer, unique } from 'drizzle-orm/pg-core';
+import { profiles } from './profiles';
+import { curriculumTopics } from './subjects';
+import { generateUUIDv7 } from '../utils/uuid';
+
+/**
+ * Challenge Round cross-session decline cooldown — one row per
+ * `(profile_id, topic_id)`. Written when a learner declines an offered round
+ * or completes one; read by the trigger evaluator to suppress repeat offers
+ * within 24h of a decline. Acceptances/completions update the row but do not
+ * gate subsequent offers (those use in-session state instead).
+ *
+ * `last_outcome` encoding (kept narrow on purpose — analytics live in
+ * `ai_response.metadata` and Inngest events, not here):
+ *   0 = declined          → 24h cooldown enforced by trigger
+ *   1 = accepted_partial  → no cross-session cooldown
+ *   2 = verified          → no cross-session cooldown
+ *   3 = reteach           → no cross-session cooldown
+ *
+ * Both FKs cascade on delete (MED-2 from the Challenge Round plan): profile
+ * delete wipes cooldown rows (correct under GDPR export-delete), and a
+ * regenerated curriculum topic gets a fresh cooldown automatically.
+ */
+export const challengeRoundCooldowns = pgTable(
+  'challenge_round_cooldowns',
+  {
+    id: uuid('id')
+      .primaryKey()
+      .$defaultFn(() => generateUUIDv7()),
+    profileId: uuid('profile_id')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'cascade' }),
+    topicId: uuid('topic_id')
+      .notNull()
+      .references(() => curriculumTopics.id, { onDelete: 'cascade' }),
+    lastOfferedAt: timestamp('last_offered_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    lastOutcome: integer('last_outcome'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('challenge_round_cooldowns_profile_topic_unique').on(
+      table.profileId,
+      table.topicId,
+    ),
+  ],
+);

--- a/packages/database/src/schema/challenge-round-cooldowns.ts
+++ b/packages/database/src/schema/challenge-round-cooldowns.ts
@@ -1,4 +1,12 @@
-import { pgTable, uuid, timestamp, integer, unique } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import {
+  pgTable,
+  uuid,
+  timestamp,
+  integer,
+  unique,
+  check,
+} from 'drizzle-orm/pg-core';
 import { profiles } from './profiles';
 import { curriculumTopics } from './subjects';
 import { generateUUIDv7 } from '../utils/uuid';
@@ -49,5 +57,9 @@ export const challengeRoundCooldowns = pgTable(
       table.profileId,
       table.topicId,
     ),
+    check(
+      'challenge_round_cooldowns_last_outcome_range',
+      sql`${table.lastOutcome} IS NULL OR (${table.lastOutcome} >= 0 AND ${table.lastOutcome} <= 3)`,
+    ),
   ],
-);
+).enableRLS();

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -20,3 +20,4 @@ export * from './quiz-mastery';
 export * from './nudges';
 export * from './practice-activity';
 export * from './webhook-idempotency';
+export * from './challenge-round-cooldowns';

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -21,6 +21,7 @@ export * from './assessments';
 // Progress, Motivation & Dashboard (Epic 4)
 export * from './progress';
 export * from './retention-status';
+export * from './struggle-status';
 export * from './snapshots';
 
 // Subscription & Billing (Epic 5)

--- a/packages/schemas/src/llm-envelope.test.ts
+++ b/packages/schemas/src/llm-envelope.test.ts
@@ -290,4 +290,175 @@ describe('normaliseSignals', () => {
     });
     expect(result.ready_to_finish).toBe(true);
   });
+
+  it('defaults challenge round fields to false / empty array', () => {
+    const result = normaliseSignals(undefined);
+    expect(result.challenge_round_offer).toBe(false);
+    expect(result.challenge_round_evaluation).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Challenge Round envelope extensions (Task 1) — see
+// docs/plans/2026-05-18-challenge-round-into-note.md
+// ---------------------------------------------------------------------------
+
+describe('challenge round envelope fields', () => {
+  it('accepts challenge_round_offer signal', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: "You've got the basics — want a challenge round?",
+      signals: { challenge_round_offer: true },
+      confidence: 'medium',
+    });
+    expect(parsed.signals?.challenge_round_offer).toBe(true);
+  });
+
+  it('accepts challenge_round_evaluation per-concept results', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'Strong work.',
+      signals: {
+        challenge_round_evaluation: [
+          {
+            concept: 'photosynthesis vs respiration',
+            result: 'solid',
+            evidence: 'learner described both directions of energy flow',
+            answerEventId: 'event-solid-1',
+            learnerQuote:
+              'photosynthesis stores energy in glucose and respiration releases it',
+          },
+          {
+            concept: 'role of ATP',
+            result: 'partial',
+            evidence: 'mentioned energy currency, missed structure',
+            answerEventId: 'event-partial-1',
+            learnerQuote: 'ATP is like energy money',
+          },
+          {
+            concept: 'where it happens',
+            result: 'misconception',
+            evidence: 'said nucleus instead of chloroplast',
+            correction: 'occurs in chloroplasts',
+            answerEventId: 'event-misconception-1',
+            learnerQuote: 'photosynthesis happens in the nucleus',
+          },
+        ],
+      },
+      confidence: 'high',
+    });
+    expect(parsed.signals?.challenge_round_evaluation).toHaveLength(3);
+    expect(parsed.signals?.challenge_round_evaluation?.[2]?.correction).toBe(
+      'occurs in chloroplasts',
+    );
+  });
+
+  it('rejects evaluation item missing answerEventId (HIGH-6 grounding requirement)', () => {
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'OK.',
+      signals: {
+        challenge_round_evaluation: [
+          {
+            concept: 'x',
+            result: 'solid',
+            evidence: 'ok',
+            // missing answerEventId
+            learnerQuote: 'something',
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects evaluation item missing learnerQuote (HIGH-6 grounding requirement)', () => {
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'OK.',
+      signals: {
+        challenge_round_evaluation: [
+          {
+            concept: 'x',
+            result: 'solid',
+            evidence: 'ok',
+            answerEventId: 'e-1',
+            // missing learnerQuote
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('caps challenge_round_evaluation array at 10 items', () => {
+    const item = {
+      concept: 'x',
+      result: 'solid' as const,
+      evidence: 'ok',
+      answerEventId: 'e-1',
+      learnerQuote: 'q',
+    };
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'OK.',
+      signals: {
+        challenge_round_evaluation: Array.from({ length: 11 }, () => item),
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts challenge_round ui_hint', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'Question 2 of 3.',
+      ui_hints: {
+        challenge_round: {
+          active: true,
+          question_index: 1,
+          total_questions: 3,
+        },
+      },
+      confidence: 'high',
+    });
+    expect(parsed.ui_hints?.challenge_round?.active).toBe(true);
+    expect(parsed.ui_hints?.challenge_round?.question_index).toBe(1);
+    expect(parsed.ui_hints?.challenge_round?.total_questions).toBe(3);
+  });
+
+  it('coerces null active in challenge_round ui_hint to false', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: 'No round active.',
+      ui_hints: { challenge_round: { active: null } },
+    });
+    expect(parsed.ui_hints?.challenge_round?.active).toBe(false);
+  });
+
+  it('accepts note_draft ui_hint with content + sources', () => {
+    const parsed = llmResponseEnvelopeSchema.parse({
+      reply: "Here's what you know now.",
+      ui_hints: {
+        note_draft: {
+          content:
+            'Photosynthesis uses light to convert CO2 and water into glucose...',
+          source_concepts: ['photosynthesis vs respiration', 'role of ATP'],
+          source_answer_event_ids: ['event-solid-1', 'event-solid-2'],
+        },
+      },
+      confidence: 'high',
+    });
+    expect(parsed.ui_hints?.note_draft?.content).toMatch(/photosynthesis/i);
+    expect(parsed.ui_hints?.note_draft?.source_answer_event_ids).toHaveLength(
+      2,
+    );
+  });
+
+  it('rejects note_draft with empty source_answer_event_ids (HIGH-6)', () => {
+    const result = llmResponseEnvelopeSchema.safeParse({
+      reply: 'X.',
+      ui_hints: {
+        note_draft: {
+          content: 'something',
+          source_concepts: ['a'],
+          source_answer_event_ids: [],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/schemas/src/llm-envelope.ts
+++ b/packages/schemas/src/llm-envelope.ts
@@ -66,6 +66,28 @@ const privateSourcesSchema = z.preprocess(
     .optional(),
 );
 
+/**
+ * Per-concept evaluation produced during a Challenge Round. The LLM scores
+ * each concept the learner explained back; the server uses these to draft a
+ * note from `solid` items only and to persist weak spots for the rest.
+ *
+ * `answerEventId` + `learnerQuote` are required so the note drafter can
+ * synthesise from the learner's exact words (HIGH-6 from the Challenge Round
+ * plan). The drafter MUST refuse to use any item where these are missing or
+ * where the result is not `solid`.
+ */
+export const challengeRoundEvaluationItemSchema = z.object({
+  concept: z.string().min(1).max(200),
+  result: z.enum(['solid', 'partial', 'missing', 'misconception']),
+  evidence: z.string().min(1).max(500),
+  answerEventId: z.string().min(1).max(120),
+  learnerQuote: z.string().min(1).max(500),
+  correction: z.string().min(1).max(500).optional(),
+});
+export type ChallengeRoundEvaluationItem = z.infer<
+  typeof challengeRoundEvaluationItemSchema
+>;
+
 const signalsSchema = z.preprocess(
   optionalObjectInput,
   z
@@ -83,6 +105,13 @@ const signalsSchema = z.preprocess(
         nullToUndefined,
         z.number().min(0).max(1).optional(),
       ),
+      /** Challenge Round: model is proposing a challenge round at this turn. Server gates eligibility. */
+      challenge_round_offer: optionalBooleanSchema,
+      /** Challenge Round: per-concept evaluation of the learner's explanations. Drives mastery + note + weak-spot persistence. */
+      challenge_round_evaluation: z
+        .array(challengeRoundEvaluationItemSchema)
+        .max(10)
+        .optional(),
     })
     .optional(),
 );
@@ -156,12 +185,47 @@ const fluencyDrillSchema = z.preprocess(
     .optional(),
 );
 
+const challengeRoundUiHintSchema = z.preprocess(
+  optionalObjectInput,
+  z
+    .object({
+      active: falseWhenMissingBooleanSchema,
+      question_index: z.preprocess(
+        nullToUndefined,
+        z.number().int().min(0).max(9).optional(),
+      ),
+      total_questions: z.preprocess(
+        nullToUndefined,
+        z.number().int().min(1).max(10).optional(),
+      ),
+    })
+    .optional(),
+);
+
+const noteDraftUiHintSchema = z.preprocess(
+  optionalObjectInput,
+  z
+    .object({
+      content: z.string().min(1).max(2000),
+      source_concepts: z.array(z.string().min(1).max(200)).min(1).max(10),
+      source_answer_event_ids: z
+        .array(z.string().min(1).max(120))
+        .min(1)
+        .max(10),
+    })
+    .optional(),
+);
+
 const uiHintsSchema = z.preprocess(
   optionalObjectInput,
   z
     .object({
       note_prompt: notePromptSchema,
       fluency_drill: fluencyDrillSchema,
+      /** Challenge Round in-progress banner state — mobile renders question N of M. */
+      challenge_round: challengeRoundUiHintSchema,
+      /** Challenge Round drafted note awaiting learner save/edit/skip. */
+      note_draft: noteDraftUiHintSchema,
     })
     .optional(),
 );
@@ -192,6 +256,10 @@ export interface NormalisedEnvelopeSignals {
    *  null (not undefined) when not scored — distinguishes "no score yet" from
    *  "score of 0". */
   retrieval_score: number | null;
+  /** Challenge Round: LLM is proposing a challenge at this turn (server gates). */
+  challenge_round_offer: boolean;
+  /** Challenge Round: per-concept evaluations. Empty array when not in a round. */
+  challenge_round_evaluation: ChallengeRoundEvaluationItem[];
 }
 
 export function normaliseSignals(
@@ -206,6 +274,8 @@ export function normaliseSignals(
     needs_deepening: signals?.needs_deepening ?? false,
     understanding_check: signals?.understanding_check ?? false,
     retrieval_score: signals?.retrieval_score ?? null,
+    challenge_round_offer: signals?.challenge_round_offer ?? false,
+    challenge_round_evaluation: signals?.challenge_round_evaluation ?? [],
   };
 }
 

--- a/packages/schemas/src/progress.ts
+++ b/packages/schemas/src/progress.ts
@@ -11,6 +11,7 @@ import {
   reportPracticeSummarySchema,
 } from './snapshots';
 import { consentStatusSchema } from './consent';
+import { struggleStatusSchema } from './struggle-status';
 
 export const celebrationNameSchema = z.enum([
   'polar_star',
@@ -240,7 +241,7 @@ export const topicProgressSchema = z.object({
   ]),
   retentionStatus: z.enum(['strong', 'fading', 'weak', 'forgotten']).nullable(),
   daysSinceLastReview: z.number().int().min(0).nullable(),
-  struggleStatus: z.enum(['normal', 'needs_deepening', 'blocked']),
+  struggleStatus: struggleStatusSchema,
   masteryScore: z.number().min(0).max(1).nullable(),
   summaryExcerpt: z.string().nullable(),
   xpStatus: z.enum(['pending', 'verified', 'decayed']).nullable(),

--- a/packages/schemas/src/sessions.test.ts
+++ b/packages/schemas/src/sessions.test.ts
@@ -349,6 +349,100 @@ describe('sessionMetadataSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
+// sessionMetadata.challengeRound — Challenge Round in-session state
+// (Task 2 of docs/plans/2026-05-18-challenge-round-into-note.md)
+// ---------------------------------------------------------------------------
+describe('sessionMetadata.challengeRound', () => {
+  it('defaults to undefined when not set', () => {
+    const m = sessionMetadataSchema.parse({});
+    expect(m.challengeRound).toBeUndefined();
+  });
+
+  it('accepts an active state with question progress', () => {
+    const m = sessionMetadataSchema.parse({
+      challengeRound: {
+        state: 'active',
+        startedAt: new Date('2026-05-19T12:00:00Z').toISOString(),
+        questionIndex: 1,
+        totalQuestions: 3,
+        offerCount: 1,
+        topicId: UUID,
+      },
+    });
+    expect(m.challengeRound?.state).toBe('active');
+    expect(m.challengeRound?.questionIndex).toBe(1);
+    expect(m.challengeRound?.totalQuestions).toBe(3);
+  });
+
+  it('defaults offerCount + declinedDontAskAgain + evaluations when absent', () => {
+    const m = sessionMetadataSchema.parse({
+      challengeRound: { state: 'offered' },
+    });
+    expect(m.challengeRound?.offerCount).toBe(0);
+    expect(m.challengeRound?.declinedDontAskAgain).toBe(false);
+    expect(m.challengeRound?.evaluations).toEqual([]);
+  });
+
+  it('rejects an unknown state value', () => {
+    expect(
+      sessionMetadataSchema.safeParse({
+        challengeRound: { state: 'frobnicated' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('preserves declined + dontAskAgain combination', () => {
+    const m = sessionMetadataSchema.parse({
+      challengeRound: {
+        state: 'declined',
+        offerCount: 1,
+        declinedDontAskAgain: true,
+      },
+    });
+    expect(m.challengeRound?.state).toBe('declined');
+    expect(m.challengeRound?.declinedDontAskAgain).toBe(true);
+  });
+
+  it('caps evaluations array at 10 items', () => {
+    const item = {
+      concept: 'x',
+      result: 'solid' as const,
+      evidence: 'ok',
+      answerEventId: 'e-1',
+      learnerQuote: 'q',
+    };
+    expect(
+      sessionMetadataSchema.safeParse({
+        challengeRound: {
+          state: 'drafting',
+          evaluations: Array.from({ length: 11 }, () => item),
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('accepts a complete round with evaluations attached', () => {
+    const m = sessionMetadataSchema.parse({
+      challengeRound: {
+        state: 'complete',
+        questionIndex: 2,
+        totalQuestions: 3,
+        evaluations: [
+          {
+            concept: 'a',
+            result: 'solid',
+            evidence: 'ok',
+            answerEventId: 'e-a',
+            learnerQuote: 'q-a',
+          },
+        ],
+      },
+    });
+    expect(m.challengeRound?.evaluations).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // sessionStartSchema
 // ---------------------------------------------------------------------------
 describe('sessionStartSchema', () => {

--- a/packages/schemas/src/sessions.test.ts
+++ b/packages/schemas/src/sessions.test.ts
@@ -479,6 +479,24 @@ describe('sessionStartSchema', () => {
       }).success,
     ).toBe(false);
   });
+
+  it('strips server-owned challengeRound metadata from client starts', () => {
+    const result = sessionStartSchema.parse({
+      subjectId: UUID,
+      metadata: {
+        inputMode: 'voice',
+        challengeRound: {
+          state: 'active',
+          offerCount: 1,
+          topicId: UUID,
+          evaluations: [],
+        },
+      },
+    });
+
+    expect(result.metadata).toEqual({ inputMode: 'voice' });
+    expect(result.metadata).not.toHaveProperty('challengeRound');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/schemas/src/sessions.ts
+++ b/packages/schemas/src/sessions.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { verificationTypeSchema } from './assessments.ts';
 import { isoDateField } from './common.ts';
+import { challengeRoundEvaluationItemSchema } from './llm-envelope.ts';
 import {
   celebrationReasonSchema,
   pendingCelebrationSchema,
@@ -142,6 +143,45 @@ export const homeworkSummarySchema = z.object({
 });
 export type HomeworkSummary = z.infer<typeof homeworkSummarySchema>;
 
+/**
+ * Challenge Round state machine — lives inside session metadata so a session
+ * close + resume preserves which question the learner was on. The server is
+ * the source of truth; mobile reads state via the session SSE stream.
+ *
+ * - `offered`: server has offered the round; learner has not yet responded.
+ * - `accepted`: learner tapped Accept; first question is being prepared.
+ * - `declined`: learner tapped Decline. Combined with `declinedDontAskAgain`
+ *   to gate within-session re-offers.
+ * - `active`: a question has been delivered and the learner's answer is awaited.
+ * - `drafting`: all questions answered; note is being drafted from solid items.
+ * - `complete`: drafted note saved or skipped; the round is fully finished.
+ * - `aborted`: learner closed the session or hit silence timeout mid-round.
+ */
+export const challengeRoundStateEnum = z.enum([
+  'offered',
+  'accepted',
+  'declined',
+  'active',
+  'drafting',
+  'complete',
+  'aborted',
+]);
+export type ChallengeRoundState = z.infer<typeof challengeRoundStateEnum>;
+
+export const challengeRoundSessionStateSchema = z.object({
+  state: challengeRoundStateEnum,
+  startedAt: z.string().datetime().optional(),
+  questionIndex: z.number().int().min(0).max(9).optional(),
+  totalQuestions: z.number().int().min(1).max(10).optional(),
+  offerCount: z.number().int().min(0).default(0),
+  topicId: z.string().uuid().optional(),
+  declinedDontAskAgain: z.boolean().default(false),
+  evaluations: z.array(challengeRoundEvaluationItemSchema).max(10).default([]),
+});
+export type ChallengeRoundSessionState = z.infer<
+  typeof challengeRoundSessionStateSchema
+>;
+
 export const sessionMetadataSchema = z
   .object({
     inputMode: inputModeSchema.optional(),
@@ -173,6 +213,11 @@ export const sessionMetadataSchema = z
     continuationDepth: z.enum(['low', 'mid', 'high']).optional(),
     reviewCalibrationAttempts: z.number().int().min(0).optional(),
     reviewCalibrationFiredAt: isoDateField.optional(),
+    /**
+     * Challenge Round state machine for this session. Server-owned; mobile
+     * reflects via session-streaming. Absent = no round has been offered.
+     */
+    challengeRound: challengeRoundSessionStateSchema.optional(),
   })
   .strip();
 export type SessionMetadata = z.infer<typeof sessionMetadataSchema>;

--- a/packages/schemas/src/sessions.ts
+++ b/packages/schemas/src/sessions.ts
@@ -222,13 +222,17 @@ export const sessionMetadataSchema = z
   .strip();
 export type SessionMetadata = z.infer<typeof sessionMetadataSchema>;
 
+export const sessionStartMetadataSchema = sessionMetadataSchema.omit({
+  challengeRound: true,
+});
+
 export const sessionStartSchema = z.object({
   subjectId: z.string().uuid(),
   topicId: z.string().uuid().optional(),
   sessionType: sessionTypeSchema.default('learning'),
   verificationType: z.enum(['standard', 'evaluate', 'teach_back']).optional(),
   inputMode: inputModeSchema.default('text'),
-  metadata: sessionMetadataSchema.optional(),
+  metadata: sessionStartMetadataSchema.optional(),
   rawInput: z.string().max(500).nullable().optional(),
 });
 export type SessionStartInput = z.infer<typeof sessionStartSchema>;

--- a/packages/schemas/src/struggle-status.test.ts
+++ b/packages/schemas/src/struggle-status.test.ts
@@ -1,0 +1,19 @@
+import {
+  struggleStatusSchema,
+  type StruggleStatus,
+} from './struggle-status.js';
+
+describe('struggleStatusSchema', () => {
+  it('accepts the three canonical values', () => {
+    for (const value of ['normal', 'needs_deepening', 'blocked'] as const) {
+      const parsed: StruggleStatus = struggleStatusSchema.parse(value);
+      expect(parsed).toBe(value);
+    }
+  });
+
+  it('rejects unknown values', () => {
+    expect(struggleStatusSchema.safeParse('struggling').success).toBe(false);
+    expect(struggleStatusSchema.safeParse('').success).toBe(false);
+    expect(struggleStatusSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/struggle-status.ts
+++ b/packages/schemas/src/struggle-status.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const struggleStatusSchema = z.enum([
+  'normal',
+  'needs_deepening',
+  'blocked',
+]);
+export type StruggleStatus = z.infer<typeof struggleStatusSchema>;


### PR DESCRIPTION
PR C (second slice) — sessionMetadata.challengeRound state schema, `challenge_round_cooldowns` DB table, and the pure trigger evaluator. Stacks on the now-merged envelope schema work (#333).

## What ships

### Task 2 — sessionMetadata.challengeRound + cooldown DB table
- New `challengeRoundStateEnum` (`offered`/`accepted`/`declined`/`active`/`drafting`/`complete`/`aborted`) + `challengeRoundSessionStateSchema` exported from `packages/schemas/src/sessions.ts`. State carries `questionIndex`/`totalQuestions`/`offerCount`/`topicId`/`declinedDontAskAgain`/`evaluations`.
- `sessionMetadataSchema` extended with optional `challengeRound` field (server-owned; mobile reads via session SSE stream).
- **New DB table** `challenge_round_cooldowns` — per `(profile_id, topic_id)` unique, FKs cascade on both axes (MED-2 from the plan). Migration `0080_slippery_groot.sql` + rollback doc generated via `drizzle-kit generate`.
- 7 new sessions.test.ts cases covering: defaults, active state, declined+dontAskAgain, evaluations cap (max 10), complete with attached evaluations, unknown-state rejection.

### Task 3 — `evaluateChallengeReadiness` pure function
- New service dir `apps/api/src/services/challenge-round/` with `trigger.ts` + `trigger.test.ts`.
- 25 tests across four describe blocks: hard gates (session type / struggle / exchanges / streak / retention), current-session new-topic path (MED-8 — sustained solid answers can offer on a brand-new topic), quota budget (ROUTING-3 — absolute remaining-turn budget replaces percentage-only gate), and in-session state + cooldown (already-in-round / dontAskAgain / 24h cross-session cooldown).
- **Reason codes** exported for the route layer to surface to mobile.
- `ChallengeReadinessRetentionInput = RetentionStatus | 'new'` — documents that `'new'` is the caller's translation of "no retention card row yet" since `retentionStatusSchema` only enumerates post-card states.

## Verification

\`pnpm exec jest --testPathPatterns="sessions|llm-envelope|struggle-status"\` from \`packages/schemas/\` — **143/143 tests pass**.
\`pnpm exec jest src/services/challenge-round/trigger.test.ts --no-coverage\` from \`apps/api/\` — **25/25 tests pass**.

Verified in main checkout per worktree-jest-haste-map memory workaround.

## What's NOT in this PR (deferred)

- **Caller wiring** — \`processExchange()\` does not yet call \`evaluateChallengeReadiness\`. The trigger is callable but unwired. That comes in Task 8 (PR D).
- **Cooldown writer** — \`recordCooldown()\` helper + the \`/decline\` route that calls it. Comes in Task 9.
- **State-machine transitions** — \`transitionChallengeState()\` from Task 4. Belongs next to the routes layer.
- **Mobile** — entire surface (Task 10).

## Stacking note

PR #333 (envelope + struggle-status) was merged into the \`challenge-round-targets\` branch, not into \`main\` directly. This PR's base is \`main\`, but it depends on #333's content. Two ways to land cleanly:
- **Option A:** Merge \`challenge-round-targets\` → \`main\` first (a one-line PR), then this PR will be a clean fast-forward.
- **Option B:** Re-base this PR onto \`challenge-round-targets\` instead of \`main\` and let the eventual \`challenge-round-targets\` → \`main\` merge land all three slices in one go.

I went with Option A's framing by targeting \`main\` directly; flag this if you'd rather restack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added challenge round cooldown tracking to prevent offering challenges too frequently.
  * Extended session metadata to track challenge round state across user interactions.
  * Added support for challenge round evaluation data and draft note UI hints in response schemas.

* **Documentation**
  * Updated implementation plan with finalized routing and session helper details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->