### PR TITLE
feat(api): challenge round pure-function helpers (Tasks 4-6)

### DIFF
--- a/apps/api/src/services/challenge-round/caps.test.ts
+++ b/apps/api/src/services/challenge-round/caps.test.ts
@@ -1,0 +1,40 @@
+import {
+  CHALLENGE_OFFER_COOLDOWN_HOURS,
+  MAX_CHALLENGE_ANSWER_CHARS,
+  MAX_CHALLENGE_QUESTIONS,
+  MIN_LEXICAL_OVERLAP_NOTE_DRAFT,
+  enforceChallengeQuestionCap,
+} from './caps';
+
+describe('challenge-round caps', () => {
+  it('exposes MAX_CHALLENGE_QUESTIONS = 3', () => {
+    expect(MAX_CHALLENGE_QUESTIONS).toBe(3);
+  });
+
+  it('exposes MAX_CHALLENGE_ANSWER_CHARS = 2000', () => {
+    expect(MAX_CHALLENGE_ANSWER_CHARS).toBe(2000);
+  });
+
+  it('exposes CHALLENGE_OFFER_COOLDOWN_HOURS = 24', () => {
+    expect(CHALLENGE_OFFER_COOLDOWN_HOURS).toBe(24);
+  });
+
+  it('exposes MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4', () => {
+    expect(MIN_LEXICAL_OVERLAP_NOTE_DRAFT).toBe(0.4);
+  });
+});
+
+describe('enforceChallengeQuestionCap', () => {
+  it('caps a requested 5 down to the MAX', () => {
+    expect(enforceChallengeQuestionCap(5)).toBe(MAX_CHALLENGE_QUESTIONS);
+  });
+
+  it('passes a valid in-range value through', () => {
+    expect(enforceChallengeQuestionCap(2)).toBe(2);
+  });
+
+  it('floors zero/negative input to 1 (never returns 0-question round)', () => {
+    expect(enforceChallengeQuestionCap(0)).toBe(1);
+    expect(enforceChallengeQuestionCap(-3)).toBe(1);
+  });
+});

--- a/apps/api/src/services/challenge-round/caps.ts
+++ b/apps/api/src/services/challenge-round/caps.ts
@@ -13,6 +13,9 @@
 export const MAX_CHALLENGE_QUESTIONS = 3;
 export const MAX_CHALLENGE_ANSWER_CHARS = 2000;
 export const CHALLENGE_OFFER_COOLDOWN_HOURS = 24;
+// Initial guess (MED-3). TODO: calibrate after first ~100 production challenge
+// rounds by histogramming `validateNoteDraft().overlapRatio` per outcome.
+// Adjust up if hallucinated drafts pass; down if learner-grounded drafts fail.
 export const MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4;
 
 export function enforceChallengeQuestionCap(requested: number): number {

--- a/apps/api/src/services/challenge-round/caps.ts
+++ b/apps/api/src/services/challenge-round/caps.ts
@@ -1,0 +1,22 @@
+/**
+ * Challenge Round caps and constants used by both the state machine and the
+ * note drafter. Keep all hard caps in one place so the trigger evaluator,
+ * state-machine helpers, prompt builders, and tests refer to the same values.
+ *
+ * The drafter-side overlap threshold `MIN_LEXICAL_OVERLAP_NOTE_DRAFT` is
+ * intentionally exported here rather than inside `note-draft.ts` so the value
+ * is visible to caps-tests and any future calibration script.
+ *
+ * Source: `docs/plans/2026-05-18-challenge-round-into-note.md` Task 4 + MED-3.
+ */
+
+export const MAX_CHALLENGE_QUESTIONS = 3;
+export const MAX_CHALLENGE_ANSWER_CHARS = 2000;
+export const CHALLENGE_OFFER_COOLDOWN_HOURS = 24;
+export const MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4;
+
+export function enforceChallengeQuestionCap(requested: number): number {
+  if (requested < 1) return 1;
+  if (requested > MAX_CHALLENGE_QUESTIONS) return MAX_CHALLENGE_QUESTIONS;
+  return requested;
+}

--- a/apps/api/src/services/challenge-round/evaluation.test.ts
+++ b/apps/api/src/services/challenge-round/evaluation.test.ts
@@ -1,0 +1,244 @@
+import type { ChallengeRoundEvaluationItem } from '@eduagent/schemas';
+import { decideMasteryAndReview, summarizeEvaluation } from './evaluation';
+
+const allSolid: ChallengeRoundEvaluationItem[] = [
+  {
+    concept: 'a',
+    result: 'solid',
+    evidence: 'x',
+    answerEventId: 'e1',
+    learnerQuote: 'I said a clearly',
+  },
+  {
+    concept: 'b',
+    result: 'solid',
+    evidence: 'y',
+    answerEventId: 'e2',
+    learnerQuote: 'I said b clearly',
+  },
+  {
+    concept: 'c',
+    result: 'solid',
+    evidence: 'z',
+    answerEventId: 'e3',
+    learnerQuote: 'I said c clearly',
+  },
+];
+
+const mixed: ChallengeRoundEvaluationItem[] = [
+  {
+    concept: 'a',
+    result: 'solid',
+    evidence: 'x',
+    answerEventId: 'e1',
+    learnerQuote: 'I said a clearly',
+  },
+  {
+    concept: 'b',
+    result: 'partial',
+    evidence: 'partial-evidence-b',
+    answerEventId: 'e2',
+    learnerQuote: 'I partly said b',
+  },
+  {
+    concept: 'c',
+    result: 'misconception',
+    evidence: 'learner confused c with d',
+    correction: 'C is actually …',
+    answerEventId: 'e3',
+    learnerQuote: 'I said c incorrectly',
+  },
+];
+
+const allMissing: ChallengeRoundEvaluationItem[] = [
+  {
+    concept: 'a',
+    result: 'missing',
+    evidence: 'no answer',
+    answerEventId: 'e1',
+    learnerQuote: 'idk',
+  },
+  {
+    concept: 'b',
+    result: 'missing',
+    evidence: 'no answer',
+    answerEventId: 'e2',
+    learnerQuote: 'pass',
+  },
+];
+
+describe('decideMasteryAndReview — happy path (all solid)', () => {
+  it('marks the round verified and exposes all solid concepts + quotes', () => {
+    const d = decideMasteryAndReview(allSolid);
+    expect(d.outcome).toBe('verified');
+    expect(d.markMasteryVerified).toBe(true);
+    expect(d.reviewTargets).toEqual([]);
+    expect(d.solidConcepts).toEqual(['a', 'b', 'c']);
+    expect(d.solidAnswerQuotes).toEqual([
+      'I said a clearly',
+      'I said b clearly',
+      'I said c clearly',
+    ]);
+  });
+});
+
+describe('decideMasteryAndReview — mixed (partial + misconception)', () => {
+  it('returns outcome=partial; never marks mastery', () => {
+    const d = decideMasteryAndReview(mixed);
+    expect(d.outcome).toBe('partial');
+    expect(d.markMasteryVerified).toBe(false);
+  });
+
+  it('promotes only partial+misconception concepts into reviewTargets', () => {
+    const d = decideMasteryAndReview(mixed);
+    expect(d.reviewTargets.map((r) => r.concept).sort()).toEqual(['b', 'c']);
+    expect(d.reviewTargets.every((r) => r.source === 'challenge_round')).toBe(
+      true,
+    );
+  });
+
+  it('preserves correction text on misconception targets', () => {
+    const d = decideMasteryAndReview(mixed);
+    const cTarget = d.reviewTargets.find((r) => r.concept === 'c');
+    expect(cTarget?.correction).toBe('C is actually …');
+    expect(cTarget?.misconception).toBe('learner confused c with d');
+  });
+
+  it('exposes only solid concepts + quotes (never partial/misconception)', () => {
+    const d = decideMasteryAndReview(mixed);
+    expect(d.solidConcepts).toEqual(['a']);
+    expect(d.solidAnswerQuotes).toEqual(['I said a clearly']);
+    expect(d.solidAnswerQuotes).not.toContain('I partly said b');
+    expect(d.solidAnswerQuotes).not.toContain('I said c incorrectly');
+  });
+});
+
+describe('decideMasteryAndReview — adversarial misconception (HIGH-8)', () => {
+  it('any misconception blocks mastery even if all other concepts are solid', () => {
+    const mostlySolid: ChallengeRoundEvaluationItem[] = [
+      {
+        concept: 'a',
+        result: 'solid',
+        evidence: 'x',
+        answerEventId: 'e1',
+        learnerQuote: 'solid a',
+      },
+      {
+        concept: 'b',
+        result: 'solid',
+        evidence: 'y',
+        answerEventId: 'e2',
+        learnerQuote: 'solid b',
+      },
+      {
+        concept: 'c',
+        result: 'misconception',
+        evidence: 'subtle wrong idea',
+        correction: 'right idea',
+        answerEventId: 'e3',
+        learnerQuote: 'wrong c',
+      },
+    ];
+    const d = decideMasteryAndReview(mostlySolid);
+    expect(d.markMasteryVerified).toBe(false);
+    expect(d.outcome).toBe('partial');
+    expect(d.reviewTargets.map((r) => r.concept)).toEqual(['c']);
+  });
+
+  it('a single partial also blocks mastery', () => {
+    const oneShaky: ChallengeRoundEvaluationItem[] = [
+      ...allSolid.slice(0, 2),
+      {
+        concept: 'c',
+        result: 'partial',
+        evidence: 'incomplete',
+        answerEventId: 'e3',
+        learnerQuote: 'mostly c',
+      },
+    ];
+    expect(decideMasteryAndReview(oneShaky).markMasteryVerified).toBe(false);
+  });
+});
+
+describe('decideMasteryAndReview — reteach / invalid edge cases', () => {
+  it('all missing → outcome=reteach, no note, no mastery, no review targets', () => {
+    const d = decideMasteryAndReview(allMissing);
+    expect(d.outcome).toBe('reteach');
+    expect(d.markMasteryVerified).toBe(false);
+    expect(d.solidConcepts).toEqual([]);
+    expect(d.solidAnswerQuotes).toEqual([]);
+    expect(d.reviewTargets).toEqual([]);
+  });
+
+  // CRIT-9: a naive `solidCount === evals.length` check returns true for
+  // `0 === 0`. The guard must short-circuit on empty input BEFORE that
+  // check, returning `outcome: 'invalid'` so no mastery is recorded for
+  // a Challenge Round that produced no evaluations (LLM failure, abort,
+  // schema rejection, etc.).
+  it('empty evaluations → outcome=invalid, never marks mastery (CRIT-9)', () => {
+    const d = decideMasteryAndReview([]);
+    expect(d.outcome).toBe('invalid');
+    expect(d.markMasteryVerified).toBe(false);
+    expect(d.solidConcepts).toEqual([]);
+    expect(d.solidAnswerQuotes).toEqual([]);
+    expect(d.reviewTargets).toEqual([]);
+  });
+
+  it('only missing + partial → outcome=partial (not reteach)', () => {
+    const oneMissingOnePartial: ChallengeRoundEvaluationItem[] = [
+      {
+        concept: 'a',
+        result: 'missing',
+        evidence: 'no answer',
+        answerEventId: 'e1',
+        learnerQuote: 'idk',
+      },
+      {
+        concept: 'b',
+        result: 'partial',
+        evidence: 'half-answer',
+        answerEventId: 'e2',
+        learnerQuote: 'mostly b',
+      },
+    ];
+    const d = decideMasteryAndReview(oneMissingOnePartial);
+    expect(d.outcome).toBe('partial');
+    expect(d.reviewTargets.map((r) => r.concept)).toEqual(['b']);
+  });
+});
+
+describe('summarizeEvaluation', () => {
+  it('counts per result bucket', () => {
+    expect(summarizeEvaluation(mixed)).toEqual({
+      solid: 1,
+      partial: 1,
+      missing: 0,
+      misconception: 1,
+      total: 3,
+    });
+  });
+
+  it('returns zeros for an empty list', () => {
+    expect(summarizeEvaluation([])).toEqual({
+      solid: 0,
+      partial: 0,
+      missing: 0,
+      misconception: 0,
+      total: 0,
+    });
+  });
+
+  it('sums correctly across all four buckets', () => {
+    const full: ChallengeRoundEvaluationItem[] = [
+      ...allSolid,
+      ...allMissing,
+      ...mixed,
+    ];
+    const s = summarizeEvaluation(full);
+    expect(s.total).toBe(allSolid.length + allMissing.length + mixed.length);
+    expect(s.solid).toBe(4);
+    expect(s.partial).toBe(1);
+    expect(s.missing).toBe(2);
+    expect(s.misconception).toBe(1);
+  });
+});

--- a/apps/api/src/services/challenge-round/evaluation.ts
+++ b/apps/api/src/services/challenge-round/evaluation.ts
@@ -1,0 +1,144 @@
+import type { ChallengeRoundEvaluationItem } from '@eduagent/schemas';
+
+/**
+ * Per-answer evaluation outcomes and mastery decision for a finished
+ * Challenge Round.
+ *
+ * Server-owned, conservative gating over structured LLM evidence
+ * (HIGH-8): the LLM scores each concept as `solid|partial|missing|
+ * misconception` via the envelope; this module decides what reaches the
+ * note drafter, the weak-spot persistence path, and the mastery axis.
+ *
+ * Invariants:
+ *  - An empty evaluation array → `outcome: 'invalid'` and NEVER
+ *    `markMasteryVerified` (CRIT-9: `0 === 0` would otherwise pass a
+ *    naive "all solid" check).
+ *  - A single `partial` or `misconception` is sufficient to block
+ *    `markMasteryVerified` regardless of how many concepts were solid.
+ *  - `solidConcepts` / `solidAnswerQuotes` only ever contain items
+ *    whose `result === 'solid'`. The note drafter must source quotes
+ *    from `solidAnswerQuotes` alone — never the full transcript and
+ *    never partial/misconception quotes (HIGH-6).
+ *  - `reviewTargets` cover `partial` and `misconception` items only;
+ *    `missing` items are not durable weak spots (no learner-emitted
+ *    text to attach).
+ *  - `outcome: 'reteach'` is reserved for the case where every
+ *    evaluated concept is `missing` (the learner could not produce any
+ *    answer at all). It does not draft a note and does not mark
+ *    mastery.
+ *
+ * Reviewed in `docs/plans/2026-05-18-challenge-round-into-note.md`
+ * (Task 5).
+ */
+
+export interface ReviewTarget {
+  concept: string;
+  answerEventId: string;
+  misconception?: string;
+  correction?: string;
+  source: 'challenge_round';
+}
+
+export type MasteryOutcome = 'verified' | 'partial' | 'reteach' | 'invalid';
+
+export interface MasteryDecision {
+  outcome: MasteryOutcome;
+  markMasteryVerified: boolean;
+  solidConcepts: string[];
+  solidAnswerQuotes: string[];
+  reviewTargets: ReviewTarget[];
+}
+
+export interface EvaluationSummary {
+  solid: number;
+  partial: number;
+  missing: number;
+  misconception: number;
+  total: number;
+}
+
+export function decideMasteryAndReview(
+  evals: ChallengeRoundEvaluationItem[],
+): MasteryDecision {
+  if (evals.length === 0) {
+    return {
+      outcome: 'invalid',
+      markMasteryVerified: false,
+      solidConcepts: [],
+      solidAnswerQuotes: [],
+      reviewTargets: [],
+    };
+  }
+
+  const solidItems = evals.filter((e) => e.result === 'solid');
+  const solidConcepts = solidItems.map((e) => e.concept);
+  const solidAnswerQuotes = solidItems.map((e) => e.learnerQuote);
+
+  const hasMisconception = evals.some((e) => e.result === 'misconception');
+  const hasPartial = evals.some((e) => e.result === 'partial');
+  const allMissing = evals.every((e) => e.result === 'missing');
+
+  const reviewTargets: ReviewTarget[] = evals
+    .filter((e) => e.result === 'partial' || e.result === 'misconception')
+    .map((e) => ({
+      concept: e.concept,
+      answerEventId: e.answerEventId,
+      misconception: e.result === 'misconception' ? e.evidence : undefined,
+      correction: e.correction,
+      source: 'challenge_round' as const,
+    }));
+
+  if (allMissing) {
+    return {
+      outcome: 'reteach',
+      markMasteryVerified: false,
+      solidConcepts: [],
+      solidAnswerQuotes: [],
+      reviewTargets,
+    };
+  }
+
+  if (solidItems.length === evals.length && !hasMisconception && !hasPartial) {
+    return {
+      outcome: 'verified',
+      markMasteryVerified: true,
+      solidConcepts,
+      solidAnswerQuotes,
+      reviewTargets: [],
+    };
+  }
+
+  return {
+    outcome: 'partial',
+    markMasteryVerified: false,
+    solidConcepts,
+    solidAnswerQuotes,
+    reviewTargets,
+  };
+}
+
+export function summarizeEvaluation(
+  evals: ChallengeRoundEvaluationItem[],
+): EvaluationSummary {
+  let solid = 0;
+  let partial = 0;
+  let missing = 0;
+  let misconception = 0;
+  for (const e of evals) {
+    switch (e.result) {
+      case 'solid':
+        solid++;
+        break;
+      case 'partial':
+        partial++;
+        break;
+      case 'missing':
+        missing++;
+        break;
+      case 'misconception':
+        misconception++;
+        break;
+    }
+  }
+  return { solid, partial, missing, misconception, total: evals.length };
+}

--- a/apps/api/src/services/challenge-round/note-draft.test.ts
+++ b/apps/api/src/services/challenge-round/note-draft.test.ts
@@ -1,0 +1,86 @@
+import { validateNoteDraft } from './note-draft';
+
+const solidLearnerQuotes = [
+  'Photosynthesis happens in chloroplasts. The plant uses light energy to convert carbon dioxide and water into glucose.',
+  'ATP is the energy currency of the cell.',
+];
+
+describe('validateNoteDraft — accepts grounded drafts', () => {
+  it('accepts a draft whose vocabulary overlaps strongly with the learner', () => {
+    const draft =
+      'Photosynthesis takes place in chloroplasts. Light energy converts carbon dioxide and water into glucose. ATP is the cell energy currency.';
+    const r = validateNoteDraft(draft, solidLearnerQuotes);
+    expect(r.ok).toBe(true);
+    expect(r.overlapRatio).toBeGreaterThan(0.4);
+  });
+
+  it('accepts a short but meaningful draft (n-gram fallback path)', () => {
+    expect(
+      validateNoteDraft('ATP stores energy.', ['ATP stores energy.']).ok,
+    ).toBe(true);
+  });
+
+  it('reports overlapRatio above threshold for an accepted draft', () => {
+    const r = validateNoteDraft(
+      'Photosynthesis happens in chloroplasts. ATP is energy currency.',
+      solidLearnerQuotes,
+    );
+    expect(r.ok).toBe(true);
+    expect(r.overlapRatio).toBeGreaterThan(0.4);
+  });
+});
+
+describe('validateNoteDraft — rejects ungrounded drafts (HIGH-1 topic drift)', () => {
+  it('rejects a draft that invents new topic content', () => {
+    const draft =
+      'The Krebs cycle is essential for cellular respiration and produces NADH and FADH2 electron carriers.';
+    const r = validateNoteDraft(draft, solidLearnerQuotes);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('low_lexical_overlap');
+  });
+
+  it('rejects an empty draft with reason=empty', () => {
+    const r = validateNoteDraft('', solidLearnerQuotes);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('empty');
+  });
+
+  it('rejects a whitespace-only draft', () => {
+    expect(validateNoteDraft('   \n\t', solidLearnerQuotes).ok).toBe(false);
+  });
+
+  // HIGH-6 boundary: callers must pass only solid quotes. The guard
+  // measures overlap against whatever it receives, so if you accidentally
+  // pass non-solid quotes the draft can pass; that is a *caller* bug, not
+  // a guard bug. This test pins both sides of the contract.
+  it('rejects when overlap is only with non-solid text (caller contract)', () => {
+    const wrongIdeas = [
+      'photosynthesis happens in the nucleus',
+      'ATP means atomic transfer power',
+    ];
+    const draft =
+      'Photosynthesis happens in the nucleus and ATP means atomic transfer power.';
+    expect(validateNoteDraft(draft, solidLearnerQuotes).ok).toBe(false);
+    expect(validateNoteDraft(draft, wrongIdeas).ok).toBe(true);
+  });
+});
+
+describe('validateNoteDraft — Unicode + non-Latin tokenization (MED-10)', () => {
+  it('accepts accented Latin (Czech) when the draft mirrors the learner', () => {
+    const quotes = ['Fotosyntéza probíhá v chloroplastech a vytváří glukózu.'];
+    const draft = 'Fotosyntéza probíhá v chloroplastech a vytváří glukózu.';
+    expect(validateNoteDraft(draft, quotes).ok).toBe(true);
+  });
+
+  it('accepts non-spaced script (Japanese) via the character n-gram fallback', () => {
+    const quotes = ['光合成は葉緑体で行われます'];
+    const draft = '光合成は葉緑体で行われます';
+    expect(validateNoteDraft(draft, quotes).ok).toBe(true);
+  });
+
+  it('rejects a Japanese draft that drifts to an unrelated string', () => {
+    const quotes = ['光合成は葉緑体で行われます'];
+    const draft = '今日の天気は晴れです';
+    expect(validateNoteDraft(draft, quotes).ok).toBe(false);
+  });
+});

--- a/apps/api/src/services/challenge-round/note-draft.ts
+++ b/apps/api/src/services/challenge-round/note-draft.ts
@@ -1,0 +1,125 @@
+import { MIN_LEXICAL_OVERLAP_NOTE_DRAFT } from './caps';
+
+/**
+ * Lexical-overlap guard for Challenge Round note drafts.
+ *
+ * Scope (HIGH-1): this guard catches *topic drift* — the LLM produced a draft
+ * whose vocabulary does not overlap meaningfully with the learner's own
+ * answers (e.g. switched from photosynthesis to the Krebs cycle). It does
+ * NOT catch *value substitution* within shared vocabulary (e.g. swapping
+ * "chloroplast" for "mitochondria") because both tokens are in the
+ * learner's vocabulary and overlap stays high.
+ *
+ * Value-substitution defense lives upstream: callers must pass ONLY
+ * `decision.solidAnswerQuotes` from `decideMasteryAndReview` — never the
+ * full transcript and never partial/misconception text. The drafter must
+ * also be prompted only on `solid` concepts (HIGH-6). If
+ * `solidAnswerQuotes.length === 0`, do not call the drafter and do not
+ * emit `ui_hints.note_draft`.
+ *
+ * Tokenization (MED-10): Unicode-aware word tokenization first, with a
+ * character-bigram fallback when the input does not split on whitespace
+ * (e.g. Japanese) or yields only a single content word. NFKC normalization
+ * + lowercase + a small English stopword set. Tokens shorter than 3
+ * characters are dropped to avoid trivial-token noise.
+ *
+ * Calibration (MED-3): the 0.4 threshold in `caps.ts` is an initial guess.
+ * Plan Task 6 Step 4 calls for re-tuning after the eval harness produces
+ * an overlap-ratio histogram across the drafting scenarios.
+ */
+
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'is',
+  'are',
+  'and',
+  'or',
+  'of',
+  'to',
+  'in',
+  'on',
+  'for',
+  'with',
+  'as',
+  'by',
+  'at',
+  'it',
+  'its',
+  'this',
+  'that',
+  'be',
+  'was',
+  'were',
+  'has',
+  'have',
+  'had',
+  'do',
+  'does',
+  'did',
+  'i',
+  'you',
+  'they',
+  'we',
+  'he',
+  'she',
+]);
+
+function normalize(text: string): string {
+  return text.normalize('NFKC').toLocaleLowerCase();
+}
+
+function characterNgrams(text: string, n = 2): Set<string> {
+  const chars = Array.from(normalize(text).replace(/[^\p{L}\p{N}]/gu, ''));
+  const grams = new Set<string>();
+  for (let i = 0; i <= chars.length - n; i += 1) {
+    grams.add(chars.slice(i, i + n).join(''));
+  }
+  return grams;
+}
+
+function tokenize(text: string): Set<string> {
+  const wordTokens = new Set(
+    normalize(text)
+      .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+      .split(/\s+/)
+      .filter((t) => t.length > 2 && !STOPWORDS.has(t)),
+  );
+  return wordTokens.size > 1 ? wordTokens : characterNgrams(text);
+}
+
+export type DraftValidationReason =
+  | 'empty'
+  | 'no_content_tokens'
+  | 'low_lexical_overlap';
+
+export interface DraftValidationResult {
+  ok: boolean;
+  overlapRatio: number;
+  reason?: DraftValidationReason;
+}
+
+export function validateNoteDraft(
+  draft: string,
+  solidLearnerQuotes: string[],
+): DraftValidationResult {
+  if (!draft.trim()) {
+    return { ok: false, overlapRatio: 0, reason: 'empty' };
+  }
+  const draftTokens = tokenize(draft);
+  if (draftTokens.size === 0) {
+    return { ok: false, overlapRatio: 0, reason: 'no_content_tokens' };
+  }
+  const learnerTokens = tokenize(solidLearnerQuotes.join(' '));
+
+  let overlap = 0;
+  for (const tok of draftTokens) {
+    if (learnerTokens.has(tok)) overlap += 1;
+  }
+  const ratio = overlap / draftTokens.size;
+  if (ratio < MIN_LEXICAL_OVERLAP_NOTE_DRAFT) {
+    return { ok: false, overlapRatio: ratio, reason: 'low_lexical_overlap' };
+  }
+  return { ok: true, overlapRatio: ratio };
+}

--- a/apps/api/src/services/challenge-round/state.test.ts
+++ b/apps/api/src/services/challenge-round/state.test.ts
@@ -1,0 +1,283 @@
+import type {
+  ChallengeRoundEvaluationItem,
+  ChallengeRoundSessionState,
+} from '@eduagent/schemas';
+import { transitionChallengeState } from './state';
+
+const TOPIC_ID = '11111111-1111-1111-1111-111111111111';
+
+function evalItem(
+  overrides: Partial<ChallengeRoundEvaluationItem> = {},
+): ChallengeRoundEvaluationItem {
+  return {
+    concept: 'photosynthesis',
+    result: 'solid',
+    evidence: 'learner described chloroplast role correctly',
+    answerEventId: 'event-1',
+    learnerQuote: 'plants use chloroplasts to capture light',
+    ...overrides,
+  };
+}
+
+const baseState: ChallengeRoundSessionState = {
+  state: 'offered',
+  offerCount: 1,
+  topicId: TOPIC_ID,
+  declinedDontAskAgain: false,
+  evaluations: [],
+};
+
+describe('transitionChallengeState — offer', () => {
+  it('undefined → offered with offerCount=1', () => {
+    const next = transitionChallengeState(undefined, {
+      type: 'offer',
+      topicId: TOPIC_ID,
+    });
+    expect(next?.state).toBe('offered');
+    expect(next?.offerCount).toBe(1);
+    expect(next?.topicId).toBe(TOPIC_ID);
+    expect(next?.declinedDontAskAgain).toBe(false);
+    expect(next?.evaluations).toEqual([]);
+  });
+
+  it('complete → offered increments offerCount', () => {
+    const next = transitionChallengeState(
+      { ...baseState, state: 'complete', offerCount: 2 },
+      { type: 'offer', topicId: TOPIC_ID },
+    );
+    expect(next?.state).toBe('offered');
+    expect(next?.offerCount).toBe(3);
+  });
+
+  it('aborted → offered is allowed', () => {
+    const next = transitionChallengeState(
+      { ...baseState, state: 'aborted' },
+      { type: 'offer', topicId: TOPIC_ID },
+    );
+    expect(next?.state).toBe('offered');
+  });
+
+  it('rejects offer from a live state (active)', () => {
+    expect(() =>
+      transitionChallengeState(
+        { ...baseState, state: 'active' },
+        { type: 'offer', topicId: TOPIC_ID },
+      ),
+    ).toThrow(/illegal/i);
+  });
+});
+
+describe('transitionChallengeState — accept / decline', () => {
+  it('offered → accepted', () => {
+    const next = transitionChallengeState(baseState, { type: 'accept' });
+    expect(next?.state).toBe('accepted');
+  });
+
+  it('offered → declined preserves dontAskAgain=true', () => {
+    const next = transitionChallengeState(baseState, {
+      type: 'decline',
+      dontAskAgain: true,
+    });
+    expect(next?.state).toBe('declined');
+    expect(next?.declinedDontAskAgain).toBe(true);
+  });
+
+  it('offered → declined preserves dontAskAgain=false (one-off skip)', () => {
+    const next = transitionChallengeState(baseState, {
+      type: 'decline',
+      dontAskAgain: false,
+    });
+    expect(next?.declinedDontAskAgain).toBe(false);
+  });
+
+  it('rejects accept from a non-offered state', () => {
+    expect(() =>
+      transitionChallengeState(
+        { ...baseState, state: 'active' },
+        { type: 'accept' },
+      ),
+    ).toThrow(/illegal/i);
+  });
+
+  it('rejects decline from a non-offered state', () => {
+    expect(() =>
+      transitionChallengeState(
+        { ...baseState, state: 'accepted' },
+        { type: 'decline', dontAskAgain: false },
+      ),
+    ).toThrow(/illegal/i);
+  });
+});
+
+describe('transitionChallengeState — start', () => {
+  it('accepted → active with questionIndex=0, startedAt, capped totalQuestions', () => {
+    const next = transitionChallengeState(
+      { ...baseState, state: 'accepted' },
+      { type: 'start', totalQuestions: 5 },
+    );
+    expect(next?.state).toBe('active');
+    expect(next?.questionIndex).toBe(0);
+    expect(next?.totalQuestions).toBe(3);
+    expect(next?.startedAt).toBeDefined();
+  });
+
+  it('accepted → active floors a 0 request to 1', () => {
+    const next = transitionChallengeState(
+      { ...baseState, state: 'accepted' },
+      { type: 'start', totalQuestions: 0 },
+    );
+    expect(next?.totalQuestions).toBe(1);
+  });
+
+  it('rejects start from a non-accepted state', () => {
+    expect(() =>
+      transitionChallengeState(baseState, {
+        type: 'start',
+        totalQuestions: 3,
+      }),
+    ).toThrow(/illegal/i);
+  });
+});
+
+describe('transitionChallengeState — answer_complete', () => {
+  it('active → active when more questions remain; preserves prior evaluations', () => {
+    const next = transitionChallengeState(
+      {
+        ...baseState,
+        state: 'active',
+        questionIndex: 0,
+        totalQuestions: 3,
+        evaluations: [evalItem({ concept: 'a', answerEventId: 'e1' })],
+      },
+      {
+        type: 'answer_complete',
+        evaluation: [evalItem({ concept: 'b', answerEventId: 'e2' })],
+      },
+    );
+    expect(next?.state).toBe('active');
+    expect(next?.questionIndex).toBe(1);
+    expect(next?.evaluations).toHaveLength(2);
+    expect(next?.evaluations.map((e) => e.concept)).toEqual(['a', 'b']);
+  });
+
+  it('active → drafting on last answer; preserves all evaluations', () => {
+    const next = transitionChallengeState(
+      {
+        ...baseState,
+        state: 'active',
+        questionIndex: 2,
+        totalQuestions: 3,
+        evaluations: [
+          evalItem({ concept: 'a', answerEventId: 'e1' }),
+          evalItem({ concept: 'b', answerEventId: 'e2' }),
+        ],
+      },
+      {
+        type: 'answer_complete',
+        evaluation: [evalItem({ concept: 'c', answerEventId: 'e3' })],
+      },
+    );
+    expect(next?.state).toBe('drafting');
+    expect(next?.evaluations).toHaveLength(3);
+  });
+
+  it('accepts multiple evaluations from one answer batch', () => {
+    const next = transitionChallengeState(
+      {
+        ...baseState,
+        state: 'active',
+        questionIndex: 0,
+        totalQuestions: 3,
+        evaluations: [],
+      },
+      {
+        type: 'answer_complete',
+        evaluation: [
+          evalItem({ concept: 'a', answerEventId: 'e1' }),
+          evalItem({ concept: 'b', answerEventId: 'e2' }),
+        ],
+      },
+    );
+    expect(next?.evaluations).toHaveLength(2);
+    expect(next?.questionIndex).toBe(1);
+  });
+
+  it('rejects answer_complete from a non-active state', () => {
+    expect(() =>
+      transitionChallengeState(
+        { ...baseState, state: 'drafting' },
+        { type: 'answer_complete', evaluation: [evalItem()] },
+      ),
+    ).toThrow(/illegal/i);
+  });
+});
+
+describe('transitionChallengeState — draft_ready / complete / abort', () => {
+  it('drafting → drafting on draft_ready (idempotent acknowledgement)', () => {
+    const prev: ChallengeRoundSessionState = {
+      ...baseState,
+      state: 'drafting',
+    };
+    expect(transitionChallengeState(prev, { type: 'draft_ready' })).toEqual(
+      prev,
+    );
+  });
+
+  it('rejects draft_ready from a non-drafting state', () => {
+    expect(() =>
+      transitionChallengeState(
+        { ...baseState, state: 'active' },
+        {
+          type: 'draft_ready',
+        },
+      ),
+    ).toThrow(/illegal/i);
+  });
+
+  it('drafting → complete', () => {
+    const next = transitionChallengeState(
+      { ...baseState, state: 'drafting' },
+      { type: 'complete' },
+    );
+    expect(next?.state).toBe('complete');
+  });
+
+  it('active → complete (early finish path)', () => {
+    const next = transitionChallengeState(
+      { ...baseState, state: 'active' },
+      { type: 'complete' },
+    );
+    expect(next?.state).toBe('complete');
+  });
+
+  it('rejects complete from an offered/accepted/declined state', () => {
+    for (const state of ['offered', 'accepted', 'declined'] as const) {
+      expect(() =>
+        transitionChallengeState({ ...baseState, state }, { type: 'complete' }),
+      ).toThrow(/illegal/i);
+    }
+  });
+
+  it('abort works from any defined state', () => {
+    for (const state of [
+      'offered',
+      'accepted',
+      'declined',
+      'active',
+      'drafting',
+      'complete',
+    ] as const) {
+      const next = transitionChallengeState(
+        { ...baseState, state },
+        { type: 'abort' },
+      );
+      expect(next?.state).toBe('aborted');
+    }
+  });
+
+  it('abort is a no-op when there is no prior round', () => {
+    expect(
+      transitionChallengeState(undefined, { type: 'abort' }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/challenge-round/state.ts
+++ b/apps/api/src/services/challenge-round/state.ts
@@ -1,0 +1,140 @@
+import {
+  type ChallengeRoundEvaluationItem,
+  type ChallengeRoundSessionState,
+} from '@eduagent/schemas';
+import { MAX_CHALLENGE_QUESTIONS, enforceChallengeQuestionCap } from './caps';
+
+/**
+ * Challenge Round state machine.
+ *
+ * Pure function — given the current `ChallengeRoundSessionState` (or
+ * `undefined` for "no round yet this session") and a transition event,
+ * returns the next state or throws `Error` on an illegal transition.
+ * No DB access, no clocks beyond `Date.now()` for `startedAt`, no Inngest
+ * dispatches. Callers persist the result via `persistSessionMetadata`.
+ *
+ * State graph (see `docs/plans/2026-05-18-challenge-round-into-note.md`
+ * Task 2 + Task 4):
+ *
+ *   undefined ──offer──▶ offered ──accept──▶ accepted ──start──▶ active
+ *                              └─decline──▶ declined
+ *   active ──answer_complete──▶ active (more questions)
+ *                            └─▶ drafting (last question answered)
+ *   drafting ──draft_ready──▶ drafting   (idempotent acknowledgement)
+ *            └─complete──▶ complete
+ *   active   ──complete──▶ complete       (early-finish path)
+ *   any       ──abort──▶ aborted
+ *   complete | aborted ──offer──▶ offered (new round same session — counts up)
+ */
+
+export type ChallengeStateTransition =
+  | { type: 'offer'; topicId: string }
+  | { type: 'accept' }
+  | { type: 'decline'; dontAskAgain: boolean }
+  | { type: 'start'; totalQuestions: number }
+  | { type: 'answer_complete'; evaluation: ChallengeRoundEvaluationItem[] }
+  | { type: 'draft_ready' }
+  | { type: 'complete' }
+  | { type: 'abort' };
+
+const REOFFERABLE_STATES = new Set<ChallengeRoundSessionState['state']>([
+  'complete',
+  'aborted',
+]);
+
+export function transitionChallengeState(
+  prev: ChallengeRoundSessionState | undefined,
+  event: ChallengeStateTransition,
+): ChallengeRoundSessionState | undefined {
+  switch (event.type) {
+    case 'offer': {
+      if (prev && !REOFFERABLE_STATES.has(prev.state)) {
+        throw new Error(
+          `illegal challenge-round transition: cannot offer from state=${prev.state}`,
+        );
+      }
+      return {
+        state: 'offered',
+        offerCount: (prev?.offerCount ?? 0) + 1,
+        topicId: event.topicId,
+        declinedDontAskAgain: false,
+        evaluations: [],
+      };
+    }
+
+    case 'accept': {
+      if (prev?.state !== 'offered') {
+        throw new Error(
+          `illegal challenge-round transition: accept requires state=offered (got ${prev?.state ?? 'undefined'})`,
+        );
+      }
+      return { ...prev, state: 'accepted' };
+    }
+
+    case 'decline': {
+      if (prev?.state !== 'offered') {
+        throw new Error(
+          `illegal challenge-round transition: decline requires state=offered (got ${prev?.state ?? 'undefined'})`,
+        );
+      }
+      return {
+        ...prev,
+        state: 'declined',
+        declinedDontAskAgain: event.dontAskAgain,
+      };
+    }
+
+    case 'start': {
+      if (prev?.state !== 'accepted') {
+        throw new Error(
+          `illegal challenge-round transition: start requires state=accepted (got ${prev?.state ?? 'undefined'})`,
+        );
+      }
+      return {
+        ...prev,
+        state: 'active',
+        questionIndex: 0,
+        totalQuestions: enforceChallengeQuestionCap(event.totalQuestions),
+        startedAt: new Date().toISOString(),
+      };
+    }
+
+    case 'answer_complete': {
+      if (prev?.state !== 'active') {
+        throw new Error(
+          `illegal challenge-round transition: answer_complete requires state=active (got ${prev?.state ?? 'undefined'})`,
+        );
+      }
+      const evaluations = [...prev.evaluations, ...event.evaluation];
+      const nextIndex = (prev.questionIndex ?? 0) + 1;
+      const total = prev.totalQuestions ?? MAX_CHALLENGE_QUESTIONS;
+      if (nextIndex >= total) {
+        return { ...prev, state: 'drafting', evaluations };
+      }
+      return { ...prev, questionIndex: nextIndex, evaluations };
+    }
+
+    case 'draft_ready': {
+      if (prev?.state !== 'drafting') {
+        throw new Error(
+          `illegal challenge-round transition: draft_ready requires state=drafting (got ${prev?.state ?? 'undefined'})`,
+        );
+      }
+      return prev;
+    }
+
+    case 'complete': {
+      if (prev?.state !== 'drafting' && prev?.state !== 'active') {
+        throw new Error(
+          `illegal challenge-round transition: complete requires state=drafting|active (got ${prev?.state ?? 'undefined'})`,
+        );
+      }
+      return { ...prev, state: 'complete' };
+    }
+
+    case 'abort': {
+      if (!prev) return undefined;
+      return { ...prev, state: 'aborted' };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Three pure-function building blocks for the Challenge Round flow, all server-side and dependency-free (only `@eduagent/schemas`). No DB writes, no LLM calls, no route changes — these are the modules that Task 8 wiring will glue into the exchange pipeline.

| Task | Files | Tests | What it does |
|------|-------|-------|---|
| **4** | `caps.{ts,test.ts}`, `state.{ts,test.ts}` | 4 + 26 | Hard caps + `transitionChallengeState()` state machine (offer/accept/decline/start/answer_complete/draft_ready/complete/abort) |
| **5** | `evaluation.{ts,test.ts}` | 13 | `decideMasteryAndReview()` — conservative gating: any single partial/misconception blocks mastery; empty input → `outcome: 'invalid'` (CRIT-9) |
| **6** | `note-draft.{ts,test.ts}` | 10 | `validateNoteDraft()` lexical-overlap guard with Unicode + char-bigram fallback (MED-10) |

**Plan**: `docs/plans/2026-05-18-challenge-round-into-note.md` (Tasks 4, 5, 6).

## Key invariants pinned by tests

- **State machine** rejects illegal transitions (`accept` from non-offered, `start` from non-accepted, etc.) and allows re-offer only from `complete`/`aborted`. `abort` is legal from any defined state.
- **Mastery decision** is "server-owned conservative gating over structured LLM evidence" (HIGH-8). `solidAnswerQuotes` / `solidConcepts` only ever surface `result === 'solid'` items so the note drafter cannot accidentally source from partial/misconception text (HIGH-6).
- **CRIT-9** guard: empty evaluations array short-circuits to `outcome: 'invalid'` — naive `solid === total` would have passed `0 === 0`.
- **Note-draft guard** catches topic drift (HIGH-1) only; value substitution within shared vocabulary is defended upstream by the solid-only drafter input contract. Scope documented in the file's jsdoc.
- **MED-10** tokenization: NFKC + locale-lowercase + Unicode word split + small stopword set; character-bigram fallback for non-spaced scripts (Czech accented Latin + Japanese regression tests included).
- **MED-3 calibration TODO** annotated above `MIN_LEXICAL_OVERLAP_NOTE_DRAFT = 0.4` in `caps.ts`.

## Verification

- ✅ Full challenge-round suite: **78/78 passing** (caps 4, state 26, trigger 25, evaluation 13, note-draft 10) — verified via clean-checkout workaround for the worktree haste-map pathology.
- ✅ `api:typecheck` green
- ✅ `api:lint` green
- ✅ Pre-commit + pre-push hooks green on every commit

## What this PR does NOT change

- No DB schema, no migration, no route handlers, no `session-exchange.ts` wiring — those land in Task 8 (next PR).
- No LLM prompts and no eval-harness scenarios — those are Task 7.
- No mobile changes.

## Next slice after merge

Task 8 Step 0 — extract `persistSessionMetadata(db, profileId, sessionId, partial)` from the file-local `updateSessionMetadata` at `session-exchange.ts:310` to `session-crud.ts`, with an IDOR break test (CRIT-3). Requires DB access (Doppler `-c stg`) and starts switching session metadata persistence to read-modify-write semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Challenge round evaluation system with mastery assessment and review targeting
  * Lexical overlap validation for challenge round note drafts

* **Tests**
  * Added comprehensive test coverage for challenge round state transitions, evaluation logic, and note draft validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->