### PR TITLE
feat: trial intent-save onboarding v0 (Tasks 1-15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,8 @@ _scratchpad.md
 # These often embed environment-specific URLs, project IDs, and other
 # infra hints that should not be tracked. Force-add (`git add -f`) if
 # a doc is genuinely meant to be checked in.
-plans/
+# Leading slash anchors to repo root — must NOT match docs/plans/.
+/plans/
 
 # Archon runtime artifacts
 .archon/state/

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -37,6 +37,7 @@ describe('validateProductionKeys', () => {
     MEMORY_FACTS_DEDUP_ROLLOUT_PCT: '0',
     MATCHER_ENABLED: 'false',
     ALLOW_MISSING_IDEMPOTENCY_KV: 'false',
+    ADULT_OWNER_GATE_ENABLED: 'true',
   });
 
   it('returns empty array for development environment', () => {
@@ -564,6 +565,7 @@ describe('validateProductionBindings', () => {
     MEMORY_FACTS_DEDUP_ROLLOUT_PCT: 0,
     MATCHER_ENABLED: 'false',
     ALLOW_MISSING_IDEMPOTENCY_KV: 'false',
+    ADULT_OWNER_GATE_ENABLED: 'true',
   };
 
   const fakeKv = {} as unknown;

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -111,6 +111,12 @@ const envSchema = z.object({
   // when active, env validation emits a structured warning so the
   // override remains visible in telemetry. Default: 'false' (gate on).
   ALLOW_MISSING_IDEMPOTENCY_KV: z.enum(['true', 'false']).default('false'),
+
+  // [OPT-C] Adult-owner gate — server-side enforcement of the 18+ requirement
+  // for a parent creating a child profile. Paired with the mobile-side
+  // ADULT_OWNER_GATE_ENABLED feature flag (apps/mobile/src/lib/feature-flags.ts).
+  // Default: true. Flip to 'false' via Doppler to disable without redeploying.
+  ADULT_OWNER_GATE_ENABLED: z.enum(['true', 'false']).default('true'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -299,7 +299,16 @@ app.onError((err, c) => {
   // try/catch. Important: we do NOT captureException for these — they are
   // expected domain outcomes, not server faults.
   if (err instanceof ForbiddenError) {
-    return c.json({ code: ERROR_CODES.FORBIDDEN, message: err.message }, 403);
+    // [OPT-C] apiCode threaded through so the mobile client can distinguish
+    // ADULT_OWNER_REQUIRED (and future apiCodes) from a generic 403.
+    return c.json(
+      {
+        code: ERROR_CODES.FORBIDDEN,
+        apiCode: err.apiCode,
+        message: err.message,
+      },
+      403,
+    );
   }
   if (err instanceof ConsentRequiredError) {
     return c.json(

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -204,6 +204,9 @@ describe('POST /v1/profiles', () => {
       expect.anything(),
       ACCOUNT_ID,
       expect.objectContaining({ displayName: 'First Owner' }),
+      // [OPT-C] Route now threads the kill-switch from c.env; assertion needs
+      // to accept the opts arg added by the adult-owner-gate wiring.
+      expect.objectContaining({ adultOwnerGateEnabled: expect.any(Boolean) }),
     );
     const body = await res.json();
     expect(body).toMatchObject({

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -25,7 +25,13 @@ import {
 } from '../services/profile';
 
 type ProfileEnv = {
-  Bindings: { DATABASE_URL: string; CLERK_JWKS_URL?: string };
+  Bindings: {
+    DATABASE_URL: string;
+    CLERK_JWKS_URL?: string;
+    // [OPT-C] Kill switch for the server-side adult-owner rule. Set to 'false'
+    // in Doppler to disable the gate (emergency rollback). Default 'true'.
+    ADULT_OWNER_GATE_ENABLED?: string;
+  };
   Variables: {
     user: AuthUser;
     db: Database;
@@ -62,7 +68,10 @@ export const profileRoutes = new Hono<ProfileEnv>()
     }
 
     try {
-      const profile = await createProfileWithLimitCheck(db, account.id, input);
+      const profile = await createProfileWithLimitCheck(db, account.id, input, {
+        // [OPT-C] Default 'true' when binding missing (safe default; matches config default).
+        adultOwnerGateEnabled: c.env?.ADULT_OWNER_GATE_ENABLED !== 'false',
+      });
 
       return c.json(profileResponseSchema.parse({ profile }), 201);
     } catch (err) {

--- a/apps/api/src/services/profile.integration.test.ts
+++ b/apps/api/src/services/profile.integration.test.ts
@@ -28,6 +28,7 @@ import { createProfileWithLimitCheck, ProfileLimitError } from './profile';
 import { createSubscription } from './billing';
 import { getTierConfig } from './subscription';
 import type { ProfileCreateInput } from '@eduagent/schemas';
+import { ForbiddenError } from '@eduagent/schemas';
 
 // ---------------------------------------------------------------------------
 // DB setup — real connection
@@ -63,9 +64,55 @@ const FIRST_PROFILE_ACCOUNT = {
   email: `${PREFIX}-first-profile@integration.test`,
 };
 
+// [OPT-C] Adult-owner gate break-test accounts
+const OPT_C_PREFIX = 'integration-profile-optc';
+const OPT_C_UNDERAGE_EMAIL = `${OPT_C_PREFIX}-underage@integration.test`;
+const OPT_C_ADULT18_EMAIL = `${OPT_C_PREFIX}-adult18@integration.test`;
+const OPT_C_FLAG_OFF_EMAIL = `${OPT_C_PREFIX}-flagoff@integration.test`;
+
 // ---------------------------------------------------------------------------
 // Seed helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Seeds an account with a single owner profile at the given birthYear.
+ * Returns the account row. A 'family' subscription is provisioned so
+ * subsequent createProfileWithLimitCheck calls are not blocked by the limit.
+ */
+async function seedOwnerAccount(
+  email: string,
+  clerkUserId: string,
+  ownerBirthYear: number,
+) {
+  const db = createIntegrationDb();
+  const [account] = await db
+    .insert(accounts)
+    .values({ clerkUserId, email })
+    .returning();
+
+  // Family subscription — cap = 4, well above what break tests need
+  const familyConfig = getTierConfig('family');
+  await createSubscription(
+    db,
+    account!.id,
+    'family',
+    familyConfig.monthlyQuota,
+    {
+      status: 'active',
+    },
+  );
+
+  // Insert owner profile directly (bypass createProfileWithLimitCheck) so the
+  // owner's birthYear is set independently of the gate logic under test.
+  await db.insert(profiles).values({
+    accountId: account!.id,
+    displayName: 'Owner',
+    birthYear: ownerBirthYear,
+    isOwner: true,
+  });
+
+  return { db, accountId: account!.id };
+}
 
 async function seedFixture() {
   const db = createIntegrationDb();
@@ -107,6 +154,9 @@ async function cleanup() {
     where: inArray(accounts.email, [
       ACCOUNT.email,
       FIRST_PROFILE_ACCOUNT.email,
+      OPT_C_UNDERAGE_EMAIL,
+      OPT_C_ADULT18_EMAIL,
+      OPT_C_FLAG_OFF_EMAIL,
     ]),
   });
   const ids = found.map((a: typeof accounts.$inferSelect) => a.id);
@@ -253,5 +303,98 @@ describe('[BUG-862] createProfileWithLimitCheck concurrent cap enforcement (inte
         displayName: 'Over-cap Child',
       }),
     ).rejects.toThrow(ProfileLimitError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [OPT-C / HIGH-D3] Adult-owner gate break-tests
+//
+// Red-green regression per CLAUDE.md "Security fixes require a break test."
+// These tests are the canonical proof that the [OPT-C] server-side rule exists
+// and cannot be silently removed without CI failing.
+// ---------------------------------------------------------------------------
+
+describe('[OPT-C] createProfileWithLimitCheck adult-owner gate (integration)', () => {
+  // Age math uses new Date().getFullYear() inside computeAgeBracket.
+  // Birth years chosen so the owner's age in the current year (2026) places
+  // them firmly underage (2013 → 13) or at the 18 boundary (2008 → 18).
+  // These remain correct for 2026+; the boundary test (2008) should be
+  // revisited when currentYear reaches 2027 (owner turns 19, still passes).
+
+  it('[BREAK / OPT-C] rejects child creation when owner is under 18', async () => {
+    // Birth year 2013 → age 13 in 2026 — clearly underage.
+    const { accountId } = await seedOwnerAccount(
+      OPT_C_UNDERAGE_EMAIL,
+      `${OPT_C_PREFIX}-underage-user`,
+      2013,
+    );
+    const db = createIntegrationDb();
+
+    // Gate ON (default). Must throw ForbiddenError with ADULT_OWNER_REQUIRED.
+    // computeAgeBracket(2013, 2026) = 'adolescent' → not 'adult' → reject.
+    await expect(
+      createProfileWithLimitCheck(
+        db,
+        accountId,
+        { displayName: 'Child', birthYear: 2014 },
+        { adultOwnerGateEnabled: true },
+      ),
+    ).rejects.toMatchObject({
+      name: 'ForbiddenError',
+      apiCode: 'ADULT_OWNER_REQUIRED',
+    });
+
+    // Confirm that ForbiddenError is the correct class (instanceof guard)
+    await expect(
+      createProfileWithLimitCheck(
+        db,
+        accountId,
+        { displayName: 'Child', birthYear: 2014 },
+        { adultOwnerGateEnabled: true },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('[OPT-C boundary] allows child creation when owner is exactly 18', async () => {
+    // Birth year 2008 → age 18 in 2026 — boundary. computeAgeBracket returns 'adult'.
+    // Note: computeAgeBracket uses currentYear - birthYear (overestimates by up to
+    // 11 months for users whose birthday hasn't occurred yet). At the boundary,
+    // the rule accepts — consistent with the mobile client gate behaviour.
+    const { accountId } = await seedOwnerAccount(
+      OPT_C_ADULT18_EMAIL,
+      `${OPT_C_PREFIX}-adult18-user`,
+      2008,
+    );
+    const db = createIntegrationDb();
+
+    // Gate ON. Owner age = 18 → 'adult' → must succeed.
+    await expect(
+      createProfileWithLimitCheck(
+        db,
+        accountId,
+        { displayName: 'Child', birthYear: 2015 },
+        { adultOwnerGateEnabled: true },
+      ),
+    ).resolves.toMatchObject({ id: expect.any(String) });
+  });
+
+  it('[OPT-C flag-off] allows child creation regardless of owner age when gate is disabled', async () => {
+    // Same underage owner (born 2013), but gate is explicitly OFF.
+    // Must succeed — identical to today's behaviour before this rule was added.
+    const { accountId } = await seedOwnerAccount(
+      OPT_C_FLAG_OFF_EMAIL,
+      `${OPT_C_PREFIX}-flagoff-user`,
+      2013,
+    );
+    const db = createIntegrationDb();
+
+    await expect(
+      createProfileWithLimitCheck(
+        db,
+        accountId,
+        { displayName: 'Child', birthYear: 2014 },
+        { adultOwnerGateEnabled: false },
+      ),
+    ).resolves.toMatchObject({ id: expect.any(String) });
   });
 });

--- a/apps/api/src/services/profile.ts
+++ b/apps/api/src/services/profile.ts
@@ -14,7 +14,7 @@ import type {
   ProfileUpdateInput,
   Profile,
 } from '@eduagent/schemas';
-import { computeAgeBracket } from '@eduagent/schemas';
+import { computeAgeBracket, ForbiddenError } from '@eduagent/schemas';
 export type ProfileValidationCode = 'CHILD_AGE_VIOLATION';
 
 export class ProfileValidationError extends Error {
@@ -254,7 +254,18 @@ export async function createProfileWithLimitCheck(
   db: Database,
   accountId: string,
   input: ProfileCreateInput,
+  opts?: {
+    /**
+     * [OPT-C] Adult-owner gate. When true (default), adding a child profile
+     * (non-first profile) requires the existing owner to be ≥18. Set to false
+     * to disable the rule without code changes — matches config.ADULT_OWNER_GATE_ENABLED.
+     * Callers should read `config.ADULT_OWNER_GATE_ENABLED === 'true'` and pass it here.
+     * Defaults to true (safe default — matches the config's default of 'true').
+     */
+    adultOwnerGateEnabled?: boolean;
+  },
 ): Promise<Profile> {
+  const adultOwnerGateEnabled = opts?.adultOwnerGateEnabled ?? true;
   return db.transaction(async (tx) => {
     const txDb = tx as unknown as Database;
 
@@ -281,6 +292,35 @@ export async function createProfileWithLimitCheck(
       const subscription = await getSubscriptionByAccountId(txDb, accountId);
       if (!subscription || !(await canAddProfile(txDb, subscription.id))) {
         throw new ProfileLimitError();
+      }
+    }
+
+    // [OPT-C] Adult-owner gate. When adding a CHILD (non-first profile),
+    // require the account's existing owner to be ≥18. Gated by flag so the
+    // rule can be toggled off without code changes (kill switch).
+    // Defense-in-depth: client-side gate (Task 13 / HIGH-A3) is the primary
+    // UX barrier; this is the server-side enforcement fallback.
+    if (adultOwnerGateEnabled && !isFirstProfile) {
+      const ownerRow = await txDb
+        .select({ birthYear: profiles.birthYear })
+        .from(profiles)
+        .where(
+          and(
+            eq(profiles.accountId, accountId),
+            eq(profiles.isOwner, true),
+            isNull(profiles.archivedAt),
+          ),
+        )
+        .limit(1);
+      const ownerBirthYear = ownerRow[0]?.birthYear;
+      if (
+        ownerBirthYear == null ||
+        computeAgeBracket(ownerBirthYear) !== 'adult'
+      ) {
+        throw new ForbiddenError(
+          'Account holder must be 18 or older to add a child profile.',
+          'ADULT_OWNER_REQUIRED',
+        );
       }
     }
 

--- a/apps/mobile/src/app/(app)/_layout.test.tsx
+++ b/apps/mobile/src/app/(app)/_layout.test.tsx
@@ -13,6 +13,11 @@ import {
   rememberPendingAuthRedirect,
   peekPendingAuthRedirect,
 } from '../../lib/pending-auth-redirect';
+import {
+  setPreviewState,
+  clearPreviewState,
+  getPreviewState,
+} from '../../lib/preview-onboarding-state';
 import { createRoutedMockFetch } from '../../test-utils/mock-api-routes';
 
 const mockFetch = createRoutedMockFetch();
@@ -274,10 +279,12 @@ describe('AppLayout', () => {
     jest.useRealTimers();
   });
 
-  it('renders guardian tab shell for accounts with linked children', () => {
+  it('renders guardian tab shell for accounts with linked children', async () => {
     renderLayout();
 
-    screen.getByTestId('tabs');
+    // await: probe-state effect (getPreviewState Promise) must resolve before
+    // the gate logic falls through to the Tabs. findByTestId polls until found.
+    await screen.findByTestId('tabs');
     expect(screen.queryByTestId('redirect')).toBeNull();
 
     const shape = resolveTabShape({
@@ -484,7 +491,7 @@ describe('AppLayout', () => {
   // parent is wrong copy and indicates a misclassified state. Pre-fix, the
   // landing showed for any CONSENTED profile with no subjects, including
   // parents.
-  it('does not show post-approval landing for parent (owner) profiles (BUG-914)', () => {
+  it('does not show post-approval landing for parent (owner) profiles (BUG-914)', async () => {
     mockUseProfile.mockReturnValue({
       profiles: [
         {
@@ -522,9 +529,10 @@ describe('AppLayout', () => {
 
     renderLayout();
 
+    // await: probe-state effect must resolve before the tabs render.
+    await screen.findByTestId('tabs');
     expect(screen.queryByTestId('post-approval-landing')).toBeNull();
     expect(screen.queryByText("You're approved!")).toBeNull();
-    screen.getByTestId('tabs');
   });
 
   // [BUG-61] A teen-owner (under-18 with their own account) who just
@@ -575,7 +583,7 @@ describe('AppLayout', () => {
     expect(screen.getByTestId('post-approval-continue'));
   });
 
-  it('does not show post-approval landing when user already has subjects (BUG-544)', () => {
+  it('does not show post-approval landing when user already has subjects (BUG-544)', async () => {
     mockUseProfile.mockReturnValue({
       profiles: [
         {
@@ -622,11 +630,12 @@ describe('AppLayout', () => {
 
     renderLayout();
 
+    // await: probe-state effect must resolve before the tabs render.
+    await screen.findByTestId('tabs');
     expect(screen.queryByTestId('post-approval-landing')).toBeNull();
-    screen.getByTestId('tabs');
   });
 
-  it('renders in-app toast instead of native alert when profile was removed (BUG-548)', () => {
+  it('renders in-app toast instead of native alert when profile was removed (BUG-548)', async () => {
     const acknowledgeProfileRemoval = jest.fn();
     mockUseProfile.mockReturnValue({
       profiles: [
@@ -646,12 +655,13 @@ describe('AppLayout', () => {
 
     renderLayout();
 
-    screen.getByTestId('profile-switched-toast');
+    // await: probe-state effect must resolve before the tabs+toast render.
+    await screen.findByTestId('profile-switched-toast');
     screen.getByText('Profile switched');
     screen.getByText('The profile you were viewing has been removed.');
   });
 
-  it('shows proxy banner and switches back to the owner profile', () => {
+  it('shows proxy banner and switches back to the owner profile', async () => {
     const switchProfile = jest.fn();
     mockUseProfile.mockReturnValue({
       profiles: [
@@ -673,7 +683,8 @@ describe('AppLayout', () => {
 
     renderLayout();
 
-    screen.getByTestId('proxy-banner');
+    // await: probe-state effect must resolve before the tabs+banner render.
+    await screen.findByTestId('proxy-banner');
     // Exact match — a regression that breaks the {{name}} interpolation
     // ("Viewing as " with an empty/literal name) would slip past the broader
     // /Viewing as/ regex. test-setup.ts initializes i18next synchronously
@@ -686,7 +697,7 @@ describe('AppLayout', () => {
     expect(switchProfile).toHaveBeenCalledWith('p1');
   });
 
-  it('tells waiting learners that consent is checked automatically', () => {
+  it('tells waiting learners that consent is checked automatically', async () => {
     mockUseProfile.mockReturnValue({
       profiles: [
         {
@@ -722,7 +733,8 @@ describe('AppLayout', () => {
 
     renderLayout();
 
-    screen.getByTestId('consent-pending-gate');
+    // await: probe-state effect must resolve before the consent gate renders.
+    await screen.findByTestId('consent-pending-gate');
     expect(screen.getByText('Checking automatically…'));
   });
 
@@ -749,6 +761,257 @@ describe('AppLayout', () => {
       screen.getByTestId('tabs');
     });
     expect(screen.queryByTestId('permission-setup-gate')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AppLayout no-profile gate — preview branch
+// Tests for the SaveWizardGate inline gate (Task 11 / [CRITICAL-A2]).
+// ---------------------------------------------------------------------------
+
+describe('AppLayout no-profile gate — preview branch', () => {
+  let testQueryClient: QueryClient;
+
+  // Minimal route handlers needed to prevent fetch errors in the layout hooks.
+  function setupDefaultRoutes() {
+    mockFetch.setRoute(
+      '/consent/my-status',
+      () =>
+        new Response(
+          JSON.stringify({
+            consentStatus: null,
+            parentEmail: null,
+            consentType: null,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    mockFetch.setRoute(
+      '/subjects',
+      () =>
+        new Response(JSON.stringify({ subjects: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/dashboard',
+      () =>
+        new Response(JSON.stringify({ children: [], demoMode: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/settings/push-token',
+      () =>
+        new Response(JSON.stringify({ registered: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  }
+
+  // Render the layout with no active profile and no loading state.
+  // Returns the render result plus a simulateProfileCreated helper.
+  function renderAppLayoutWithNoProfile() {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    mockUseProfile.mockReturnValue({
+      profiles: [],
+      activeProfile: null,
+      isLoading: false,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: jest.fn(),
+      switchProfile: jest.fn(),
+    });
+    const AppLayout = require('./_layout').default;
+    const result = render(<AppLayout />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    function simulateProfileCreated(profile: { id: string; isOwner: boolean }) {
+      mockUseProfile.mockReturnValue({
+        profiles: [profile],
+        activeProfile: profile,
+        isLoading: false,
+        profileWasRemoved: false,
+        acknowledgeProfileRemoval: jest.fn(),
+        switchProfile: jest.fn(),
+      });
+      act(() => {
+        result.rerender(<AppLayout />);
+      });
+    }
+
+    return { ...result, simulateProfileCreated };
+  }
+
+  // Render the layout with an active profile already set (no-profile gate skipped).
+  function renderAppLayoutWithActiveProfile() {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    mockUseProfile.mockReturnValue({
+      profiles: [
+        { id: 'p1', isOwner: true, consentStatus: null, birthYear: 1990 },
+      ],
+      activeProfile: {
+        id: 'p1',
+        isOwner: true,
+        consentStatus: null,
+        birthYear: 1990,
+      },
+      isLoading: false,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: jest.fn(),
+      switchProfile: jest.fn(),
+    });
+    const AppLayout = require('./_layout').default;
+    return render(<AppLayout />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    mockUsePathname.mockReturnValue('/home');
+    const SecureStoreMock = require('../../lib/secure-storage');
+    (SecureStoreMock.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (SecureStoreMock.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+    (SecureStoreMock.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+    // Also clear the in-memory preview state between tests.
+    await clearPreviewState();
+    setupDefaultRoutes();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    // Restore any spies (e.g. getPreviewState spy in the loading test) so
+    // they don't leak into subsequent tests. clearAllMocks() in beforeEach
+    // clears call counts but not spy implementations.
+    jest.restoreAllMocks();
+  });
+
+  it('renders the SaveWizardGate when preview state exists and flag is on', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+
+    const { findByTestId, queryByTestId } = renderAppLayoutWithNoProfile();
+
+    // [CRITICAL-A2] The wizard is INLINE — no route navigation; assert the
+    // SaveWizardGate testID is present in the same render tree.
+    expect(await findByTestId('save-wizard-gate')).toBeTruthy();
+    expect(queryByTestId('create-profile-gate')).toBeNull();
+  });
+
+  // [MEDIUM-D2 / CJS constraint] The ideal approach is jest.doMock +
+  // jest.isolateModulesAsync, but @testing-library/react-native registers
+  // afterAll hooks at import time, which Jest forbids inside isolateModules
+  // callbacks. jest.isolateModulesAsync with dynamic import() also requires
+  // --experimental-vm-modules (not enabled in this Babel/CJS preset).
+  //
+  // Safe alternative in CJS: patch the shared FEATURE_FLAGS object for the
+  // duration of the test and restore it in a finally block. Jest runs tests
+  // within a file sequentially (never in parallel within the same worker), so
+  // the mutation does not race with other tests in this file. Cross-worker
+  // isolation is already guaranteed by Jest's separate-process-per-file model.
+  it('falls through to CreateProfileGate when flag is off, even with stale preview state', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+
+    const flags = require('../../lib/feature-flags') as {
+      FEATURE_FLAGS: { PREVIEW_ONBOARDING_ENABLED: boolean };
+    };
+    const original = flags.FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED;
+    try {
+      (
+        flags.FEATURE_FLAGS as { PREVIEW_ONBOARDING_ENABLED: boolean }
+      ).PREVIEW_ONBOARDING_ENABLED = false;
+      const { findByTestId, queryByTestId } = renderAppLayoutWithNoProfile();
+      expect(await findByTestId('create-profile-gate')).toBeTruthy();
+      expect(queryByTestId('save-wizard-gate')).toBeNull();
+    } finally {
+      (
+        flags.FEATURE_FLAGS as {
+          PREVIEW_ONBOARDING_ENABLED: boolean;
+        }
+      ).PREVIEW_ONBOARDING_ENABLED = original;
+    }
+  });
+
+  it('renders loading state during preview-state async probe', async () => {
+    // Spy getPreviewState to return a pending promise. Assert loading testID
+    // is rendered; assert neither gate nor wizard is in the tree.
+    let resolve!: (v: null) => void;
+    jest
+      .spyOn(require('../../lib/preview-onboarding-state'), 'getPreviewState')
+      .mockReturnValue(
+        new Promise<null>((r) => {
+          resolve = r;
+        }),
+      );
+
+    const { getByTestId, queryByTestId } = renderAppLayoutWithNoProfile();
+    expect(getByTestId('preview-state-loading')).toBeTruthy();
+    expect(queryByTestId('create-profile-gate')).toBeNull();
+    expect(queryByTestId('save-wizard-gate')).toBeNull();
+
+    // Resolve the promise so the effect completes and doesn't cause warnings.
+    await act(async () => {
+      resolve(null);
+    });
+  });
+
+  // [CRITICAL-A2 / HIGH-A2] Wizard outlives the auto-activation transition.
+  it('keeps SaveWizardGate mounted after ProfileProvider auto-activates the first profile', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    const { findByTestId, simulateProfileCreated } =
+      renderAppLayoutWithNoProfile();
+    await findByTestId('save-wizard-gate');
+    // Drive the harness to inject a created profile and let the provider
+    // auto-activate it (mirrors what happens at runtime after the owner POST
+    // resolves and the cache is updated).
+    simulateProfileCreated({ id: 'p1', isOwner: true });
+    // Wizard MUST still be mounted; we have NOT signalled wizardDone yet.
+    expect(await findByTestId('save-wizard-gate')).toBeTruthy();
+  });
+
+  // [CRITICAL-B2] Verify the layout does NOT install the auto-cleanup effect.
+  it('does NOT clear preview state automatically when activeProfile becomes truthy', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    renderAppLayoutWithActiveProfile();
+    await Promise.resolve();
+    // The layout must leave the key intact; cleanup is the wizard's job (or TTL/sign-out).
+    expect(await getPreviewState()).not.toBeNull();
   });
 });
 

--- a/apps/mobile/src/app/(app)/_layout.test.tsx
+++ b/apps/mobile/src/app/(app)/_layout.test.tsx
@@ -1316,6 +1316,284 @@ describe('SaveWizard — Step 1', () => {
 });
 
 // ---------------------------------------------------------------------------
+// SaveWizard — Step 2 (Profile Basics)
+// [HIGH-A3 / HIGH-B2] Adult-age gate + form field tests.
+// ---------------------------------------------------------------------------
+
+describe('SaveWizard — Step 2 (Profile Basics)', () => {
+  let testQueryClient: QueryClient;
+
+  function setupDefaultRoutes() {
+    mockFetch.setRoute(
+      '/consent/my-status',
+      () =>
+        new Response(
+          JSON.stringify({
+            consentStatus: null,
+            parentEmail: null,
+            consentType: null,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    mockFetch.setRoute(
+      '/subjects',
+      () =>
+        new Response(JSON.stringify({ subjects: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/dashboard',
+      () =>
+        new Response(JSON.stringify({ children: [], demoMode: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/settings/push-token',
+      () =>
+        new Response(JSON.stringify({ registered: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  }
+
+  function renderWizardLayout() {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    mockUseProfile.mockReturnValue({
+      profiles: [],
+      activeProfile: null,
+      isLoading: false,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: jest.fn(),
+      switchProfile: jest.fn(),
+    });
+    const AppLayout = require('./_layout').default;
+    return render(<AppLayout />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    mockUsePathname.mockReturnValue('/home');
+    const SecureStoreMock = require('../../lib/secure-storage');
+    (SecureStoreMock.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (SecureStoreMock.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+    (SecureStoreMock.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+    await clearPreviewState();
+    setupDefaultRoutes();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // [HIGH-A3 / HIGH-B2] Under-18 parent with target=child: Continue must be
+  // disabled and the adult-required warning view must be visible.
+  it('under-18 parent (target=child) cannot submit; Continue stays disabled', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+
+    // 2013 → age 13 in 2026 — computeAgeBracket returns 'adolescent'/'child'.
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-parent-name'),
+      'TooYoung',
+    );
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-parent-birth-year'),
+      '2013',
+    );
+    fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-child-birth-year'),
+      '2014',
+    );
+
+    const cta = screen.getByTestId('save-basics-continue');
+    expect(cta.props.accessibilityState?.disabled).toBe(true);
+    expect(screen.getByTestId('save-basics-adult-required')).toBeTruthy();
+  });
+
+  // [HIGH-A3] Boundary: exactly 18 (birthYear 2008 in 2026) must pass the gate.
+  it('parent aged exactly 18 (target=child) is allowed to submit', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+    // Stub profiles POST so submit doesn't fail on network.
+    mockFetch.setRoute(
+      '/profiles',
+      () =>
+        new Response(
+          JSON.stringify({
+            profile: {
+              id: 'p1',
+              displayName: 'Pat',
+              birthYear: 2008,
+              isOwner: true,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+
+    // computeAgeBracket(2008, 2026) → age 18 → 'adult'. Boundary must pass.
+    fireEvent.changeText(screen.getByTestId('save-basics-parent-name'), 'Pat');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-parent-birth-year'),
+      '2008',
+    );
+    fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-child-birth-year'),
+      '2014',
+    );
+
+    const cta = screen.getByTestId('save-basics-continue');
+    expect(cta.props.accessibilityState?.disabled).toBe(false);
+    expect(screen.queryByTestId('save-basics-adult-required')).toBeNull();
+  });
+
+  // [OPT-C] target=self: the adult-age gate must NOT apply regardless of age.
+  // Server's 11+ floor covers this case; wizard has no age gate for self.
+  it('self target skips the adult gate (any age ≥ 11 allowed)', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 'algebra',
+      createdAt: new Date().toISOString(),
+    });
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+    mockFetch.setRoute(
+      '/profiles',
+      () =>
+        new Response(
+          JSON.stringify({
+            profile: {
+              id: 'p1',
+              displayName: 'Solo',
+              birthYear: 2013,
+              isOwner: true,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+
+    // 13-year-old solo learner — gate must NOT apply.
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-display-name'),
+      'Solo',
+    );
+    fireEvent.changeText(screen.getByTestId('save-basics-birth-year'), '2013');
+
+    const cta = screen.getByTestId('save-basics-continue');
+    expect(cta.props.accessibilityState?.disabled).toBe(false);
+    expect(screen.queryByTestId('save-basics-adult-required')).toBeNull();
+  });
+
+  // [OPT-C / MEDIUM-D2] Flag-off: when ADULT_OWNER_GATE_ENABLED is false, the
+  // adult-age gate is bypassed. Uses the established mutation pattern from
+  // SaveWizardGate flag-off test (line ~936 of this file) — safe in CJS because
+  // Jest runs tests within a file sequentially; the mutation is restored in
+  // a finally block.
+  it('underage parent allowed through when ADULT_OWNER_GATE_ENABLED is false [OPT-C]', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+    mockFetch.setRoute(
+      '/profiles',
+      () =>
+        new Response(
+          JSON.stringify({
+            profile: {
+              id: 'p1',
+              displayName: 'TooYoung',
+              birthYear: 2013,
+              isOwner: true,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+
+    const flags = require('../../lib/feature-flags') as {
+      FEATURE_FLAGS: { ADULT_OWNER_GATE_ENABLED: boolean };
+    };
+    const original = flags.FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED;
+    try {
+      (
+        flags.FEATURE_FLAGS as { ADULT_OWNER_GATE_ENABLED: boolean }
+      ).ADULT_OWNER_GATE_ENABLED = false;
+
+      renderWizardLayout();
+      await screen.findByTestId('save-wizard-step-1');
+      fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+
+      // 13-year-old parent — would be blocked by gate but flag is off.
+      fireEvent.changeText(
+        screen.getByTestId('save-basics-parent-name'),
+        'TooYoung',
+      );
+      fireEvent.changeText(
+        screen.getByTestId('save-basics-parent-birth-year'),
+        '2013',
+      );
+      fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+      fireEvent.changeText(
+        screen.getByTestId('save-basics-child-birth-year'),
+        '2014',
+      );
+
+      const cta = screen.getByTestId('save-basics-continue');
+      expect(cta.props.accessibilityState?.disabled).toBe(false);
+      expect(screen.queryByTestId('save-basics-adult-required')).toBeNull();
+    } finally {
+      (
+        flags.FEATURE_FLAGS as { ADULT_OWNER_GATE_ENABLED: boolean }
+      ).ADULT_OWNER_GATE_ENABLED = original;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // [BUG-776 / M-14] buildSwitchProfileConfirmation
 // ---------------------------------------------------------------------------
 // Pre-fix the consent-gate "Switch profile" handler silently picked the

--- a/apps/mobile/src/app/(app)/_layout.test.tsx
+++ b/apps/mobile/src/app/(app)/_layout.test.tsx
@@ -1594,6 +1594,293 @@ describe('SaveWizard — Step 2 (Profile Basics)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// SaveWizard — Step 3 (Confirm + Landing)
+// Task 14: Replace ConfirmStep placeholder with real implementation.
+// [Task 0 resolution] Dual landing keyed off the wizard's `target` flag:
+//   - self (or both+self_first): router.replace to /(app)/session with rawInput
+//   - child (or both+child_first): router.replace to /(app)/home
+// ---------------------------------------------------------------------------
+
+describe('SaveWizard — Step 3 (Confirm + Landing)', () => {
+  let testQueryClient: QueryClient;
+
+  function setupDefaultRoutes() {
+    mockFetch.setRoute(
+      '/consent/my-status',
+      () =>
+        new Response(
+          JSON.stringify({
+            consentStatus: null,
+            parentEmail: null,
+            consentType: null,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    mockFetch.setRoute(
+      '/subjects',
+      () =>
+        new Response(JSON.stringify({ subjects: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/dashboard',
+      () =>
+        new Response(JSON.stringify({ children: [], demoMode: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/settings/push-token',
+      () =>
+        new Response(JSON.stringify({ registered: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    // /profiles POST — returns a minimal owner profile for step 2 submission.
+    mockFetch.setRoute(
+      '/profiles',
+      () =>
+        new Response(
+          JSON.stringify({
+            profile: {
+              id: 'p1',
+              displayName: 'Solo',
+              birthYear: 2000,
+              isOwner: true,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+  }
+
+  /** Render the full layout with no active profile (triggers SaveWizardGate). */
+  function renderWizardLayout(
+    switchProfileImpl?: () => Promise<{ success: boolean; error?: string }>,
+  ) {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    mockUseProfile.mockReturnValue({
+      profiles: [],
+      activeProfile: null,
+      isLoading: false,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: jest.fn(),
+      switchProfile:
+        switchProfileImpl ?? jest.fn().mockResolvedValue({ success: true }),
+    });
+    const AppLayout = require('./_layout').default;
+    return render(<AppLayout />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+  }
+
+  /**
+   * Drive from step 1 through step 2 (self target) and reach step 3.
+   * Returns once the "save-confirm-land" CTA is visible.
+   */
+  async function driveToStep3Self() {
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+    // Step 2 — solo learner form
+    await screen.findByTestId('save-basics-display-name');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-display-name'),
+      'Solo',
+    );
+    fireEvent.changeText(screen.getByTestId('save-basics-birth-year'), '2000');
+    fireEvent.press(screen.getByTestId('save-basics-continue'));
+    await screen.findByTestId('save-confirm-land');
+  }
+
+  /**
+   * Drive from step 1 through step 2 (child target) and reach step 3.
+   * Returns once the "save-confirm-land" CTA is visible.
+   */
+  async function driveToStep3Child() {
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    // Override to child target
+    fireEvent.press(screen.getByTestId('save-target-child'));
+    fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+    // Step 2 — parent + child form
+    await screen.findByTestId('save-basics-parent-name');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-parent-name'),
+      'Parent',
+    );
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-parent-birth-year'),
+      '1985',
+    );
+    fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Kid');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-child-birth-year'),
+      '2014',
+    );
+    fireEvent.press(screen.getByTestId('save-basics-continue'));
+    await screen.findByTestId('save-confirm-land');
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockReplace.mockReset();
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    mockUsePathname.mockReturnValue('/home');
+    const SecureStoreMock = require('../../lib/secure-storage');
+    (SecureStoreMock.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (SecureStoreMock.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+    (SecureStoreMock.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+    await clearPreviewState();
+    setupDefaultRoutes();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('self target: replaces history with session route on CTA press', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 'algebra',
+      createdAt: new Date().toISOString(),
+    });
+
+    await driveToStep3Self();
+    fireEvent.press(screen.getByTestId('save-confirm-land'));
+
+    await waitFor(() => {
+      const call = mockReplace.mock.calls.find(
+        (c) =>
+          typeof c[0] === 'object' &&
+          (c[0] as { pathname?: string }).pathname === '/(app)/session',
+      );
+      expect(call).toBeDefined();
+    });
+  });
+
+  it('child target: replaces history with /(app)/home on CTA press', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+
+    await driveToStep3Child();
+    fireEvent.press(screen.getByTestId('save-confirm-land'));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(app)/home');
+    });
+  });
+
+  it('clears preview state on save completion', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 'fractions',
+      createdAt: new Date().toISOString(),
+    });
+
+    await driveToStep3Self();
+    fireEvent.press(screen.getByTestId('save-confirm-land'));
+
+    await waitFor(async () => {
+      expect(await getPreviewState()).toBeNull();
+    });
+  });
+
+  it('switchProfile failure surfaces error in landing error block', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 'history',
+      createdAt: new Date().toISOString(),
+    });
+
+    // Re-render with a failing switchProfile
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    const switchProfileMock = jest
+      .fn()
+      .mockResolvedValue({ success: false, error: 'profile switch failed' });
+    mockUseProfile.mockReturnValue({
+      profiles: [],
+      activeProfile: null,
+      isLoading: false,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: jest.fn(),
+      switchProfile: switchProfileMock,
+    });
+
+    mockFetch.setRoute(
+      '/profiles',
+      () =>
+        new Response(
+          JSON.stringify({
+            profile: {
+              id: 'p1',
+              displayName: 'Solo',
+              birthYear: 2000,
+              isOwner: true,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+
+    const AppLayout = require('./_layout').default;
+    render(<AppLayout />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-wizard-step-1-continue'));
+    await screen.findByTestId('save-basics-display-name');
+    fireEvent.changeText(
+      screen.getByTestId('save-basics-display-name'),
+      'Solo',
+    );
+    fireEvent.changeText(screen.getByTestId('save-basics-birth-year'), '2000');
+    fireEvent.press(screen.getByTestId('save-basics-continue'));
+    await screen.findByTestId('save-confirm-land');
+
+    fireEvent.press(screen.getByTestId('save-confirm-land'));
+
+    await waitFor(() => {
+      expect(screen.getByText('profile switch failed')).toBeTruthy();
+    });
+    // Must NOT navigate on failure
+    expect(mockReplace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: '/(app)/session' }),
+    );
+    expect(mockReplace).not.toHaveBeenCalledWith('/(app)/home');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // [BUG-776 / M-14] buildSwitchProfileConfirmation
 // ---------------------------------------------------------------------------
 // Pre-fix the consent-gate "Switch profile" handler silently picked the

--- a/apps/mobile/src/app/(app)/_layout.test.tsx
+++ b/apps/mobile/src/app/(app)/_layout.test.tsx
@@ -1146,6 +1146,176 @@ describe('resolveHomeTabPresentation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// SaveWizard — Step 1 (Where to Save)
+// Tests for the multi-step save-wizard skeleton + Step 1 target selection.
+// [CRITICAL-A2] The wizard is INLINE — rendered by AppLayout's gate ordering
+// when preview state is present and wizardDone is false. Tests render the
+// full layout; SaveWizardGate is NOT exported from _layout.tsx.
+// ---------------------------------------------------------------------------
+
+describe('SaveWizard — Step 1', () => {
+  let testQueryClient: QueryClient;
+
+  function setupDefaultRoutes() {
+    mockFetch.setRoute(
+      '/consent/my-status',
+      () =>
+        new Response(
+          JSON.stringify({
+            consentStatus: null,
+            parentEmail: null,
+            consentType: null,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    mockFetch.setRoute(
+      '/subjects',
+      () =>
+        new Response(JSON.stringify({ subjects: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/dashboard',
+      () =>
+        new Response(JSON.stringify({ children: [], demoMode: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    mockFetch.setRoute(
+      '/settings/push-token',
+      () =>
+        new Response(JSON.stringify({ registered: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  }
+
+  function renderWizardLayout() {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    mockUseProfile.mockReturnValue({
+      profiles: [],
+      activeProfile: null,
+      isLoading: false,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: jest.fn(),
+      switchProfile: jest.fn(),
+    });
+    const AppLayout = require('./_layout').default;
+    return render(<AppLayout />, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    testQueryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    mockUsePathname.mockReturnValue('/home');
+    const SecureStoreMock = require('../../lib/secure-storage');
+    (SecureStoreMock.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (SecureStoreMock.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+    (SecureStoreMock.deleteItemAsync as jest.Mock).mockResolvedValue(undefined);
+    await clearPreviewState();
+    setupDefaultRoutes();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // [CRITICAL-3] No dead-end when wizard mounts with expired/missing state.
+  // Simulates the TTL-expiry race: layout's probe sees state as 'present'
+  // (first call), then the TTL expires before the wizard's own internal probe
+  // runs (second call returns null). The wizard must call onComplete + navigate
+  // home rather than rendering a blank dead-end screen.
+  it('redirects to /(app)/home when wizard mounts but state has expired', async () => {
+    // First call (layout probe) returns a valid state so the wizard branch is entered.
+    // Second call (wizard's internal probe) returns null to simulate TTL expiry.
+    const previewModule = require('../../lib/preview-onboarding-state');
+    let callCount = 0;
+    jest
+      .spyOn(previewModule, 'getPreviewState')
+      .mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            intent: 'self',
+            path: 'learner_value_prop',
+            createdAt: new Date().toISOString(),
+          };
+        }
+        return null;
+      });
+
+    renderWizardLayout();
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(app)/home');
+    });
+    expect(screen.queryByTestId('save-wizard-step-1')).toBeNull();
+  });
+
+  it('preselects "My learning" when intent was self', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 't',
+      createdAt: new Date().toISOString(),
+    });
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    expect(
+      screen.getByTestId('save-target-self').props.accessibilityState?.selected,
+    ).toBe(true);
+  });
+
+  it('preselects "My child" when intent was child', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    expect(
+      screen.getByTestId('save-target-child').props.accessibilityState
+        ?.selected,
+    ).toBe(true);
+  });
+
+  it('overrides intent when user picks a different target', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    renderWizardLayout();
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-target-self'));
+    expect(
+      screen.getByTestId('save-target-self').props.accessibilityState?.selected,
+    ).toBe(true);
+    expect(
+      screen.getByTestId('save-target-child').props.accessibilityState
+        ?.selected,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // [BUG-776 / M-14] buildSwitchProfileConfirmation
 // ---------------------------------------------------------------------------
 // Pre-fix the consent-gate "Switch profile" handler silently picked the

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -58,11 +58,12 @@ import { FEATURE_FLAGS } from '../../lib/feature-flags';
 import {
   getPreviewState,
   setPreviewState,
+  clearPreviewState,
   type PreviewOnboardingStateV0,
   type SaveTarget,
 } from '../../lib/preview-onboarding-state';
-// Note: clearPreviewState is NOT imported here. [CRITICAL-B2] cleanup is
-// owned by the wizard's Step-3 success path (Task 14) and by sign-out.
+// [CRITICAL-B2] clearPreviewState is now imported here — ownership is
+// Task 14's Step-3 success path (this file) and sign-out.
 import { useApiClient } from '../../lib/api-client';
 import { assertOk } from '../../lib/assert-ok';
 
@@ -1045,14 +1046,114 @@ function ProfileBasicsStep({
   );
 }
 
-function ConfirmStep(_props: {
+/**
+ * Step 3 of the save wizard: confirmation screen + landing handoff.
+ *
+ * Dual landing keyed off the wizard's `target` flag (Task 0 resolution):
+ * - self / both+self_first → navigate to /(app)/session with rawInput so the
+ *   session screen handles subject creation and streams the opening message.
+ * - child / both+child_first → navigate to /(app)/home where the "Add child"
+ *   CTA closes the loop and the saved topic surfaces as a card.
+ *
+ * Always calls onComplete() after successful landing so the layout's wizard
+ * branch exits cleanly ([HIGH-A2]).
+ */
+function ConfirmStep({
+  target,
+  previewState,
+  created,
+  router,
+  onComplete,
+}: {
   target: SaveTarget;
   previewState: PreviewOnboardingStateV0;
+  created: { parent: Profile; child?: Profile };
   router: ReturnType<typeof useRouter>;
   onComplete: () => void; // [HIGH-A2] layout-level wizard-done signal
 }): React.ReactElement {
-  // Implemented in Task 14.
-  return <Text>TODO step 3</Text>;
+  const { switchProfile } = useProfile();
+  const [landing, setLanding] = React.useState(false);
+  const [landingError, setLandingError] = React.useState<string | null>(null);
+
+  const isSelfBranch =
+    target === 'self' ||
+    (target === 'both' && previewState.bothPriority === 'self_first');
+
+  const cta = isSelfBranch ? 'Start lesson' : 'Open parent home';
+
+  const onLand = React.useCallback(async () => {
+    if (landing) return;
+    setLanding(true);
+    try {
+      const sw = await switchProfile(created.parent.id);
+      if (!sw.success) {
+        setLandingError(sw.error ?? 'Could not switch profile.');
+        return;
+      }
+
+      await clearPreviewState();
+      onComplete(); // [HIGH-A2] signal wizard done before navigating
+
+      if (isSelfBranch) {
+        // Land in a session for the saved topic. Pass rawInput so the session
+        // screen handles subject creation and opens the chat directly.
+        router.replace({
+          pathname: '/(app)/session',
+          params: {
+            mode: 'freeform',
+            ...(previewState.topicText
+              ? { rawInput: previewState.topicText }
+              : {}),
+          },
+        } as import('expo-router').Href);
+      } else {
+        // Parent branch: "Add child" CTA on home closes the loop.
+        router.replace('/(app)/home' as import('expo-router').Href);
+      }
+    } catch (err) {
+      setLandingError(formatApiError(err));
+    } finally {
+      setLanding(false);
+    }
+  }, [
+    landing,
+    switchProfile,
+    created.parent.id,
+    isSelfBranch,
+    previewState.topicText,
+    onComplete,
+    router,
+  ]);
+
+  return (
+    <View>
+      <Text className="text-h3 font-semibold text-text-primary mb-2">
+        {isSelfBranch
+          ? `Your first lesson is ready${previewState.topicText ? `: ${previewState.topicText}` : ''}.`
+          : "Your child's profile is set up. Let's open parent home."}
+      </Text>
+      {landingError && (
+        <View className="bg-danger/10 rounded-card px-4 py-3 mb-3">
+          <Text className="text-danger text-body-sm">{landingError}</Text>
+        </View>
+      )}
+      <Pressable
+        onPress={() => void onLand()}
+        disabled={landing}
+        className={`rounded-button py-3.5 items-center ${landing ? 'bg-primary/40' : 'bg-primary'}`}
+        testID="save-confirm-land"
+        accessibilityRole="button"
+      >
+        {landing ? (
+          <ActivityIndicator color="white" />
+        ) : (
+          <Text className="text-body font-semibold text-text-inverse">
+            {cta}
+          </Text>
+        )}
+      </Pressable>
+    </View>
+  );
 }
 
 /**
@@ -1170,10 +1271,11 @@ function SaveWizardGate({
         />
       )}
 
-      {step === 3 && (
+      {step === 3 && created && (
         <ConfirmStep
           target={target!}
           previewState={previewState}
+          created={created}
           router={router}
           onComplete={onComplete} // [HIGH-A2] forwarded from layout
         />

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -17,7 +17,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as SecureStore from '../../lib/secure-storage';
 import { useProfile, isGuardianProfile } from '../../lib/profile';
-import { computeAgeBracket } from '@eduagent/schemas';
+import { computeAgeBracket, type Profile } from '@eduagent/schemas';
 import {
   useThemeColors,
   useTokenVars,
@@ -55,7 +55,11 @@ import {
 } from '../../hooks/use-active-profile-role';
 import { useMentorLanguageSync } from '../../hooks/use-mentor-language-sync';
 import { FEATURE_FLAGS } from '../../lib/feature-flags';
-import { getPreviewState } from '../../lib/preview-onboarding-state';
+import {
+  getPreviewState,
+  type PreviewOnboardingStateV0,
+  type SaveTarget,
+} from '../../lib/preview-onboarding-state';
 // Note: clearPreviewState is NOT imported here. [CRITICAL-B2] cleanup is
 // owned by the wizard's Step-3 success path (Task 14) and by sign-out.
 
@@ -717,6 +721,63 @@ function CreateProfileGate(): React.ReactElement {
   );
 }
 
+// ─── Save Wizard types and constants ─────────────────────────────────────────
+
+type WizardStep = 1 | 2 | 3;
+
+interface TargetOption {
+  target: SaveTarget;
+  label: string;
+  testID: string;
+}
+
+const SAVE_TARGETS: ReadonlyArray<TargetOption> = [
+  { target: 'self', label: 'My learning', testID: 'save-target-self' },
+  {
+    target: 'child',
+    label: "My child's learning",
+    testID: 'save-target-child',
+  },
+  { target: 'both', label: 'Both', testID: 'save-target-both' },
+];
+
+function defaultTargetFor(
+  state: PreviewOnboardingStateV0 | null,
+): SaveTarget | null {
+  if (!state) return null;
+  switch (state.intent) {
+    case 'self':
+      return 'self';
+    case 'child':
+      return 'child';
+    case 'both':
+      return 'both';
+    case 'not_sure':
+      return null; // ask explicitly per spec Routing And Landing Rules
+  }
+}
+
+// ─── Step placeholder components (Tasks 13 and 14) ───────────────────────────
+
+function ProfileBasicsStep(_props: {
+  target: SaveTarget;
+  previewState: PreviewOnboardingStateV0;
+  onComplete: (created: { parent: Profile; child?: Profile }) => void;
+}): React.ReactElement {
+  // Implemented in Task 13.
+  return <Text>TODO step 2</Text>;
+}
+
+function ConfirmStep(_props: {
+  target: SaveTarget;
+  previewState: PreviewOnboardingStateV0;
+  router: ReturnType<typeof useRouter>;
+  onComplete: () => void; // [HIGH-A2] layout-level wizard-done signal
+}): React.ReactElement {
+  // Implemented in Task 14.
+  return <Text>TODO step 3</Text>;
+}
+
 /**
  * [CRITICAL-A2] Save-wizard gate — shown when a user arrives post-OAuth with
  * a valid preview-onboarding state (they previewed the app before signing up).
@@ -724,26 +785,116 @@ function CreateProfileGate(): React.ReactElement {
  * the profile-creation transition (ProfileProvider auto-activates the first
  * profile; a nested route would unmount mid-wizard at that point).
  *
- * Task 12 fills in the multi-step UI. This stub satisfies the Task 11 wiring
- * test (`save-wizard-gate` testID) and the `onComplete` callback contract.
+ * Multi-step controller: Step 1 = target selection, Step 2 = profile basics
+ * (Task 13), Step 3 = confirm + landing (Task 14).
  */
 function SaveWizardGate({
-  onComplete: _onComplete,
+  onComplete,
 }: {
   onComplete: () => void;
 }): React.ReactElement {
-  // TODO(Task 12): Replace stub with the real multi-step save wizard.
-  // `_onComplete` is prefixed with `_` (unused-vars convention) because the
-  // real step logic (Task 12) will wire it; the stub renders a placeholder.
+  const router = useRouter();
   const insets = useSafeAreaInsets();
+  const [previewState, setLocalPreviewState] =
+    React.useState<PreviewOnboardingStateV0 | null>(null);
+  const [probeDone, setProbeDone] = React.useState(false);
+  const [target, setTarget] = React.useState<SaveTarget | null>(null);
+  const [step, setStep] = React.useState<WizardStep>(1);
+
+  React.useEffect(() => {
+    void getPreviewState().then((s) => {
+      setLocalPreviewState(s);
+      setTarget(defaultTargetFor(s));
+      setProbeDone(true);
+    });
+  }, []);
+
+  // [CRITICAL-3] Recovery path for "wizard mounted with no state" — happens
+  // when the 1h TTL expires between the layout's initial probe and this
+  // component's second probe, or when SecureStore is wiped externally
+  // (sign-out race). Without this, the wizard renders null and traps the user.
+  // [HIGH-A2] Signal completion to the layout BEFORE navigating, so the wizard
+  // branch in AppLayout exits cleanly and falls through to the next gate.
+  React.useEffect(() => {
+    if (probeDone && !previewState) {
+      onComplete();
+      router.replace('/(app)/home');
+    }
+  }, [probeDone, previewState, router, onComplete]);
+
+  if (!previewState) {
+    return <View testID="save-wizard-gate" className="flex-1 bg-background" />;
+  }
+
   return (
-    <View
-      className="flex-1 bg-background items-center justify-center px-6"
-      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{
+        paddingTop: insets.top + 24,
+        paddingBottom: insets.bottom + 24,
+        paddingHorizontal: 24,
+      }}
       testID="save-wizard-gate"
     >
-      <ActivityIndicator size="large" />
-    </View>
+      <View testID={`save-wizard-step-${step}`} />
+      <Text className="text-h1 font-bold text-text-primary mb-2">
+        Great, let&apos;s save this and get you started.
+      </Text>
+
+      {step === 1 && (
+        <View>
+          <Text className="text-body text-text-secondary mb-6">
+            Where should we save this?
+          </Text>
+          {SAVE_TARGETS.map((opt) => {
+            const selected = target === opt.target;
+            return (
+              <Pressable
+                key={opt.target}
+                onPress={() => setTarget(opt.target)}
+                className={`rounded-card px-4 py-4 mb-3 ${selected ? 'bg-primary/10 border border-primary' : 'bg-surface'}`}
+                testID={opt.testID}
+                accessibilityRole="radio"
+                accessibilityState={{ selected }}
+              >
+                <Text className="text-body font-semibold text-text-primary">
+                  {opt.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+          <Pressable
+            onPress={() => target && setStep(2)}
+            disabled={!target}
+            className={`rounded-button py-3.5 items-center mt-4 ${target ? 'bg-primary' : 'bg-primary/40'}`}
+            testID="save-wizard-step-1-continue"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !target }}
+          >
+            <Text className="text-body font-semibold text-text-inverse">
+              Continue
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {step === 2 && (
+        <ProfileBasicsStep
+          target={target!}
+          previewState={previewState}
+          onComplete={() => setStep(3)}
+        />
+      )}
+
+      {step === 3 && (
+        <ConfirmStep
+          target={target!}
+          previewState={previewState}
+          router={router}
+          onComplete={onComplete} // [HIGH-A2] forwarded from layout
+        />
+      )}
+    </ScrollView>
   );
 }
 

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -57,11 +57,14 @@ import { useMentorLanguageSync } from '../../hooks/use-mentor-language-sync';
 import { FEATURE_FLAGS } from '../../lib/feature-flags';
 import {
   getPreviewState,
+  setPreviewState,
   type PreviewOnboardingStateV0,
   type SaveTarget,
 } from '../../lib/preview-onboarding-state';
 // Note: clearPreviewState is NOT imported here. [CRITICAL-B2] cleanup is
 // owned by the wizard's Step-3 success path (Task 14) and by sign-out.
+import { useApiClient } from '../../lib/api-client';
+import { assertOk } from '../../lib/assert-ok';
 
 initNotificationHandler();
 
@@ -757,15 +760,289 @@ function defaultTargetFor(
   }
 }
 
-// ─── Step placeholder components (Tasks 13 and 14) ───────────────────────────
+// ─── Step 2: Profile Basics (Task 13) ────────────────────────────────────────
 
-function ProfileBasicsStep(_props: {
+function ProfileBasicsStep({
+  target,
+  previewState,
+  onComplete,
+}: {
   target: SaveTarget;
   previewState: PreviewOnboardingStateV0;
   onComplete: (created: { parent: Profile; child?: Profile }) => void;
 }): React.ReactElement {
-  // Implemented in Task 13.
-  return <Text>TODO step 2</Text>;
+  const client = useApiClient();
+  const queryClient = useQueryClient();
+
+  const [parentName, setParentName] = React.useState('');
+  const [parentBirthYear, setParentBirthYear] = React.useState('');
+  const [childName, setChildName] = React.useState('');
+  const [childBirthYear, setChildBirthYear] = React.useState('');
+  const [createdParent, setCreatedParent] = React.useState<Profile | null>(
+    null,
+  );
+  const [error, setError] = React.useState<string | null>(null);
+  const [childError, setChildError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+
+  const needsChild = target === 'child' || target === 'both';
+  const needsOwner = true; // all targets require an owner profile
+
+  const isValidYear = (s: string) =>
+    /^\d{4}$/.test(s) &&
+    Number(s) > 1900 &&
+    Number(s) <= new Date().getFullYear();
+
+  // [HIGH-A3 / HIGH-B2] Client-side adult-age gate. Server has NO 18+ rule
+  // (apps/api/src/services/profile.ts:184-191 only enforces 11+), so without
+  // this gate a minor could complete the wizard as isOwner=true with a child
+  // linked underneath. Skipped entirely when target === 'self' — server's 11+
+  // floor covers that case.
+  //
+  // [OPT-C] Gated by FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED. When OFF,
+  // adultGateRequired is false and adultGatePasses is trivially true, so
+  // canSubmit falls back to today's behaviour (field validations only).
+  const parentIsAdult =
+    isValidYear(parentBirthYear) &&
+    computeAgeBracket(Number(parentBirthYear)) === 'adult';
+  const adultGateRequired =
+    FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED && needsChild;
+  const adultGatePasses = !adultGateRequired || parentIsAdult;
+
+  const canSubmit =
+    !loading &&
+    parentName.trim().length > 0 &&
+    isValidYear(parentBirthYear) &&
+    (needsChild
+      ? childName.trim().length > 0 && isValidYear(childBirthYear)
+      : true) &&
+    adultGatePasses;
+
+  const submit = React.useCallback(async () => {
+    setError(null);
+    setChildError(null);
+    setLoading(true);
+    try {
+      let parent = createdParent;
+
+      // [HIGH-4] Resume guard: if the preview state already records a created
+      // owner profile id and that profile is in the cache, skip the owner POST
+      // to prevent double-creation on wizard remount mid-flight.
+      if (!parent && previewState.createdOwnerProfileId) {
+        const cached = queryClient.getQueriesData<Profile[]>({
+          predicate: (q) => String(q.queryKey[0]) === 'profiles',
+        });
+        for (const [, list] of cached) {
+          const match = list?.find(
+            (p) => p.id === previewState.createdOwnerProfileId,
+          );
+          if (match) {
+            parent = match;
+            setCreatedParent(match);
+            break;
+          }
+        }
+      }
+
+      if (!parent) {
+        const res = await client.profiles.$post({
+          json: {
+            displayName: parentName.trim(),
+            birthYear: Number(parentBirthYear),
+          },
+        });
+        await assertOk(res);
+        const data = (await res.json()) as { profile: Profile };
+        parent = data.profile;
+        setCreatedParent(parent);
+
+        // [HIGH-4] Persist owner id BEFORE the second POST so a crash between
+        // the two calls can resume without double-creating the owner.
+        await setPreviewState({
+          ...previewState,
+          createdOwnerProfileId: parent.id,
+        });
+
+        queryClient.setQueriesData<Profile[]>(
+          { predicate: (q) => String(q.queryKey[0]) === 'profiles' },
+          (old) => (old ? [...old, parent!] : [parent!]),
+        );
+      }
+
+      let child: Profile | undefined;
+      if (needsChild) {
+        try {
+          // [CRITICAL-1] No `forChild` field. profileCreateSchema rejects it;
+          // server auto-classifies non-first POST as child via
+          // createProfileWithLimitCheck (apps/api/src/services/profile.ts:253).
+          const res = await client.profiles.$post({
+            json: {
+              displayName: childName.trim(),
+              birthYear: Number(childBirthYear),
+            },
+          });
+          await assertOk(res);
+          const data = (await res.json()) as { profile: Profile };
+          child = data.profile;
+
+          queryClient.setQueriesData<Profile[]>(
+            { predicate: (q) => String(q.queryKey[0]) === 'profiles' },
+            (old) => (old ? [...old, child!] : [child!]),
+          );
+        } catch (childErr) {
+          // [AC 9] Keep parent. Surface retryable child error inline.
+          setChildError(formatApiError(childErr));
+          setLoading(false);
+          return;
+        }
+      }
+
+      await queryClient.invalidateQueries({
+        predicate: (q) => String(q.queryKey[0]) === 'profiles',
+      });
+
+      if (parent) {
+        onComplete({ parent, child });
+      }
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    client,
+    queryClient,
+    createdParent,
+    needsChild,
+    parentName,
+    parentBirthYear,
+    childName,
+    childBirthYear,
+    previewState,
+    onComplete,
+  ]);
+
+  return (
+    <View>
+      {needsOwner && (
+        <View className="mb-6">
+          <Text className="text-h3 font-semibold text-text-primary mb-3">
+            {target === 'self' ? 'Tell us about you' : 'About you (the parent)'}
+          </Text>
+          <TextInput
+            placeholder="Your name"
+            value={parentName}
+            onChangeText={setParentName}
+            className="bg-surface text-text-primary rounded-input px-4 py-3 mb-3"
+            testID={
+              target === 'self'
+                ? 'save-basics-display-name'
+                : 'save-basics-parent-name'
+            }
+          />
+          <TextInput
+            placeholder="Birth year (e.g. 1985)"
+            value={parentBirthYear}
+            onChangeText={setParentBirthYear}
+            keyboardType="number-pad"
+            maxLength={4}
+            className="bg-surface text-text-primary rounded-input px-4 py-3"
+            testID={
+              target === 'self'
+                ? 'save-basics-birth-year'
+                : 'save-basics-parent-birth-year'
+            }
+          />
+        </View>
+      )}
+
+      {needsChild && (
+        <View className="mb-6">
+          <Text className="text-h3 font-semibold text-text-primary mb-3">
+            About your child
+          </Text>
+          <TextInput
+            placeholder="Their name or nickname"
+            value={childName}
+            onChangeText={setChildName}
+            className="bg-surface text-text-primary rounded-input px-4 py-3 mb-3"
+            testID="save-basics-child-name"
+          />
+          <TextInput
+            placeholder="Birth year"
+            value={childBirthYear}
+            onChangeText={setChildBirthYear}
+            keyboardType="number-pad"
+            maxLength={4}
+            className="bg-surface text-text-primary rounded-input px-4 py-3"
+            testID="save-basics-child-birth-year"
+          />
+        </View>
+      )}
+
+      {/* [HIGH-A3] Adult-age gate inline message. Visible only when the parent
+          has entered a valid 4-digit year that resolves to under-18, while the
+          flow needs a child profile. Empty / partial input shows nothing.
+          Copy matches plan spec exactly. */}
+      {adultGateRequired && isValidYear(parentBirthYear) && !parentIsAdult && (
+        <View
+          className="bg-warning/10 rounded-card px-4 py-3 mb-3"
+          testID="save-basics-adult-required"
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
+        >
+          <Text className="text-warning text-body-sm">
+            To set up a child&apos;s learning, the account holder must be 18 or
+            older. You can still set up your own learning instead — pick
+            &quot;My learning&quot; on the previous step.
+          </Text>
+        </View>
+      )}
+      {error && (
+        <View
+          className="bg-danger/10 rounded-card px-4 py-3 mb-3"
+          testID="save-basics-error"
+        >
+          <Text className="text-danger text-body-sm">{error}</Text>
+        </View>
+      )}
+      {childError && (
+        <View
+          className="bg-danger/10 rounded-card px-4 py-3 mb-3"
+          testID="save-basics-child-error"
+        >
+          <Text className="text-danger text-body-sm mb-2">
+            We saved your account, but couldn&apos;t add your child yet:{' '}
+            {childError}
+          </Text>
+          <Pressable
+            onPress={() => void submit()}
+            testID="save-basics-retry-child"
+            accessibilityRole="button"
+          >
+            <Text className="text-primary font-semibold">Retry</Text>
+          </Pressable>
+        </View>
+      )}
+
+      <Pressable
+        onPress={() => void submit()}
+        disabled={!canSubmit}
+        className={`rounded-button py-3.5 items-center ${canSubmit ? 'bg-primary' : 'bg-primary/40'}`}
+        testID="save-basics-continue"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !canSubmit }}
+      >
+        {loading ? (
+          <ActivityIndicator color="white" />
+        ) : (
+          <Text className="text-body font-semibold text-text-inverse">
+            Continue
+          </Text>
+        )}
+      </Pressable>
+    </View>
+  );
 }
 
 function ConfirmStep(_props: {
@@ -800,6 +1077,10 @@ function SaveWizardGate({
   const [probeDone, setProbeDone] = React.useState(false);
   const [target, setTarget] = React.useState<SaveTarget | null>(null);
   const [step, setStep] = React.useState<WizardStep>(1);
+  const [created, setCreated] = React.useState<{
+    parent: Profile;
+    child?: Profile;
+  } | null>(null);
 
   React.useEffect(() => {
     void getPreviewState().then((s) => {
@@ -882,7 +1163,10 @@ function SaveWizardGate({
         <ProfileBasicsStep
           target={target!}
           previewState={previewState}
-          onComplete={() => setStep(3)}
+          onComplete={(c) => {
+            setCreated(c);
+            setStep(3);
+          }}
         />
       )}
 

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -54,6 +54,10 @@ import {
   type ActiveProfileRole,
 } from '../../hooks/use-active-profile-role';
 import { useMentorLanguageSync } from '../../hooks/use-mentor-language-sync';
+import { FEATURE_FLAGS } from '../../lib/feature-flags';
+import { getPreviewState } from '../../lib/preview-onboarding-state';
+// Note: clearPreviewState is NOT imported here. [CRITICAL-B2] cleanup is
+// owned by the wizard's Step-3 success path (Task 14) and by sign-out.
 
 initNotificationHandler();
 
@@ -709,6 +713,36 @@ function CreateProfileGate(): React.ReactElement {
           </Text>
         </Pressable>
       </GateContent>
+    </View>
+  );
+}
+
+/**
+ * [CRITICAL-A2] Save-wizard gate — shown when a user arrives post-OAuth with
+ * a valid preview-onboarding state (they previewed the app before signing up).
+ * Renders INLINE (not as a nested Expo Router route) so it stays mounted across
+ * the profile-creation transition (ProfileProvider auto-activates the first
+ * profile; a nested route would unmount mid-wizard at that point).
+ *
+ * Task 12 fills in the multi-step UI. This stub satisfies the Task 11 wiring
+ * test (`save-wizard-gate` testID) and the `onComplete` callback contract.
+ */
+function SaveWizardGate({
+  onComplete: _onComplete,
+}: {
+  onComplete: () => void;
+}): React.ReactElement {
+  // TODO(Task 12): Replace stub with the real multi-step save wizard.
+  // `_onComplete` is prefixed with `_` (unused-vars convention) because the
+  // real step logic (Task 12) will wire it; the stub renders a placeholder.
+  const insets = useSafeAreaInsets();
+  return (
+    <View
+      className="flex-1 bg-background items-center justify-center px-6"
+      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      testID="save-wizard-gate"
+    >
+      <ActivityIndicator size="large" />
     </View>
   );
 }
@@ -1530,6 +1564,42 @@ export default function AppLayout() {
     }
   }, [isLoaded, isSignedIn]);
 
+  // [CRITICAL-A2] Preview-state probe — async, resolves once on mount.
+  // Determines whether to show the SaveWizardGate (inline gate, not a route).
+  // Initial state is 'loading' to hold rendering until the probe settles,
+  // preventing a transient CreateProfileGate flash while the async read runs.
+  const [previewProbeState, setPreviewProbeState] = React.useState<
+    'loading' | 'present' | 'absent'
+  >('loading');
+  // [HIGH-A2] Wizard completion sentinel. previewProbeState alone never flips
+  // back to 'absent' after mount; the wizard signals completion via onComplete.
+  const [wizardDone, setWizardDone] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED) {
+      setPreviewProbeState('absent');
+      return;
+    }
+    let cancelled = false;
+    void getPreviewState().then((s) => {
+      if (cancelled) return;
+      setPreviewProbeState(s ? 'present' : 'absent');
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // [CRITICAL-B2] DELIBERATELY no auto-cleanup effect here. A previous
+  // iteration had:
+  //   useEffect(() => { if (activeProfile && profiles.length > 0) clearPreviewState() })
+  // — that races the wizard's owner-POST → child-POST sequence and wipes
+  // `createdOwnerProfileId` between the two calls, destroying the [HIGH-4]
+  // resume guard. Cleanup is owned by:
+  //   (a) TTL inside getPreviewState (1h)
+  //   (b) sign-out-cleanup (Task 4)
+  //   (c) wizard's explicit clearPreviewState() on Step-3 success (Task 14)
+
   if (!isLoaded)
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -1660,6 +1730,48 @@ export default function AppLayout() {
   //
   // key={themeKey} removed — crashes Android Fabric (MENTOMATE-MOBILE-6).
   // NativeWind vars() style updates propagate without remounting.
+
+  // [CRITICAL-A2] Gate ordering — preview probe + wizard branch.
+  // These sit ABOVE !activeProfile so the wizard stays mounted when
+  // ProfileProvider auto-activates the first profile mid-wizard
+  // (profile.ts:154-174). Without this ordering the wizard would unmount
+  // after Step 2's POST succeeds.
+  //
+  // [CRITICAL-A3] Ordering guarantees (non-negotiable):
+  //   1. !isLoaded → spinner  (auth not loaded; do not render any app UI)
+  //   2. !isSignedIn → Redirect  (signed-out user must not see the wizard)
+  //   3. pendingAuthRedirect spinner  (OAuth-return redirect-replay)
+  //   4. isProfileLoading spinner  (profile query in flight)
+  //   5. profileLoadError fallback  (independent of preview state)
+  //   6. preview-probe-loading spinner  ← HERE
+  //   7. SaveWizardGate branch  ← HERE
+  //   8. !activeProfile → CreateProfileGate  (existing)
+  //   9. consent gates → Tabs  (existing)
+  if (
+    FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED &&
+    previewProbeState === 'loading'
+  ) {
+    return (
+      <View
+        className="flex-1 bg-background items-center justify-center"
+        testID="preview-state-loading"
+      >
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (
+    FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED &&
+    previewProbeState === 'present' &&
+    !wizardDone
+  ) {
+    return (
+      <FeedbackProvider>
+        <SaveWizardGate onComplete={() => setWizardDone(true)} />
+      </FeedbackProvider>
+    );
+  }
 
   // No profile exists — show gate that pushes to profile creation modal
   if (!activeProfile) {

--- a/apps/mobile/src/app/(auth)/sign-in.test.tsx
+++ b/apps/mobile/src/app/(auth)/sign-in.test.tsx
@@ -12,6 +12,24 @@ import * as Linking from 'expo-linking';
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
 
+// Mutable flag state so individual tests can toggle PREVIEW_ONBOARDING_ENABLED.
+// Defaults to true (matches the real feature-flags.ts value).
+let mockPreviewOnboardingEnabled = true;
+jest.mock(
+  '../../lib/feature-flags' /* gc1-allow: screen test pins flag branch for CTA visibility */,
+  () => ({
+    get FEATURE_FLAGS() {
+      return {
+        COACH_BAND_ENABLED: true,
+        MIC_IN_PILL_ENABLED: true,
+        I18N_ENABLED: true,
+        PREVIEW_ONBOARDING_ENABLED: mockPreviewOnboardingEnabled,
+        ADULT_OWNER_GATE_ENABLED: true,
+      };
+    },
+  }),
+);
+
 jest.mock('expo-router', () => ({
   useRouter: () => ({ replace: mockReplace, push: mockPush }),
   useLocalSearchParams: () => ({}),
@@ -1102,5 +1120,39 @@ describe('SignInScreen', () => {
       expect(mockReplace).not.toHaveBeenCalled();
       expect(mockPush).not.toHaveBeenCalled();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PREVIEW_ONBOARDING_ENABLED flag gate — Try MentoMate CTA
+// ---------------------------------------------------------------------------
+
+describe('SignInScreen — Try MentoMate CTA', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearTransitionState();
+    clearPendingAuthRedirect();
+    clearSessionExpiredNotice();
+    // Restore flag to default (on) before each test in this describe block
+    mockPreviewOnboardingEnabled = true;
+  });
+
+  afterEach(() => {
+    // Restore global default so other describe blocks are unaffected
+    mockPreviewOnboardingEnabled = true;
+  });
+
+  it('renders the Try MentoMate CTA when flag is on', async () => {
+    mockPreviewOnboardingEnabled = true;
+    render(<SignInScreen />);
+    await act(async () => undefined);
+    expect(screen.getByTestId('try-mentomate-cta')).toBeTruthy();
+  });
+
+  it('hides the CTA when flag is off', async () => {
+    mockPreviewOnboardingEnabled = false;
+    render(<SignInScreen />);
+    await act(async () => undefined);
+    expect(screen.queryByTestId('try-mentomate-cta')).toBeNull();
   });
 });

--- a/apps/mobile/src/app/(auth)/sign-in.tsx
+++ b/apps/mobile/src/app/(auth)/sign-in.tsx
@@ -5,6 +5,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   Dimensions,
   ActivityIndicator,
@@ -46,6 +47,7 @@ import {
   rememberPendingAuthRedirect,
 } from '../../lib/pending-auth-redirect';
 import { ErrorFallback } from '../../components/common/ErrorFallback';
+import { FEATURE_FLAGS } from '../../lib/feature-flags';
 
 // Use physical screen height (not window) so the content container always
 // overflows the ScrollView after adjustResize shrinks it for the keyboard.
@@ -1419,6 +1421,25 @@ export default function SignInScreen() {
                 testID="sign-up-link"
               />
             </View>
+
+            {FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED && (
+              <View className="w-full mt-6 pt-6 border-t border-border">
+                <Text className="text-body-sm text-text-secondary text-center mb-3">
+                  New here?
+                </Text>
+                <Pressable
+                  onPress={() => router.push('/preview')}
+                  className="bg-surface rounded-button py-3.5 px-8 items-center w-full"
+                  testID="try-mentomate-cta"
+                  accessibilityRole="button"
+                  accessibilityLabel="Try MentoMate"
+                >
+                  <Text className="text-body font-semibold text-primary">
+                    Try MentoMate
+                  </Text>
+                </Pressable>
+              </View>
+            )}
           </View>
         </ScrollView>
       </View>

--- a/apps/mobile/src/app/preview/_layout.tsx
+++ b/apps/mobile/src/app/preview/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function PreviewLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/apps/mobile/src/app/preview/index.tsx
+++ b/apps/mobile/src/app/preview/index.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MentomateLogo } from '../../components/MentomateLogo';
+import { goBackOrReplace } from '../../lib/navigation';
 
 export default function PreviewLandingScreen() {
   const router = useRouter();
@@ -13,6 +14,17 @@ export default function PreviewLandingScreen() {
       style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
       testID="preview-landing"
     >
+      <Pressable
+        onPress={() => goBackOrReplace(router, '/(auth)/sign-in' as const)}
+        className="self-start min-h-[44px] justify-center mb-4"
+        testID="preview-landing-back"
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+      >
+        <Text className="text-body-sm font-semibold text-primary">
+          Back to sign in
+        </Text>
+      </Pressable>
       <MentomateLogo size="lg" />
       <Text className="text-h1 font-bold text-text-primary mt-8 mb-3 text-center">
         Try MentoMate

--- a/apps/mobile/src/app/preview/index.tsx
+++ b/apps/mobile/src/app/preview/index.tsx
@@ -1,0 +1,36 @@
+import { View, Text, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MentomateLogo } from '../../components/MentomateLogo';
+
+export default function PreviewLandingScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      className="flex-1 bg-background items-center justify-center px-6"
+      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      testID="preview-landing"
+    >
+      <MentomateLogo size="lg" />
+      <Text className="text-h1 font-bold text-text-primary mt-8 mb-3 text-center">
+        Try MentoMate
+      </Text>
+      <Text className="text-body text-text-secondary mb-10 text-center">
+        See how it works — no sign-up needed yet.
+      </Text>
+      <Pressable
+        onPress={() => router.push('/preview/intent')}
+        className="bg-primary rounded-button py-3.5 px-10 items-center w-full"
+        testID="preview-landing-continue"
+        accessibilityRole="button"
+        accessibilityLabel="Continue"
+      >
+        <Text className="text-body font-semibold text-text-inverse">
+          Continue
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/preview/intent.test.tsx
+++ b/apps/mobile/src/app/preview/intent.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import IntentScreen from './intent';
+import * as state from '../../lib/preview-onboarding-state';
+
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+describe('Preview IntentScreen', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    push.mockReset();
+    jest.spyOn(state, 'setPreviewState').mockResolvedValue();
+  });
+
+  it('routes Me → topic with intent self', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-self'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'self', path: 'learner_value_prop' }),
+    );
+    expect(push).toHaveBeenCalledWith('/preview/topic');
+  });
+
+  it('routes My child → value-prop parent variant', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-child'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'child', path: 'parent_value_prop' }),
+    );
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/preview/value-prop',
+      params: { variant: 'parent' },
+    });
+  });
+
+  it('routes Both → topic (child-first default recorded)', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-both'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'both',
+        bothPriority: 'child_first',
+        path: 'parent_value_prop',
+      }),
+    );
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/preview/value-prop',
+      params: { variant: 'parent' },
+    });
+  });
+
+  it('routes Not sure → topic (lesson fork) with intent not_sure', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-not-sure'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'not_sure' }),
+    );
+    expect(push).toHaveBeenCalledWith('/preview/topic');
+  });
+});

--- a/apps/mobile/src/app/preview/intent.tsx
+++ b/apps/mobile/src/app/preview/intent.tsx
@@ -1,0 +1,124 @@
+import { View, Text, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  setPreviewState,
+  type PreviewIntent,
+} from '../../lib/preview-onboarding-state';
+
+interface Option {
+  intent: PreviewIntent;
+  label: string;
+  description: string;
+  testID: string;
+}
+
+const OPTIONS: ReadonlyArray<Option> = [
+  {
+    intent: 'self',
+    label: 'Me',
+    description: "I'm setting this up for myself.",
+    testID: 'intent-self',
+  },
+  {
+    intent: 'child',
+    label: 'My child',
+    description: 'I want to help my child.',
+    testID: 'intent-child',
+  },
+  {
+    intent: 'both',
+    label: 'Both',
+    description: 'For me and my child.',
+    testID: 'intent-both',
+  },
+  {
+    intent: 'not_sure',
+    label: 'Not sure',
+    description: 'Show me how it works first.',
+    testID: 'intent-not-sure',
+  },
+];
+
+export default function PreviewIntentScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const onSelect = async (intent: PreviewIntent) => {
+    const createdAt = new Date().toISOString();
+
+    if (intent === 'self') {
+      await setPreviewState({
+        intent: 'self',
+        path: 'learner_value_prop',
+        createdAt,
+      });
+      router.push('/preview/topic');
+      return;
+    }
+    if (intent === 'child') {
+      await setPreviewState({
+        intent: 'child',
+        path: 'parent_value_prop',
+        createdAt,
+      });
+      router.push({
+        pathname: '/preview/value-prop',
+        params: { variant: 'parent' },
+      });
+      return;
+    }
+    if (intent === 'both') {
+      await setPreviewState({
+        intent: 'both',
+        path: 'parent_value_prop',
+        bothPriority: 'child_first',
+        createdAt,
+      });
+      router.push({
+        pathname: '/preview/value-prop',
+        params: { variant: 'parent' },
+      });
+      return;
+    }
+    // not_sure → lesson fork (v0: same as self)
+    await setPreviewState({
+      intent: 'not_sure',
+      path: 'learner_value_prop',
+      createdAt,
+    });
+    router.push('/preview/topic');
+  };
+
+  return (
+    <View
+      className="flex-1 bg-background px-6"
+      style={{ paddingTop: insets.top + 32, paddingBottom: insets.bottom }}
+      testID="preview-intent"
+    >
+      <Text className="text-h1 font-bold text-text-primary mb-2 text-center">
+        Who are you setting this up for?
+      </Text>
+      <Text className="text-body text-text-secondary mb-8 text-center">
+        We&apos;ll tailor what you see next.
+      </Text>
+      {OPTIONS.map((opt) => (
+        <Pressable
+          key={opt.intent}
+          onPress={() => void onSelect(opt.intent)}
+          className="bg-surface rounded-card px-4 py-4 mb-3"
+          testID={opt.testID}
+          accessibilityRole="button"
+          accessibilityLabel={opt.label}
+        >
+          <Text className="text-body font-semibold text-text-primary mb-1">
+            {opt.label}
+          </Text>
+          <Text className="text-body-sm text-text-secondary">
+            {opt.description}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/app/preview/intent.tsx
+++ b/apps/mobile/src/app/preview/intent.tsx
@@ -5,6 +5,7 @@ import {
   setPreviewState,
   type PreviewIntent,
 } from '../../lib/preview-onboarding-state';
+import { goBackOrReplace } from '../../lib/navigation';
 
 interface Option {
   intent: PreviewIntent;
@@ -96,6 +97,17 @@ export default function PreviewIntentScreen() {
       style={{ paddingTop: insets.top + 32, paddingBottom: insets.bottom }}
       testID="preview-intent"
     >
+      <Pressable
+        onPress={() => goBackOrReplace(router, '/(auth)/sign-in' as const)}
+        className="self-start min-h-[44px] justify-center mb-2"
+        testID="preview-intent-back"
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+      >
+        <Text className="text-body-sm font-semibold text-primary">
+          Back to sign in
+        </Text>
+      </Pressable>
       <Text className="text-h1 font-bold text-text-primary mb-2 text-center">
         Who are you setting this up for?
       </Text>

--- a/apps/mobile/src/app/preview/topic.test.tsx
+++ b/apps/mobile/src/app/preview/topic.test.tsx
@@ -1,0 +1,64 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import TopicScreen from './topic';
+import * as state from '../../lib/preview-onboarding-state';
+
+jest.mock('expo-router', () => ({ useRouter: jest.fn() }));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// prettier-ignore
+jest.mock('../../lib/theme', /* gc1-allow: nativewind vars() does not resolve 'react' in jest; stub theme hooks so screen tests don't blow up on import */ () => ({
+  useThemeColors: () => ({ muted: '#71717a' }),
+  useTheme: () => ({ colorScheme: 'dark' }),
+  useTokenVars: () => ({}),
+}));
+
+describe('Preview TopicScreen', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    push.mockReset();
+    jest.spyOn(state, 'getPreviewState').mockResolvedValue({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    jest.spyOn(state, 'setPreviewState').mockResolvedValue();
+  });
+
+  it('stores topic and navigates to value-prop learner variant', async () => {
+    render(<TopicScreen />);
+    fireEvent.changeText(
+      screen.getByTestId('preview-topic-input'),
+      'algebra basics',
+    );
+    fireEvent.press(screen.getByTestId('preview-topic-continue'));
+
+    await waitFor(() => {
+      expect(state.setPreviewState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topicText: 'algebra basics',
+          intent: 'self',
+        }),
+      );
+    });
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/preview/value-prop',
+      params: { variant: 'learner' },
+    });
+  });
+
+  it('disables continue when topic is empty', () => {
+    render(<TopicScreen />);
+    const cta = screen.getByTestId('preview-topic-continue');
+    expect(cta.props.accessibilityState?.disabled).toBe(true);
+  });
+});

--- a/apps/mobile/src/app/preview/topic.tsx
+++ b/apps/mobile/src/app/preview/topic.tsx
@@ -8,6 +8,7 @@ import {
   setPreviewState,
   type PreviewOnboardingStateV0,
 } from '../../lib/preview-onboarding-state';
+import { goBackOrReplace } from '../../lib/navigation';
 
 // [MEDIUM-5] Single-line topic cap. The value is persisted to SecureStore for
 // up to 1h pre-signup, so it WILL outlive the screen. Keeping the field short
@@ -54,6 +55,17 @@ export default function PreviewTopicScreen() {
       style={{ paddingTop: insets.top + 32, paddingBottom: insets.bottom + 16 }}
       testID="preview-topic"
     >
+      <Pressable
+        onPress={() => goBackOrReplace(router, '/(auth)/sign-in' as const)}
+        className="self-start min-h-[44px] justify-center mb-2"
+        testID="preview-topic-back"
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+      >
+        <Text className="text-body-sm font-semibold text-primary">
+          Back to sign in
+        </Text>
+      </Pressable>
       <Text className="text-h1 font-bold text-text-primary mb-2 text-center">
         What should we help with?
       </Text>

--- a/apps/mobile/src/app/preview/topic.tsx
+++ b/apps/mobile/src/app/preview/topic.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useThemeColors } from '../../lib/theme';
+import {
+  getPreviewState,
+  setPreviewState,
+  type PreviewOnboardingStateV0,
+} from '../../lib/preview-onboarding-state';
+
+// [MEDIUM-5] Single-line topic cap. The value is persisted to SecureStore for
+// up to 1h pre-signup, so it WILL outlive the screen. Keeping the field short
+// discourages users from pasting longer free text that may contain PII (child
+// names, school names, learning disability descriptions), and the parent-vs-
+// learner branch never needs more than a couple of words to tailor copy.
+// Spec §Preview State (Minimal) accepts the truncated cap.
+const MAX_TOPIC_LEN = 80;
+
+export default function PreviewTopicScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+  const [current, setCurrent] = useState<PreviewOnboardingStateV0 | null>(null);
+  const [topic, setTopic] = useState('');
+
+  useEffect(() => {
+    void getPreviewState().then((s) => {
+      if (s) {
+        setCurrent(s);
+        if (s.topicText) setTopic(s.topicText);
+      }
+    });
+  }, []);
+
+  const trimmed = topic.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_TOPIC_LEN;
+
+  const onContinue = async () => {
+    if (!canSubmit) return;
+    // Re-fetch state in case the effect hadn't settled when the user pressed.
+    const s = current ?? (await getPreviewState());
+    if (!s) return;
+    await setPreviewState({ ...s, topicText: trimmed });
+    router.push({
+      pathname: '/preview/value-prop',
+      params: { variant: 'learner' },
+    });
+  };
+
+  return (
+    <View
+      className="flex-1 bg-background px-6"
+      style={{ paddingTop: insets.top + 32, paddingBottom: insets.bottom + 16 }}
+      testID="preview-topic"
+    >
+      <Text className="text-h1 font-bold text-text-primary mb-2 text-center">
+        What should we help with?
+      </Text>
+      <Text className="text-body text-text-secondary mb-6 text-center">
+        A topic, a question, anything you&apos;re working on.
+      </Text>
+      <TextInput
+        value={topic}
+        onChangeText={setTopic}
+        maxLength={MAX_TOPIC_LEN}
+        placeholder="e.g. quadratic equations"
+        placeholderTextColor={colors.muted}
+        className="bg-surface text-text-primary text-body rounded-input px-4 py-3 mb-6"
+        autoFocus
+        testID="preview-topic-input"
+        accessibilityLabel="Topic"
+      />
+      <Pressable
+        onPress={() => void onContinue()}
+        disabled={!canSubmit}
+        className={`rounded-button py-3.5 items-center ${canSubmit ? 'bg-primary' : 'bg-primary/40'}`}
+        testID="preview-topic-continue"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !canSubmit }}
+        accessibilityLabel="Continue"
+      >
+        <Text className="text-body font-semibold text-text-inverse">
+          Continue
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/preview/value-prop.test.tsx
+++ b/apps/mobile/src/app/preview/value-prop.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import ValuePropScreen from './value-prop';
+import * as state from '../../lib/preview-onboarding-state';
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+describe('Preview ValuePropScreen', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    push.mockReset();
+    jest.spyOn(state, 'getPreviewState').mockResolvedValue({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 'algebra',
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+  it('learner variant renders sample dialogue marked as sample', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'learner' });
+    render(<ValuePropScreen />);
+    expect(screen.getByTestId('preview-value-prop-learner')).toBeTruthy();
+    expect(screen.getByTestId('preview-sample-marker')).toBeTruthy();
+  });
+
+  it('parent variant renders sample weekly insight marked as sample', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'parent' });
+    render(<ValuePropScreen />);
+    expect(screen.getByTestId('preview-value-prop-parent')).toBeTruthy();
+    expect(screen.getByTestId('preview-sample-marker')).toBeTruthy();
+  });
+
+  it('does not render a chat shell or any LLM-driven element', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'learner' });
+    render(<ValuePropScreen />);
+    expect(screen.queryByTestId('chat-shell')).toBeNull();
+    expect(screen.queryByTestId('message-input')).toBeNull();
+  });
+
+  it('CTA routes to sign-up', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'learner' });
+    render(<ValuePropScreen />);
+    fireEvent.press(screen.getByTestId('preview-signup-cta'));
+    expect(push).toHaveBeenCalledWith('/sign-up');
+  });
+});

--- a/apps/mobile/src/app/preview/value-prop.tsx
+++ b/apps/mobile/src/app/preview/value-prop.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  getPreviewState,
+  type PreviewOnboardingStateV0,
+} from '../../lib/preview-onboarding-state';
+
+type Variant = 'learner' | 'parent';
+
+export default function ValuePropScreen() {
+  const params = useLocalSearchParams<{ variant?: Variant }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  // [LOW-2] Named `previewState` (not `state`) to avoid shadowing the
+  // `import * as state from '../../lib/preview-onboarding-state'` pattern
+  // used in tests, and to match save.tsx conventions.
+  const [previewState, setPreviewStateLocal] =
+    useState<PreviewOnboardingStateV0 | null>(null);
+
+  useEffect(() => {
+    void getPreviewState().then(setPreviewStateLocal);
+  }, []);
+
+  const variant: Variant = params.variant === 'parent' ? 'parent' : 'learner';
+  const topic = previewState?.topicText ?? '';
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{
+        paddingTop: insets.top + 24,
+        paddingBottom: insets.bottom + 24,
+        paddingHorizontal: 24,
+      }}
+      testID={
+        variant === 'learner'
+          ? 'preview-value-prop-learner'
+          : 'preview-value-prop-parent'
+      }
+    >
+      {variant === 'learner' ? (
+        <LearnerVariant topic={topic} />
+      ) : (
+        <ParentVariant />
+      )}
+      <Pressable
+        onPress={() => router.push('/sign-up')}
+        className="bg-primary rounded-button py-3.5 px-8 items-center w-full mt-8"
+        testID="preview-signup-cta"
+        accessibilityRole="button"
+      >
+        <Text className="text-body font-semibold text-text-inverse">
+          {variant === 'learner'
+            ? topic
+              ? `Sign up to start your first lesson on ${topic}`
+              : 'Sign up to start your first lesson'
+            : 'Sign up to set up your child'}
+        </Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function SampleMarker() {
+  return (
+    <View
+      className="self-start bg-surface rounded-full px-3 py-1 mb-4"
+      testID="preview-sample-marker"
+    >
+      <Text className="text-caption text-text-muted uppercase tracking-wider">
+        Sample
+      </Text>
+    </View>
+  );
+}
+
+function LearnerVariant({ topic }: { topic: string }) {
+  return (
+    <View>
+      <Text className="text-h1 font-bold text-text-primary mb-3">
+        Here&apos;s how MentoMate teaches
+      </Text>
+      <Text className="text-body text-text-secondary mb-6">
+        A back-and-forth conversation that follows what you actually need — not
+        a fixed lesson plan.
+      </Text>
+      <SampleMarker />
+      <View className="bg-surface rounded-card p-4 mb-3 self-start max-w-[85%]">
+        <Text className="text-body-sm text-text-primary">
+          {topic
+            ? `Let's work on ${topic}. What part is tripping you up?`
+            : 'What are you working on today?'}
+        </Text>
+      </View>
+      <View className="bg-primary/10 rounded-card p-4 mb-3 self-end max-w-[85%]">
+        <Text className="text-body-sm text-text-primary">
+          I get the formula but I don&apos;t know when to use it.
+        </Text>
+      </View>
+      <View className="bg-surface rounded-card p-4 self-start max-w-[85%]">
+        <Text className="text-body-sm text-text-primary">
+          Good — that&apos;s the most useful question. Let me show you with a
+          concrete example…
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function ParentVariant() {
+  return (
+    <View>
+      <Text className="text-h1 font-bold text-text-primary mb-3">
+        Here&apos;s how MentoMate helps families
+      </Text>
+      <Text className="text-body text-text-secondary mb-6">
+        You set up your child, they learn, and you get a short weekly read on
+        what they&apos;re working on. No surveillance, just signal.
+      </Text>
+      <SampleMarker />
+      <View className="bg-surface rounded-card p-5 mb-3">
+        <Text className="text-body font-semibold text-text-primary mb-2">
+          Weekly highlight
+        </Text>
+        <Text className="text-body-sm text-text-secondary mb-3">
+          Practiced quadratic equations for 45 minutes across three sessions.
+          Getting comfortable with factoring; working on completing the square.
+        </Text>
+        <Text className="text-caption text-text-muted">
+          Sample data — your child&apos;s real insights appear after their first
+          session.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/preview/value-prop.tsx
+++ b/apps/mobile/src/app/preview/value-prop.tsx
@@ -6,6 +6,7 @@ import {
   getPreviewState,
   type PreviewOnboardingStateV0,
 } from '../../lib/preview-onboarding-state';
+import { goBackOrReplace } from '../../lib/navigation';
 
 type Variant = 'learner' | 'parent';
 
@@ -40,6 +41,17 @@ export default function ValuePropScreen() {
           : 'preview-value-prop-parent'
       }
     >
+      <Pressable
+        onPress={() => goBackOrReplace(router, '/(auth)/sign-in' as const)}
+        className="self-start min-h-[44px] justify-center mb-2"
+        testID="preview-value-prop-back"
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+      >
+        <Text className="text-body-sm font-semibold text-primary">
+          Back to sign in
+        </Text>
+      </Pressable>
       {variant === 'learner' ? (
         <LearnerVariant topic={topic} />
       ) : (
@@ -69,9 +81,7 @@ function SampleMarker() {
       className="self-start bg-surface rounded-full px-3 py-1 mb-4"
       testID="preview-sample-marker"
     >
-      <Text className="text-caption text-text-muted uppercase tracking-wider">
-        Sample
-      </Text>
+      <Text className="text-caption text-text-muted">Sample</Text>
     </View>
   );
 }

--- a/apps/mobile/src/lib/feature-flags.ts
+++ b/apps/mobile/src/lib/feature-flags.ts
@@ -8,4 +8,28 @@ export const FEATURE_FLAGS = {
   //     English regardless of device settings.
   //   - more.tsx: shows the App-language picker row.
   I18N_ENABLED: true,
+  // Pre-signup intent + post-signup save wizard.
+  // Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
+  // When false:
+  //   - sign-in.tsx: "Try MentoMate" CTA hidden, /preview/* unreachable via UI.
+  //   - (app)/_layout.tsx: no-profile gate ignores preview state, falls through to CreateProfileGate.
+  //   - (app)/_layout.tsx: preview/save tab entry not registered (defensive; route is unreachable anyway).
+  // isFamilyCapableProfile() and the mentomate_preview_intent entry in sign-out-cleanup ship UNCONDITIONALLY.
+  PREVIEW_ONBOARDING_ENABLED: true,
+
+  // [OPT-C] Independent adult-owner gate flag — toggles the 18+ requirement
+  // for a parent creating a child profile. Defense-in-depth: paired with the
+  // API-side ADULT_OWNER_GATE_ENABLED config (apps/api/src/config.ts).
+  //
+  // When false:
+  //   - save.tsx ProfileBasicsStep: the adult-age UI gate is bypassed.
+  //     `canSubmit` falls back to today's behaviour (only the existing
+  //     display-name + valid-4-digit-year checks; no adult-age check).
+  //     The `save-basics-adult-required` warning view is not rendered.
+  //   - With this flag OFF and the API flag also OFF, the system is
+  //     identical to today (no adult-age constraint exists anywhere).
+  //
+  // This flag is INDEPENDENT of PREVIEW_ONBOARDING_ENABLED. The preview
+  // feature can ship while the adult-owner gate stays off (or vice versa).
+  ADULT_OWNER_GATE_ENABLED: true,
 } as const;

--- a/apps/mobile/src/lib/preview-onboarding-state.test.ts
+++ b/apps/mobile/src/lib/preview-onboarding-state.test.ts
@@ -1,0 +1,69 @@
+import * as SecureStore from './secure-storage';
+import {
+  getPreviewState,
+  setPreviewState,
+  clearPreviewState,
+  PREVIEW_INTENT_KEY,
+  PREVIEW_TTL_MS,
+  type PreviewOnboardingStateV0,
+} from './preview-onboarding-state';
+
+describe('preview-onboarding-state', () => {
+  beforeEach(async () => {
+    await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(
+      () => undefined,
+    );
+    clearPreviewState();
+  });
+
+  const baseState: PreviewOnboardingStateV0 = {
+    intent: 'self',
+    path: 'learner_value_prop',
+    topicText: 'algebra basics',
+    createdAt: new Date().toISOString(),
+  };
+
+  it('returns null when no state set', async () => {
+    expect(await getPreviewState()).toBeNull();
+  });
+
+  it('writes in-memory and to SecureStore', async () => {
+    await setPreviewState(baseState);
+    expect(await getPreviewState()).toEqual(baseState);
+    const raw = await SecureStore.getItemAsync(PREVIEW_INTENT_KEY);
+    expect(raw).not.toBeNull();
+  });
+
+  it('hydrates from SecureStore when memory empty (cold-start)', async () => {
+    await setPreviewState(baseState);
+    clearPreviewState(); // simulate process restart: memory wiped, key intact
+
+    // Re-write the key directly to simulate the cold-start path
+    await SecureStore.setItemAsync(
+      PREVIEW_INTENT_KEY,
+      JSON.stringify({ ...baseState, savedAt: Date.now() }),
+    );
+
+    const result = await getPreviewState();
+    expect(result?.intent).toBe('self');
+  });
+
+  it('treats expired key as absent', async () => {
+    const stale = {
+      ...baseState,
+      savedAt: Date.now() - (PREVIEW_TTL_MS + 1000),
+    };
+    await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(stale));
+    clearPreviewState();
+
+    expect(await getPreviewState()).toBeNull();
+  });
+
+  it('clearPreviewState wipes memory AND SecureStore', async () => {
+    await setPreviewState(baseState);
+    await clearPreviewState();
+
+    expect(await getPreviewState()).toBeNull();
+    expect(await SecureStore.getItemAsync(PREVIEW_INTENT_KEY)).toBeNull();
+  });
+});

--- a/apps/mobile/src/lib/preview-onboarding-state.ts
+++ b/apps/mobile/src/lib/preview-onboarding-state.ts
@@ -1,8 +1,4 @@
 import * as SecureStore from './secure-storage';
-// [MEDIUM-4] Import the keychain-accessible constant directly from the
-// native module. The wrapper passes options through unchanged
-// (secure-storage.ts:106), so a typed value works without `as never` casts.
-import { WHEN_UNLOCKED_THIS_DEVICE_ONLY } from 'expo-secure-store';
 
 export const PREVIEW_INTENT_KEY = 'mentomate_preview_intent';
 export const PREVIEW_TTL_MS = 60 * 60_000; // 1 hour
@@ -80,7 +76,7 @@ export async function setPreviewState(
     // and device-to-device backups; bounds the topic-text leak surface to
     // the originating device. Spec §Preview State (Minimal).
     await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
-      keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
     });
   } catch {
     // Non-fatal; in-memory state still survives the warm session.
@@ -117,6 +113,6 @@ export async function seedPreviewStateForTesting(
   memoryState = state;
   const record: StoredRecord = { ...state, savedAt: Date.now() - staleMs };
   await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
-    keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
   });
 }

--- a/apps/mobile/src/lib/preview-onboarding-state.ts
+++ b/apps/mobile/src/lib/preview-onboarding-state.ts
@@ -1,0 +1,122 @@
+import * as SecureStore from './secure-storage';
+// [MEDIUM-4] Import the keychain-accessible constant directly from the
+// native module. The wrapper passes options through unchanged
+// (secure-storage.ts:106), so a typed value works without `as never` casts.
+import { WHEN_UNLOCKED_THIS_DEVICE_ONLY } from 'expo-secure-store';
+
+export const PREVIEW_INTENT_KEY = 'mentomate_preview_intent';
+export const PREVIEW_TTL_MS = 60 * 60_000; // 1 hour
+
+export type PreviewIntent = 'self' | 'child' | 'both' | 'not_sure';
+export type PreviewPath = 'learner_value_prop' | 'parent_value_prop';
+export type SaveTarget = 'self' | 'child' | 'both';
+
+export interface PreviewOnboardingStateV0 {
+  intent: PreviewIntent;
+  path: PreviewPath;
+  topicText?: string;
+  bothPriority?: 'child_first' | 'self_first';
+  preferredSaveTarget?: SaveTarget;
+  createdAt: string;
+  // [HIGH-4] Set inside the save wizard after the owner POST succeeds, so a
+  // wizard remount mid-flight (refresh, OOM-kill, app background) can resume
+  // without double-creating profiles. Cleared by clearPreviewState() on
+  // wizard completion or sign-out.
+  createdOwnerProfileId?: string;
+}
+
+interface StoredRecord extends PreviewOnboardingStateV0 {
+  savedAt: number;
+}
+
+let memoryState: PreviewOnboardingStateV0 | null = null;
+
+function isFresh(savedAt: number): boolean {
+  return Date.now() - savedAt < PREVIEW_TTL_MS;
+}
+
+export async function getPreviewState(): Promise<PreviewOnboardingStateV0 | null> {
+  if (memoryState) return memoryState;
+
+  try {
+    const raw = await SecureStore.getItemAsync(PREVIEW_INTENT_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<StoredRecord>;
+    if (
+      typeof parsed.savedAt !== 'number' ||
+      typeof parsed.intent !== 'string' ||
+      typeof parsed.path !== 'string' ||
+      typeof parsed.createdAt !== 'string'
+    ) {
+      await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(
+        () => undefined,
+      );
+      return null;
+    }
+
+    if (!isFresh(parsed.savedAt)) {
+      await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(
+        () => undefined,
+      );
+      return null;
+    }
+
+    const { savedAt: _ignored, ...state } = parsed as StoredRecord;
+    memoryState = state as PreviewOnboardingStateV0;
+    return memoryState;
+  } catch {
+    return null;
+  }
+}
+
+export async function setPreviewState(
+  state: PreviewOnboardingStateV0,
+): Promise<void> {
+  memoryState = state;
+  const record: StoredRecord = { ...state, savedAt: Date.now() };
+  try {
+    // [SEC] WHEN_UNLOCKED_THIS_DEVICE_ONLY excludes from iCloud Keychain sync
+    // and device-to-device backups; bounds the topic-text leak surface to
+    // the originating device. Spec §Preview State (Minimal).
+    await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
+      keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+  } catch {
+    // Non-fatal; in-memory state still survives the warm session.
+  }
+}
+
+export async function clearPreviewState(): Promise<void> {
+  memoryState = null;
+  try {
+    await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY);
+  } catch {
+    // Non-fatal.
+  }
+}
+
+/**
+ * [LOW-1] Dev/E2E only. Writes a preview-state record whose `savedAt` is
+ * artificially backdated by `staleMs` milliseconds, so Maestro flows can
+ * simulate a TTL-expired record without waiting an hour.
+ *
+ * Mirrors `seedPendingAuthRedirectForTesting` (pending-auth-redirect.ts:115).
+ * Throws in production builds or when EXPO_PUBLIC_E2E !== 'true'.
+ */
+export async function seedPreviewStateForTesting(
+  state: PreviewOnboardingStateV0,
+  staleMs: number,
+): Promise<void> {
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.EXPO_PUBLIC_E2E !== 'true'
+  ) {
+    throw new Error('seedPreviewStateForTesting is dev-only');
+  }
+  memoryState = state;
+  const record: StoredRecord = { ...state, savedAt: Date.now() - staleMs };
+  await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
+    keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  });
+}

--- a/apps/mobile/src/lib/profile.test.ts
+++ b/apps/mobile/src/lib/profile.test.ts
@@ -1,0 +1,49 @@
+import { isFamilyCapableProfile } from './profile';
+import type { Profile } from '@eduagent/schemas';
+
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    id: 'p1',
+    displayName: 'Test',
+    birthYear: 1985,
+    isOwner: true,
+    consentStatus: 'CONSENTED',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    linkCreatedAt: null,
+    parentEmail: null,
+    ...overrides,
+  } as Profile;
+}
+
+describe('isFamilyCapableProfile', () => {
+  const owner = makeProfile({ id: 'p1', isOwner: true, birthYear: 1985 });
+  const child = makeProfile({ id: 'p2', isOwner: false, birthYear: 2015 });
+
+  it('returns true when owner has at least one linked non-owner', () => {
+    expect(isFamilyCapableProfile(owner, [owner, child])).toBe(true);
+  });
+
+  it('returns false when owner has no linked non-owner', () => {
+    expect(isFamilyCapableProfile(owner, [owner])).toBe(false);
+  });
+
+  it('returns false for non-owner active profile', () => {
+    expect(isFamilyCapableProfile(child, [owner, child])).toBe(false);
+  });
+
+  it('returns false when activeProfile is null', () => {
+    expect(isFamilyCapableProfile(null, [owner, child])).toBe(false);
+  });
+
+  // [CRITICAL-4] Explicit anti-test: this predicate must NOT consider age.
+  // Age-based gating ("add child" button visibility) lives at its own
+  // call sites, never inside the family-capable check.
+  it('returns true for a minor owner with a linked non-owner (age is NOT part of this predicate)', () => {
+    const minorOwner = makeProfile({
+      id: 'p1',
+      isOwner: true,
+      birthYear: 2015,
+    });
+    expect(isFamilyCapableProfile(minorOwner, [minorOwner, child])).toBe(true);
+  });
+});

--- a/apps/mobile/src/lib/profile.ts
+++ b/apps/mobile/src/lib/profile.ts
@@ -35,6 +35,29 @@ export function isGuardianProfile(
   return allProfiles.some((p) => !p.isOwner);
 }
 
+/**
+ * Family-capable profile predicate. Shared verbatim with Study/Family v0 spec.
+ * True iff active profile is an owner with at least one linked non-owner.
+ *
+ * [CRITICAL-4] Deliberately NO age check — CLAUDE.md forbids using
+ * computeAgeBracket() for feature gating. Adult-only affordances (e.g.
+ * "Add child") keep their own age checks at their own call sites.
+ *
+ * Shape is identical to isGuardianProfile() above; the alternate name
+ * exists so sibling-spec readers find the term they expect.
+ *
+ * Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md §Implementation step 1
+ * Sibling: docs/specs/2026-05-19-study-and-family-mode-navigation-v0.md §Implementation step 1
+ */
+export function isFamilyCapableProfile(
+  activeProfile: Profile | null | undefined,
+  profiles: ReadonlyArray<Profile>,
+): boolean {
+  if (!activeProfile) return false;
+  if (!activeProfile.isOwner) return false;
+  return profiles.some((p) => p.id !== activeProfile.id && !p.isOwner);
+}
+
 export interface SwitchProfileResult {
   success: boolean;
   error?: string;

--- a/apps/mobile/src/lib/secure-storage.ts
+++ b/apps/mobile/src/lib/secure-storage.ts
@@ -27,6 +27,9 @@ type GetOptions = Parameters<typeof ExpoSecureStore.getItemAsync>[1];
 type SetOptions = Parameters<typeof ExpoSecureStore.setItemAsync>[2];
 type DeleteOptions = Parameters<typeof ExpoSecureStore.deleteItemAsync>[1];
 
+export const WHEN_UNLOCKED_THIS_DEVICE_ONLY =
+  ExpoSecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY;
+
 const memoryStorage = new Map<string, string>();
 
 // One-shot warning so the web fallback is visible in dev consoles but never

--- a/apps/mobile/src/lib/sign-out-cleanup.test.ts
+++ b/apps/mobile/src/lib/sign-out-cleanup.test.ts
@@ -26,6 +26,12 @@ describe('clearProfileSecureStorageOnSignOut [BUG-723 / SEC-7]', () => {
     jest.restoreAllMocks();
   });
 
+  it('clears mentomate_preview_intent on sign-out', async () => {
+    await clearProfileSecureStorageOnSignOut([]);
+    const calledWith = mockDelete.mock.calls.map((c) => c[0] as string);
+    expect(calledWith).toContain('mentomate_preview_intent');
+  });
+
   it('clears global keys even when no profileIds are passed', async () => {
     await clearProfileSecureStorageOnSignOut([]);
     const calledWith = mockDelete.mock.calls.map((c) => c[0] as string);

--- a/apps/mobile/src/lib/sign-out-cleanup.ts
+++ b/apps/mobile/src/lib/sign-out-cleanup.ts
@@ -85,6 +85,11 @@ export const GLOBAL_KEYS: ReadonlyArray<string> = [
   // [CR-SECURESTORE-REGISTRY-11] Previously-unregistered. BYOK waitlist is
   // account-scoped (see BUG-399 comment in subscription.tsx) — clears on sign-out.
   'byok-waitlist-joined',
+  // preview-onboarding-state.ts — pre-signup intent + topic (1h TTL).
+  // Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
+  // Unconditional: cleanup is harmless when key absent; prevents cross-account
+  // leak if feature flag is off but the key was written in a prior session.
+  'mentomate_preview_intent',
 ];
 
 // [CR-SECURESTORE-REGISTRY-11] Documented exceptions — specific callsites that

--- a/apps/mobile/src/lib/sign-out-cleanup.ts
+++ b/apps/mobile/src/lib/sign-out-cleanup.ts
@@ -111,19 +111,19 @@ export const REGISTRY_EXCEPTIONS: ReadonlyArray<{
 }> = [
   {
     file: 'apps/mobile/src/lib/secure-storage.ts',
-    line: 94,
+    line: 97,
     reason:
       'Wrapper module — this is the setItemAsync function definition, not a callsite. The scanner matches the function signature; the key parameter is caller-supplied.',
   },
   {
     file: 'apps/mobile/src/lib/secure-storage.ts',
-    line: 106,
+    line: 109,
     reason:
       'Wrapper module — delegates to ExpoSecureStore.setItemAsync (with options). Not a callsite that writes app data; caller-supplied key.',
   },
   {
     file: 'apps/mobile/src/lib/secure-storage.ts',
-    line: 108,
+    line: 111,
     reason:
       'Wrapper module — delegates to ExpoSecureStore.setItemAsync (without options). Not a callsite that writes app data; caller-supplied key.',
   },

--- a/apps/mobile/src/lib/surface-ownership.test.ts
+++ b/apps/mobile/src/lib/surface-ownership.test.ts
@@ -57,6 +57,22 @@ const KNOWN_BARRELS = [
 // ---------------------------------------------------------------------------
 
 const barrelMap = buildBarrelMap(REPO_ROOT, KNOWN_BARRELS);
+const TEMP_ROOT = path.join(REPO_ROOT, '.tmp/surface-ownership-tests');
+
+function cleanupTempPath(tempPath: string): void {
+  try {
+    fs.rmSync(tempPath, {
+      force: true,
+      maxRetries: 3,
+      recursive: true,
+      retryDelay: 100,
+    });
+  } catch {
+    /* best-effort cleanup for Windows file-lock races */
+  }
+}
+
+cleanupTempPath(TEMP_ROOT);
 
 // ---------------------------------------------------------------------------
 // Guard tests — one describe per surface rule
@@ -225,9 +241,10 @@ describe('Surface ownership self-check: guard is not always-green', () => {
     // Create a synthetic TS source string and verify collectImports reads it.
     // We write a temp file so collectImports (which reads from disk) can parse it.
     const tmpPath = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_surface-ownership-selfcheck.tmp.ts',
     );
+    fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
     const tmpSource = `
 import { useProgressInventory, useOverallProgress } from '../../hooks/use-progress';
 import type { SomeType } from '@eduagent/schemas';
@@ -265,7 +282,7 @@ export function Foo() { return null; }
       expect(namespaceImport).toBeDefined();
       expect(namespaceImport!.namespace).toBe('AllFromLib');
     } finally {
-      fs.unlinkSync(tmpPath);
+      cleanupTempPath(tmpPath);
     }
   });
 });
@@ -310,14 +327,14 @@ describe('Surface ownership: namespace-import bypass (Bug A)', () => {
   afterAll(() => {
     for (const f of tmpFiles) {
       try {
-        fs.unlinkSync(f);
+        cleanupTempPath(f);
       } catch {
         /* ignore */
       }
     }
     for (const d of tmpDirs) {
       try {
-        fs.rmdirSync(d);
+        cleanupTempPath(d);
       } catch {
         /* ignore */
       }
@@ -327,7 +344,7 @@ describe('Surface ownership: namespace-import bypass (Bug A)', () => {
   it('flags `import * as P; P.useProgressInventory` on a session surface', () => {
     // Write a synthetic file under the session surface and verify checkFile flags it.
     const tmpDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_namespace_bypass_test',
     );
     fs.mkdirSync(tmpDir, { recursive: true });
@@ -357,7 +374,7 @@ export function Foo() {
 
   it('does NOT flag namespace imports that never access a forbidden member', () => {
     const tmpDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_namespace_clean_test',
     );
     fs.mkdirSync(tmpDir, { recursive: true });
@@ -383,9 +400,10 @@ export function Foo() {
 
   it('collectImports captures namespace member accesses', () => {
     const tmpPath = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_surface-ownership-ns-accesses.tmp.ts',
     );
+    fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
     tmpFiles.push(tmpPath);
 
     const tmpSource = `
@@ -407,7 +425,7 @@ export const b = Lib.someOtherSymbol();
   // is functionally identical to `Hooks.useProgressInventory` and must be flagged.
   it('flags `const { forbiddenName } = NamespaceImport` on a session surface', () => {
     const tmpDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_namespace_destructure_test',
     );
     fs.mkdirSync(tmpDir, { recursive: true });
@@ -439,9 +457,10 @@ export function Foo() {
 
   it('collectImports captures namespace accesses from destructuring', () => {
     const tmpPath = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_surface-ownership-ns-destructure.tmp.ts',
     );
+    fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
     tmpFiles.push(tmpPath);
 
     const tmpSource = `
@@ -459,7 +478,7 @@ const { useProgressInventory, someOtherSymbol } = Lib;
 
   it('flags destructuring with rename (`const { forbiddenName: alias } = Ns`)', () => {
     const tmpDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_namespace_destructure_rename_test',
     );
     fs.mkdirSync(tmpDir, { recursive: true });
@@ -491,7 +510,7 @@ export function Foo() {
 
   it('does NOT flag destructuring of non-forbidden members from namespace import', () => {
     const tmpDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_namespace_destructure_clean_test',
     );
     fs.mkdirSync(tmpDir, { recursive: true });
@@ -527,14 +546,14 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
   afterAll(() => {
     for (const f of tmpFiles) {
       try {
-        fs.unlinkSync(f);
+        cleanupTempPath(f);
       } catch {
         /* ignore */
       }
     }
     for (const d of tmpDirs) {
       try {
-        fs.rmdirSync(d);
+        cleanupTempPath(d);
       } catch {
         /* ignore */
       }
@@ -546,11 +565,11 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
     // A consumer that imports the benign name from the barrel must still be flagged
     // because the underlying symbol is on the forbid list.
     const fakeOriginDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_barrel_test_origin',
     );
     const fakeBarrelDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_barrel_test_barrel',
     );
     fs.mkdirSync(fakeOriginDir, { recursive: true });
@@ -560,7 +579,7 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
     const originPath = path.join(fakeOriginDir, 'use-progress.ts');
     const barrelPath = path.join(fakeBarrelDir, 'index.ts');
     const consumerDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_barrel_consumer_test',
     );
     fs.mkdirSync(consumerDir, { recursive: true });
@@ -588,7 +607,7 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
     // Build a barrel map that includes our synthetic barrel.
     const augmentedMap = buildBarrelMap(REPO_ROOT, [
       ...KNOWN_BARRELS,
-      'apps/mobile/src/lib/_barrel_test_barrel/index.ts',
+      path.relative(REPO_ROOT, barrelPath).replace(/\\/g, '/'),
     ]);
 
     const sessionRule = SURFACE_RULES.find(
@@ -609,11 +628,11 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
 
   it('barrel-resolved happy path: clean re-export with no forbidden underlying symbol is not flagged', () => {
     const fakeOriginDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_barrel_test_origin_clean',
     );
     const fakeBarrelDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/lib/_barrel_test_barrel_clean',
     );
     fs.mkdirSync(fakeOriginDir, { recursive: true });
@@ -623,7 +642,7 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
     const originPath = path.join(fakeOriginDir, 'helpers.ts');
     const barrelPath = path.join(fakeBarrelDir, 'index.ts');
     const consumerDir = path.join(
-      REPO_ROOT,
+      TEMP_ROOT,
       'apps/mobile/src/app/(app)/session/_barrel_consumer_clean_test',
     );
     fs.mkdirSync(consumerDir, { recursive: true });
@@ -649,7 +668,7 @@ describe('Surface ownership: barrel resolution wiring (Bug B)', () => {
 
     const augmentedMap = buildBarrelMap(REPO_ROOT, [
       ...KNOWN_BARRELS,
-      'apps/mobile/src/lib/_barrel_test_barrel_clean/index.ts',
+      path.relative(REPO_ROOT, barrelPath).replace(/\\/g, '/'),
     ]);
     const sessionRule = SURFACE_RULES.find(
       (r: SurfaceRule) => r.label === 'Session screens',

--- a/apps/mobile/src/test-setup.ts
+++ b/apps/mobile/src/test-setup.ts
@@ -267,11 +267,32 @@ jest.mock('expo-notifications', () => ({
   AndroidImportance: { DEFAULT: 3 },
 }));
 
-jest.mock('expo-secure-store', () => ({
-  getItemAsync: jest.fn().mockResolvedValue(null),
-  setItemAsync: jest.fn().mockResolvedValue(undefined),
-  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
-}));
+jest.mock('expo-secure-store', () => {
+  const store = new Map<string, string>();
+  const mock = {
+    // Matches the real expo-secure-store keychain-accessible constant used by
+    // production code (e.g. preview-onboarding-state.ts). Value matches the
+    // native SDK string so any test that reads the constant gets a truthy string.
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
+    getItemAsync: jest.fn(async (key: string) => store.get(key) ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    deleteItemAsync: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+    __store: store,
+  };
+  return mock;
+});
+
+// Reset the SecureStore Map between tests to prevent cross-test pollution.
+beforeEach(() => {
+  const secureStoreMock = jest.requireMock('expo-secure-store') as {
+    __store: Map<string, string>;
+  };
+  secureStoreMock.__store.clear();
+});
 
 // expo-crypto loads a native module on import; mock to Node's randomUUID so
 // the outbox dedup-id path works under jest. The runtime app uses

--- a/docs/plans/2026-05-19-study-and-family-mode-navigation-FULL.md
+++ b/docs/plans/2026-05-19-study-and-family-mode-navigation-FULL.md
@@ -1,0 +1,3266 @@
+# Study and Family Mode Navigation — Implementation Plan
+
+> **Amendments from adversarial review (2026-05-19):**
+> - **CRITICAL-1**: Task 16 rewritten — `goBackOrReplace` and `homeHrefForReturnTo` already exist at `apps/mobile/src/lib/navigation.ts:16,26`. Extend, do not create parallel implementations.
+> - **CRITICAL-2**: Task 1 keeps `Set<string>` for tab-visibility (existing shape at `_layout.tsx:114-126`); plan-wide replace of `.includes(...)` with `.has(...)`.
+> - **CRITICAL-3**: Task 0 is verification-only — canonical class is `QuotaExceededError` from `@eduagent/schemas`, re-exported through `apps/mobile/src/lib/api-errors.ts`. Do NOT invent `QuotaExhaustedError`.
+> - **HIGH-1**: Task 6 + Task 8 — intent='family' with no children routes through a Family-setup-empty screen; no silent fall-through to Study.
+> - **HIGH-2**: Task 14 owns its own `router.replace` because `useModeSwitch` only navigates when leaving a `FAMILY_ONLY_ROUTES` pathname.
+> - **HIGH-3**: Forward-compat coercion dropped — `profileSchema.defaultAppContext: appContextSchema.nullable()` (not `.optional()`), `mapProfileRow` casts directly (no `?? null`). Deploy-order is the only defence.
+> - **MEDIUM-1**: Single unified return-token set lives in `navigation.ts` (extended, not forked).
+> - **MEDIUM-2**: Recaps cursor `decodeCursor` validates the decoded payload with zod and logs a warn on malformed input.
+> - **MEDIUM-3**: Migration backfill removed — no production users yet; users see Study tabs once after update and switch via More.
+> - **MEDIUM-4**: `mapProfileRow` refactored to options-object so `hasFamilyLinks` is REQUIRED (not silently `false`).
+> - **MEDIUM-5**: Engagement-signal seed test must first check whether the column is typed/CHECKed — drop or rewrite as unit test if so.
+> - **MEDIUM-6**: Family-setup-empty Playwright case now backed by Task 8 Step 0 (`family-setup-empty` testID).
+> - **MEDIUM-7**: Schema-source grep tightened to `sessionSummaries.<column>\b` to avoid false-matching the table name.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **All commits go through `/commit`.** Never `git commit` directly in this repo. See `CLAUDE.md` → "Git Commits".
+>
+> **Subagents do NOT commit.** Only the coordinator runs `/commit` after a task's verification passes. See `feedback_agents_commit_push`.
+
+**Spec:** `docs/specs/2026-05-19-study-and-family-mode-navigation.md`
+
+**Goal:** Replace the current identity-driven guardian/learner tab shell with context-driven Study/Family modes, add a parent-native Recaps surface, persist per-profile default mode, and remove proxy mode from normal parent UX.
+
+**Architecture:** Mode is per-profile state stored in `profiles.default_app_context`, exposed via existing `GET /profiles` and mutated via `PATCH /profiles/:id`. The mobile tab shell resolves visible tabs from the active context (`'study' | 'family'`) rather than from `isGuardianProfile`. Recaps is a new parent-native API and mobile route that reads existing `session_summaries` recap columns without adding new storage. Family capability is gated server-side by `family_links` and exposed as `hasFamilyLinks: boolean` on profile responses.
+
+**Tech Stack:** Drizzle migration + PostgreSQL CHECK constraint; Hono routes; `@eduagent/schemas` zod; React Native + Expo Router; TanStack Query; Jest (mobile + API integration); Playwright (web smoke).
+
+**Deploy order (mandatory):** migration → API → mobile. Reading `defaultAppContext` on mobile before the API exposes it = schema drift. See `project_schema_drift_pattern`. Per adversarial review §HIGH-3 (round 2), the deploy-order rule is the only defence — no in-code "forward-compat" coercion. `profileSchema.defaultAppContext` is `appContextSchema.nullable()` (always present, may be null). The mapper writes the column value directly without `?? null` fallback. CLAUDE.md "Don't add error handling, fallbacks, or validation for scenarios that can't happen" applies.
+
+**Merge boundaries (phased shipping):**
+- **Phase 1 — Foundation** (Tasks 1-5): tab shape rename, migration + capability + intent screen. Independently mergeable and rollback-safe.
+- **Phase 2 — Recaps and bridges** (Tasks 6-15): mode switch, Children tab, Recaps, Learn this too, proxy removal, notifications.
+- **Phase 3 — Hardening** (Tasks 16-20): navigation helpers, analytics, leak guards, web E2E, branch-wide validation.
+
+Phase 1 is the cut line for "ship something useful and reviewable in isolation." Phase 2/3 may merge together if review cycle permits.
+
+---
+
+## Pre-flight
+
+- [ ] **Confirm branch state**
+
+```bash
+git branch --show-current
+git status
+```
+
+If not on a feature branch, create one from the current working branch (do not switch trees mid-flight; WIP carries forward per `feedback_branch_carries_wip`):
+
+```bash
+git checkout -b study-family-mode-navigation
+```
+
+- [ ] **Identify next migration number**
+
+Run:
+
+```bash
+ls apps/api/drizzle | grep -E '^[0-9]{4}_' | sort | tail -3
+```
+
+Highest at spec time was `0078_webhook_idempotency_keys.sql`. Use the next available number when creating the migration in Task 2 (likely `0079`, but verify at execution time).
+
+Throughout this plan we refer to it as `00NN`. Substitute the real number consistently across the `.sql` file, the `.rollback.md` file, and any references.
+
+---
+
+## Task 0: API-client typed error classification (verification only)
+
+Several downstream tasks (`Task 6`, `Task 7`, `Task 13`) catch `err instanceof ForbiddenError` / `err instanceof QuotaExceededError` on the mobile side. Per CLAUDE.md "UX Resilience Rules" → "Classify errors at the API client boundary, not per-screen." The hierarchy already exists — this task only verifies that and pins the canonical names for downstream tasks.
+
+**Files:**
+- Verify: `apps/mobile/src/lib/api-errors.ts`
+
+- [ ] **Step 1: Confirm canonical classes are exported**
+
+Open `apps/mobile/src/lib/api-errors.ts`. Confirm it re-exports `ForbiddenError` and `QuotaExceededError` from `@eduagent/schemas` (verified present at lines 18-25, 27-38 of that file). These are the canonical names — `QuotaExceededError` is the 403 quota class; do NOT invent `QuotaExhaustedError` or any other parallel name. Per the comment at api-errors.ts:8-12 (BUG-644 / P-4), the shared classes are sourced from `@eduagent/schemas` so cross-package `instanceof` checks work.
+
+- [ ] **Step 2: Pin downstream import paths**
+
+All downstream tasks that catch quota errors import from `apps/mobile/src/lib/api-errors.ts`:
+
+```ts
+import { ForbiddenError, QuotaExceededError } from '../lib/api-errors';
+```
+
+Never import `QuotaExceededError` directly from `@eduagent/schemas` in mobile code — go through the re-export so the existing `Object.setPrototypeOf` plumbing in `api-errors.ts` stays in scope.
+
+No code changes in this task. No commit.
+
+---
+
+## Task 1: Terminology + tab shape rename (foundation)
+
+Rename `TabShape = 'guardian' | 'learner'` to a context-driven shape. This is a mechanical rename touching `_layout.tsx` and its callers, but it unlocks every downstream task by removing the identity/visibility semantic collision flagged in spec §HIGH-1.
+
+**Pre-existing shape (verified at `apps/mobile/src/app/(app)/_layout.tsx:70-126`):** `GUARDIAN_TABS` / `LEARNER_TABS` / `PARENT_PROXY_TABS` are `ReadonlySet<string>` literals; `computeVisibleTabs(shape, isParentProxy)` already exists and returns `Set<string>`. Keep `Set<string>` throughout — do NOT introduce arrays — and use `.has(...)` for membership tests. Adversarial review §CRITICAL-2.
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx:91-106` (TabShape type, resolveTabShape)
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx:60-75` (visible-tab arrays)
+- Test: `apps/mobile/src/app/(app)/_layout.test.tsx` (co-located, create or extend)
+
+- [ ] **Step 1: Write failing test for new shape values**
+
+Create or extend `apps/mobile/src/app/(app)/_layout.test.tsx`:
+
+```tsx
+import { computeVisibleTabs, type AppTabContextShape } from './_layout';
+
+describe('computeVisibleTabs', () => {
+  it('returns exactly home, library, progress, more for study', () => {
+    expect([...computeVisibleTabs('study')].sort()).toEqual(
+      ['home', 'library', 'more', 'progress'],
+    );
+  });
+
+  it('returns exactly home, recaps, progress, more for family', () => {
+    expect([...computeVisibleTabs('family')].sort()).toEqual(
+      ['home', 'more', 'progress', 'recaps'],
+    );
+  });
+
+  it('returns the study set for unknown context (defensive default)', () => {
+    expect([...computeVisibleTabs(undefined as unknown as AppTabContextShape)].sort()).toEqual(
+      ['home', 'library', 'more', 'progress'],
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.test.tsx --no-coverage
+```
+
+Expected: FAIL (`computeVisibleTabs is not exported` / `AppTabContextShape is not exported`).
+
+- [ ] **Step 3: Rename `TabShape` to `AppTabContextShape` with values `'study' | 'family'`**
+
+In `apps/mobile/src/app/(app)/_layout.tsx` near line 91, replace:
+
+```ts
+export type TabShape = 'guardian' | 'learner';
+```
+
+with:
+
+```ts
+export type AppTabContextShape = 'study' | 'family';
+```
+
+- [ ] **Step 4: Replace visible-tab sets**
+
+Near line 70-83, replace `GUARDIAN_TABS` and `LEARNER_TABS` with `Set` literals (preserving the existing `ReadonlySet<string>` type so consumers using `.has(...)` keep compiling):
+
+```ts
+const STUDY_TABS: ReadonlySet<string> = new Set([
+  'home',
+  'library',
+  'progress',
+  'more',
+]);
+
+const FAMILY_TABS: ReadonlySet<string> = new Set([
+  'home',
+  'recaps',
+  'progress',
+  'more',
+]);
+// PARENT_PROXY_TABS unchanged — proxy override is preserved.
+```
+
+- [ ] **Step 5: Update `computeVisibleTabs()` (already exists)**
+
+The helper already exists at `_layout.tsx:114-126` with signature `(shape: TabShape = 'guardian', isParentProxy = false): Set<string>`. Update its body to the new shape values — do not change the return type or remove the `isParentProxy` overload (it preserves the proxy chrome contract):
+
+```ts
+export function computeVisibleTabs(
+  context: AppTabContextShape = 'study',
+  isParentProxy = false,
+): Set<string> {
+  if (isParentProxy) return new Set(PARENT_PROXY_TABS);
+  return context === 'family' ? new Set(FAMILY_TABS) : new Set(STUDY_TABS);
+}
+```
+
+All call sites continue using `visibleTabs.has(name)` (Set semantics). Anywhere downstream that the plan shows `visibleTabs.includes(...)` should be read as `visibleTabs.has(...)`.
+
+- [ ] **Step 6: Update `resolveTabShape()` signature**
+
+`resolveTabShape()` (line 93-106) currently takes profile state. It now becomes context-driven. Replace its body:
+
+```ts
+export function resolveTabShape({
+  isParentProxy,
+  defaultAppContext,
+  isFamilyCapable,
+}: {
+  isParentProxy: boolean;
+  defaultAppContext: 'study' | 'family' | null;
+  isFamilyCapable: boolean;
+}): AppTabContextShape {
+  if (isParentProxy) return 'study'; // proxy override still uses learner-shape visible tabs
+  if (!isFamilyCapable) return 'study';
+  return defaultAppContext === 'family' ? 'family' : 'study';
+}
+```
+
+Note: `isFamilyCapable` and `defaultAppContext` will be wired up in Tasks 2-4. For now, callers pass placeholders that compile.
+
+- [ ] **Step 7: Update callers in `_layout.tsx`**
+
+The single existing caller of `resolveTabShape` in `_layout.tsx` (around lines 1700-1740 in the Tabs.Screen render) must now read the new fields. Temporarily wire:
+
+```ts
+const tabShape = resolveTabShape({
+  isParentProxy,
+  defaultAppContext: null,        // wired in Task 5
+  isFamilyCapable: false,         // wired in Task 4
+});
+```
+
+Add a `// TODO(study-family): wire defaultAppContext from profile query (Task 5)` comment so the next task knows.
+
+- [ ] **Step 8: Run test to verify pass + run typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.test.tsx --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Expected: PASS, no type errors.
+
+- [ ] **Step 9: Search for any external uses of removed names**
+
+```bash
+```
+
+Use Grep tool with pattern `(GUARDIAN_TABS|LEARNER_TABS|TabShape)\b` in `apps/mobile/src/`. Update any callers (likely only `_layout.tsx` itself, but verify). If a test file references the old names, update it to the new shape.
+
+- [ ] **Step 10: Commit**
+
+Invoke `/commit` with description: `refactor(mobile): rename TabShape to AppTabContextShape with study|family values`
+
+---
+
+## Task 2: Migration + Drizzle schema + shared schema for `defaultAppContext` and `hasFamilyLinks`
+
+This is the deploy-critical task. Migration ships FIRST, then API exposure, then mobile consumption. Until the migration is applied and deployed, the API must not return `defaultAppContext` in `mapProfileRow`.
+
+**Files:**
+- Create: `apps/api/drizzle/00NN_profiles_default_app_context.sql`
+- Create: `apps/api/drizzle/00NN_profiles_default_app_context.rollback.md`
+- Modify: `packages/database/src/schema/profiles.ts:52-103` (profiles table)
+- Modify: `packages/schemas/src/profiles.ts:92-109` (profileSchema)
+- Modify: `apps/api/src/services/profile.ts:50-75` (mapProfileRow)
+- Modify: `apps/api/src/services/profile.ts:84-111` (listProfiles — emit hasFamilyLinks)
+- Test: `apps/api/src/services/profile.test.ts` (co-located)
+
+- [ ] **Step 1: Create the SQL migration**
+
+Replace `00NN` with the next available number from pre-flight.
+
+```sql
+-- 00NN_profiles_default_app_context.sql
+ALTER TABLE profiles
+  ADD COLUMN default_app_context text;
+
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_default_app_context_check
+  CHECK (
+    default_app_context IS NULL
+    OR default_app_context IN ('study', 'family')
+  );
+
+-- No backfill. Per adversarial review §MEDIUM-3: predicating the backfill on
+-- "is_owner AND has non-archived linked child" is looser than the runtime
+-- guardian-shape gate `isGuardianProfile(activeProfile, profiles)`, and would
+-- pre-flip accounts whose family_links arrived via flows that never intended
+-- Family-shape navigation. Per project_pre_launch_no_users.md the store is
+-- not live, so there is no production user base to migrate. New and returning
+-- users see Study tabs once after update, switch via More if they want
+-- Family, and the choice persists from there.
+```
+
+- [ ] **Step 2: Create the rollback markdown**
+
+```md
+# Rollback: 00NN_profiles_default_app_context
+
+## Rollback
+
+Rollback is possible. Drop `profiles_default_app_context_check`, then drop
+`profiles.default_app_context`. This loses the user-set Study/Family
+preference; no learning, session, profile, report, or family link data is
+lost. After rollback, family-capable adults will need to re-pick their
+default mode the next time the column is restored (or remain in the client
+default — Study). No backfill was applied, so there is no derived state to
+recover.
+
+Recovery procedure:
+
+```sql
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_default_app_context_check;
+ALTER TABLE profiles DROP COLUMN IF EXISTS default_app_context;
+```
+
+Mobile clients running the new build will see `defaultAppContext: null` from
+the API after rollback and will default to Study, which is the safe behavior.
+```
+
+- [ ] **Step 3: Add the Drizzle column**
+
+In `packages/database/src/schema/profiles.ts` inside the `profiles = pgTable(...)` block (around line 52-103), add the new column. Place it next to `pronouns: text('pronouns')` for grouping with other user-preference fields:
+
+```ts
+  defaultAppContext: text('default_app_context'), // 'study' | 'family' | null; CHECK constraint in migration 00NN
+```
+
+- [ ] **Step 4: Generate Drizzle types**
+
+```bash
+pnpm run db:generate:dev
+```
+
+This regenerates `$inferSelect` so `mapProfileRow` sees the new field. Do NOT run `db:push:dev` — we are migration-driven now.
+
+- [ ] **Step 5: Apply the migration to dev DB**
+
+```bash
+pnpm run db:migrate:dev
+```
+
+Expected: migration applies cleanly. Verify with `pnpm run db:studio:dev` if needed.
+
+- [ ] **Step 6: Add `appContextSchema` and update `profileSchema`**
+
+In `packages/schemas/src/profiles.ts` near the top (after existing enum schemas):
+
+```ts
+export const APP_CONTEXTS = ['study', 'family'] as const;
+export const appContextSchema = z.enum(APP_CONTEXTS);
+export type AppContext = z.infer<typeof appContextSchema>;
+```
+
+Then update `profileSchema` (around lines 92-109) by adding two fields inside the `z.object({...})`:
+
+```ts
+  // Per adversarial review §HIGH-3: deploy order (migration → API → mobile) is
+  // the only defence. The column is always present in API responses once
+  // shipped; it may be null. No `.optional()`, no in-code fallback. CLAUDE.md
+  // "no validation for scenarios that can't happen" applies.
+  defaultAppContext: appContextSchema.nullable(),
+  hasFamilyLinks: z.boolean(),
+```
+
+- [ ] **Step 7: Verify `packages/schemas/src/index.ts` barrel re-exports**
+
+The barrel uses `export * from './profiles'` (line 8). The new `APP_CONTEXTS`, `appContextSchema`, and `AppContext` are exported automatically. Confirm by:
+
+```bash
+```
+
+Use Grep tool with pattern `export \* from './profiles'` in `packages/schemas/src/index.ts`. If the barrel uses explicit re-exports for some reason, add `AppContext` explicitly.
+
+- [ ] **Step 8: Write failing test for `mapProfileRow` and `listProfiles`**
+
+In `apps/api/src/services/profile.test.ts` (extend or create):
+
+```ts
+import { mapProfileRow, listProfiles } from './profile';
+// existing imports
+
+describe('mapProfileRow', () => {
+  it('exposes defaultAppContext from the row', () => {
+    const row = {
+      id: 'p1', accountId: 'a1', displayName: 'A', avatarUrl: null,
+      birthYear: 1990, birthYearSetBy: null, location: null, isOwner: true,
+      hasPremiumLlm: false, conversationLanguage: 'en', pronouns: null,
+      defaultAppContext: 'family',
+      createdAt: new Date(), updatedAt: new Date(), archivedAt: null,
+    } as unknown as typeof profiles.$inferSelect;
+    const mapped = mapProfileRow(row);
+    expect(mapped.defaultAppContext).toBe('family');
+  });
+
+  it('exposes null defaultAppContext as null (no inference at mapper layer)', () => {
+    const row = { /* ...same with defaultAppContext: null... */ } as never;
+    expect(mapProfileRow(row).defaultAppContext).toBeNull();
+  });
+
+  it('defaults hasFamilyLinks to false when not passed', () => {
+    const row = { /* ...same... */ } as never;
+    expect(mapProfileRow(row).hasFamilyLinks).toBe(false);
+  });
+});
+
+describe('listProfiles', () => {
+  it('sets hasFamilyLinks=true for owners with at least one family_links row', async () => {
+    // integration: seed account with owner + family_links + child, call listProfiles, assert owner.hasFamilyLinks === true and child.hasFamilyLinks === false
+  });
+
+  it('sets hasFamilyLinks=false for owners with no family_links', async () => {
+    // integration: seed account with owner only, assert owner.hasFamilyLinks === false
+  });
+});
+```
+
+The integration cases should live in a `.integration.test.ts` if `listProfiles` requires a DB. Follow the existing pattern in the file.
+
+- [ ] **Step 9: Run the failing tests**
+
+```bash
+cd apps/api && pnpm exec jest --findRelatedTests src/services/profile.ts --no-coverage
+```
+
+Expected: FAIL.
+
+- [ ] **Step 10: Export `mapProfileRow`, expose `defaultAppContext`, refactor to options-object**
+
+In `apps/api/src/services/profile.ts:50` the current declaration is `function mapProfileRow(row, consentStatus?, linkCreatedAt?)` — **not exported**. The Step 8 tests import it directly, so:
+
+1. Add the `export` keyword.
+2. Per adversarial review §MEDIUM-4, refactor to a single options-object so adding `hasFamilyLinks` cannot silently default to `false` for callers that should have computed it. Positional defaults would let `findOwnerProfile` (line 137) return `hasFamilyLinks: false` for a guardian, polluting any consumer of that helper.
+3. Update every existing caller (`profile.ts:103, 137, 155, 243, 339, 363` per plan-time grep — re-verify before editing) to the new options shape. Callers that legitimately don't know `hasFamilyLinks` (e.g. `findOwnerProfile`) compute it explicitly via a small `countActiveChildLinks(db, profileId)` helper.
+
+```ts
+export function mapProfileRow(
+  row: typeof profiles.$inferSelect,
+  opts: {
+    consentStatus?: Profile['consentStatus'];
+    linkCreatedAt?: Date | null;
+    hasFamilyLinks: boolean; // REQUIRED — no default
+  },
+): Profile {
+  return {
+    // ...existing fields...
+    // Per §HIGH-3: deploy-order is enforced; the column is always present.
+    // Direct cast, no `?? null` fallback.
+    defaultAppContext: row.defaultAppContext as AppContext | null,
+    hasFamilyLinks: opts.hasFamilyLinks,
+    consentStatus: opts.consentStatus ?? null,
+    linkCreatedAt: opts.linkCreatedAt?.toISOString() ?? null,
+    // ...
+  };
+}
+
+async function countActiveChildLinks(db: Database, parentProfileId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(familyLinks)
+    .innerJoin(profiles, eq(familyLinks.childProfileId, profiles.id))
+    .where(and(
+      eq(familyLinks.parentProfileId, parentProfileId),
+      isNull(profiles.archivedAt),
+    ));
+  return row?.count ?? 0;
+}
+```
+
+`findOwnerProfile` (line 122-156) computes its own `hasFamilyLinks`:
+
+```ts
+const hasFamilyLinks = ownerRow.isOwner && (await countActiveChildLinks(db, ownerRow.id)) > 0;
+return mapProfileRow(ownerRow, { consentStatus, hasFamilyLinks });
+```
+
+The options-object signature is strictly required: TypeScript will fail the build if any updated caller forgets `hasFamilyLinks`. That's the point — forced acknowledgement at every call site.
+
+- [ ] **Step 11: Update `listProfiles` to derive `hasFamilyLinks`**
+
+In `apps/api/src/services/profile.ts` (lines 84-111), the existing `listProfiles` already queries `family_links` for `linkCreatedAt`. Reuse that query result:
+
+```ts
+const familyLinksRows = await db.select(...).from(familyLinks).where(...);
+const familyLinksByParent = new Map<string, FamilyLinkRow[]>();
+for (const link of familyLinksRows) {
+  const arr = familyLinksByParent.get(link.parentProfileId) ?? [];
+  arr.push(link);
+  familyLinksByParent.set(link.parentProfileId, arr);
+}
+
+return rows.map((row) => {
+  const links = familyLinksByParent.get(row.id) ?? [];
+  return mapProfileRow(row, {
+    consentStatus: consentByProfile.get(row.id),
+    linkCreatedAt: linkCreatedAtByChildId.get(row.id) ?? null,
+    hasFamilyLinks: row.isOwner && links.length > 0,
+  });
+});
+```
+
+Adjust to fit the existing variable names and join shape; the principle is: `hasFamilyLinks = isOwner && exists(family_links where parent_profile_id = row.id AND child.archived_at IS NULL)`. The `family_links` query must join `profiles` on the child side and filter `profiles.archived_at IS NULL` so an owner with only archived children does NOT get `hasFamilyLinks: true`.
+
+- [ ] **Step 12: Re-run tests**
+
+```bash
+cd apps/api && pnpm exec jest --findRelatedTests src/services/profile.ts --no-coverage
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Run integration tests + typecheck**
+
+```bash
+cd apps/api && pnpm exec jest src/services/profile.integration.test.ts --no-coverage
+cd apps/api && pnpm exec tsc --noEmit
+pnpm exec nx run api:typecheck
+pnpm exec nx run @eduagent/schemas:typecheck
+```
+
+- [ ] **Step 14: Commit**
+
+`/commit` description: `feat(api): add profiles.default_app_context column + hasFamilyLinks on profile responses`
+
+The commit must include the migration `.sql`, the rollback `.md`, the Drizzle schema change, the shared schema change, and the service changes together. Per CLAUDE.md "Schema and Deploy Safety": migration ships first, but in git we ship one PR; the deploy order is enforced by the deploy script applying migration before code.
+
+---
+
+## Task 3: PATCH /profiles/:id app-context route + service
+
+The mode mutation. Extends the existing `PATCH /profiles/:id` route. Server validates capability before accepting `'family'`, scopes to the active profile, and is idempotent.
+
+**Files:**
+- Modify: `apps/api/src/routes/profiles.ts:77-93` (PATCH /profiles/:id)
+- Modify: `apps/api/src/services/profile.ts:347-364` (updateProfile)
+- Modify: `packages/schemas/src/profiles.ts:60-63` (profileUpdateSchema)
+- Test: `apps/api/src/routes/profiles.test.ts` (co-located)
+- Test: `apps/api/src/services/profile.test.ts`
+
+- [ ] **Step 1: Extend `profileUpdateSchema`**
+
+In `packages/schemas/src/profiles.ts` around line 60:
+
+```ts
+export const profileUpdateSchema = z.object({
+  displayName: z.string().min(1).max(80).optional(),
+  avatarUrl: z.string().url().nullable().optional(),
+  pronouns: pronounsSchema.nullable().optional(),
+  conversationLanguage: conversationLanguageSchema.optional(),
+  defaultAppContext: appContextSchema.optional(), // 'study' | 'family' only — no null write
+});
+```
+
+Note: clients cannot write `null` — only the migration default is null. Switching from family to study writes `'study'`, not `null`.
+
+- [ ] **Step 2: Write failing tests for the route**
+
+In `apps/api/src/routes/profiles.test.ts`:
+
+```ts
+describe('PATCH /profiles/:id (defaultAppContext)', () => {
+  it('accepts study for any active profile', async () => {
+    // arrange: signed-in account with owner profile, X-Profile-Id = owner.id
+    const res = await client.profiles[':id'].$patch({
+      param: { id: ownerProfileId },
+      json: { defaultAppContext: 'study' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profile.defaultAppContext).toBe('study');
+  });
+
+  it('accepts family when the active profile is family-capable (owner + adult + has linked child)', async () => {
+    // arrange: owner profile (adult), one non-owner child profile, family_links row
+    const res = await client.profiles[':id'].$patch({
+      param: { id: ownerProfileId },
+      json: { defaultAppContext: 'family' },
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).profile.defaultAppContext).toBe('family');
+  });
+
+  it('rejects family for a non-owner profile (child)', async () => {
+    // arrange: switch active profile to child via X-Profile-Id
+    const res = await client.profiles[':id'].$patch({
+      param: { id: childProfileId },
+      json: { defaultAppContext: 'family' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects family for an under-18 owner', async () => {
+    // arrange: owner with birthYear making them <18
+    const res = await client.profiles[':id'].$patch({
+      param: { id: minorOwnerProfileId },
+      json: { defaultAppContext: 'family' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects family for an owner with no family_links', async () => {
+    const res = await client.profiles[':id'].$patch({
+      param: { id: childlessOwnerProfileId },
+      json: { defaultAppContext: 'family' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects defaultAppContext writes when route :id does not match X-Profile-Id active scope', async () => {
+    // arrange: active profile is owner, request patches a sibling profile's mode
+    const res = await client.profiles[':id'].$patch({
+      param: { id: siblingProfileId },
+      json: { defaultAppContext: 'study' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('still accepts non-mode field writes on a sibling profile (onboarding flow compat)', async () => {
+    // arrange: active profile is owner, request patches a sibling profile's displayName
+    const res = await client.profiles[':id'].$patch({
+      param: { id: siblingProfileId },
+      json: { displayName: 'New Name' },
+    });
+    expect(res.status).toBe(200); // scope-match guard is mode-write-specific
+  });
+
+  it('is idempotent: writing study twice yields 200 both times', async () => {
+    const r1 = await patch(ownerProfileId, 'study');
+    const r2 = await patch(ownerProfileId, 'study');
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+```
+
+Note: tests must NOT use `jest.mock` for internal modules per GC1/GC6. Use real DB seeded by test setup.
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+cd apps/api && pnpm exec jest --findRelatedTests src/routes/profiles.ts --no-coverage
+```
+
+Expected: FAIL on most.
+
+- [ ] **Step 4: Add capability check in service**
+
+In `apps/api/src/services/profile.ts` add (or extend) a helper:
+
+```ts
+import { computeAgeBracket } from '@eduagent/schemas';
+
+export async function assertFamilyCapability(
+  db: Database,
+  profile: typeof profiles.$inferSelect,
+): Promise<void> {
+  if (!profile.isOwner) {
+    throw new ForbiddenError('family-context-requires-owner');
+  }
+  if (computeAgeBracket(profile.birthYear) !== 'adult') {
+    throw new ForbiddenError('family-context-requires-adult');
+  }
+  const linkCount = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(familyLinks)
+    .innerJoin(profiles, eq(familyLinks.childProfileId, profiles.id))
+    .where(and(
+      eq(familyLinks.parentProfileId, profile.id),
+      isNull(profiles.archivedAt),
+    ));
+  if ((linkCount[0]?.count ?? 0) === 0) {
+    throw new ForbiddenError('family-context-requires-linked-child');
+  }
+}
+```
+
+The exact error class should match the existing typed error hierarchy used in this repo (see `apps/api/src/services/errors.ts` or equivalent). If no `ForbiddenError` exists, throw the existing pattern that produces 403 from the Hono error handler.
+
+- [ ] **Step 5: Extend `updateProfile` in the service**
+
+In `apps/api/src/services/profile.ts` around line 347-364, add capability check when `defaultAppContext === 'family'`:
+
+```ts
+export async function updateProfile(
+  db: Database,
+  profileId: string,
+  accountId: string,
+  patch: ProfileUpdate,
+): Promise<Profile> {
+  const existing = await getRawProfileRow(db, profileId, accountId); // existing helper, or inline
+  if (!existing) throw new NotFoundError('profile-not-found');
+
+  if (patch.defaultAppContext === 'family') {
+    await assertFamilyCapability(db, existing);
+  }
+
+  const [updated] = await db
+    .update(profiles)
+    .set({
+      ...patch,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(profiles.id, profileId), eq(profiles.accountId, accountId)))
+    .returning();
+
+  // Re-derive hasFamilyLinks for the response (cheap; or reuse a single source)
+  const hasFamilyLinks = existing.isOwner && (await countLinks(db, profileId)) > 0;
+  return mapProfileRow(updated, { hasFamilyLinks });
+}
+```
+
+- [ ] **Step 6: Enforce route-vs-active-scope match — ONLY for `defaultAppContext` writes**
+
+The existing PATCH `/profiles/:id` route is also used for `displayName`, `avatarUrl`, `pronouns`, `conversationLanguage`, and (via `use-onboarding-dimensions.ts:74, :114`) for dimension/pronoun mutations during onboarding — where the active profile may legitimately not equal `:id` (e.g. parent patching a freshly-created child). A blanket 403 here would regress those flows (adversarial review §CRITICAL-1).
+
+Apply the scope-match guard **only when the patch includes `defaultAppContext`**. Mode is per-profile state set by the profile itself; the other fields keep their existing account-ownership-only semantics.
+
+In `apps/api/src/routes/profiles.ts:77-93`, the PATCH handler:
+
+```ts
+.patch(
+  '/:id',
+  zValidator('param', z.object({ id: z.string().uuid() })),
+  zValidator('json', profileUpdateSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const accountId = c.get('account').id;
+    const input = c.req.valid('json');
+
+    // Scope-match guard applies ONLY to defaultAppContext writes. Other fields
+    // (displayName, pronouns, etc.) keep account-ownership-only semantics so
+    // onboarding flows that patch a sibling profile still work.
+    if (input.defaultAppContext !== undefined) {
+      const activeProfileId = c.get('profileId'); // from profile-scope middleware
+      if (activeProfileId !== id) {
+        return forbidden(c, 'Default app context can only be changed for the active profile');
+      }
+    }
+
+    const updated = await updateProfile(c.get('db'), id, accountId, input);
+    if (!updated) return notFound(c, 'Profile not found');
+    return c.json(profileResponseSchema.parse({ profile: updated }));
+  },
+)
+```
+
+The `profile-scope` middleware at `apps/api/src/middleware/profile-scope.ts` already sets `c.set('profileId', ...)` (confirmed line 113, 166), so no additional plumbing is needed.
+
+Tests must cover both branches: (a) patching `displayName` on a sibling profile is still 200; (b) patching `defaultAppContext` on a non-active profile is 403.
+
+- [ ] **Step 7: Run tests + lint + typecheck**
+
+```bash
+cd apps/api && pnpm exec jest --findRelatedTests src/routes/profiles.ts src/services/profile.ts --no-coverage
+pnpm exec nx run api:lint
+pnpm exec nx run api:typecheck
+```
+
+ESLint G1/G5 will reject route-file direct DB access. Keep all DB work in the service.
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+`/commit` description: `feat(api): allow PATCH /profiles/:id to update defaultAppContext with capability check`
+
+---
+
+## Task 4: Family capability helper (mobile)
+
+A shared helper so every gating check uses one predicate. Replaces ad-hoc `isGuardianProfile` uses where Family mode access is the question.
+
+**Files:**
+- Modify: `apps/mobile/src/lib/profile.ts` (add `isFamilyCapableProfile`)
+- Test: `apps/mobile/src/lib/profile.test.ts` (co-located)
+
+- [ ] **Step 1: Write failing tests**
+
+In `apps/mobile/src/lib/profile.test.ts`:
+
+```ts
+import { isFamilyCapableProfile } from './profile';
+import type { Profile } from '@eduagent/schemas';
+
+const mkProfile = (overrides: Partial<Profile> = {}): Profile => ({
+  id: 'p1', accountId: 'a1', displayName: 'A', avatarUrl: null,
+  birthYear: 1990, location: null, isOwner: true, hasPremiumLlm: false,
+  conversationLanguage: 'en', pronouns: null, consentStatus: null,
+  linkCreatedAt: null, createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  defaultAppContext: null, hasFamilyLinks: true,
+  ...overrides,
+});
+
+describe('isFamilyCapableProfile', () => {
+  it('returns true for adult owner with hasFamilyLinks', () => {
+    expect(isFamilyCapableProfile(mkProfile())).toBe(true);
+  });
+
+  it('returns false for a non-owner profile', () => {
+    expect(isFamilyCapableProfile(mkProfile({ isOwner: false }))).toBe(false);
+  });
+
+  it('returns false for an under-18 owner with linked children', () => {
+    const currentYear = new Date().getFullYear();
+    expect(isFamilyCapableProfile(mkProfile({ birthYear: currentYear - 15 }))).toBe(false);
+  });
+
+  it('returns false for an adult owner without family links', () => {
+    expect(isFamilyCapableProfile(mkProfile({ hasFamilyLinks: false }))).toBe(false);
+  });
+
+  it('returns false for a null profile', () => {
+    expect(isFamilyCapableProfile(null)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.ts --no-coverage
+```
+
+Expected: FAIL (`isFamilyCapableProfile is not exported`).
+
+- [ ] **Step 3: Implement the helper**
+
+In `apps/mobile/src/lib/profile.ts`:
+
+```ts
+import { computeAgeBracket } from '@eduagent/schemas';
+import type { Profile } from '@eduagent/schemas';
+
+export function isFamilyCapableProfile(profile: Profile | null | undefined): boolean {
+  if (!profile) return false;
+  if (!profile.isOwner) return false;
+  if (computeAgeBracket(profile.birthYear) !== 'adult') return false;
+  return profile.hasFamilyLinks === true;
+}
+```
+
+Critically: do NOT compute capability from `profiles.some(p => !p.isOwner)`. Per spec Glossary, `hasFamilyLinks` is the server source of truth.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`/commit` description: `feat(mobile): add isFamilyCapableProfile helper for Family mode gating`
+
+---
+
+## Task 5: Wire `defaultAppContext` and `isFamilyCapable` into the tab shell
+
+Connect the new helper + server-backed field to `resolveTabShape()` callers in `_layout.tsx`. Removes the TODOs left in Task 1.
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx` (caller of resolveTabShape)
+- Test: `apps/mobile/src/app/(app)/_layout.test.tsx`
+
+- [ ] **Step 1: Add resolveTabShape integration tests**
+
+Extend `_layout.test.tsx`:
+
+```tsx
+import { resolveTabShape } from './_layout';
+
+describe('resolveTabShape', () => {
+  it('returns study when not family-capable, regardless of default', () => {
+    expect(resolveTabShape({ isParentProxy: false, defaultAppContext: 'family', isFamilyCapable: false })).toBe('study');
+  });
+
+  it('returns study when family-capable but defaultAppContext is null', () => {
+    expect(resolveTabShape({ isParentProxy: false, defaultAppContext: null, isFamilyCapable: true })).toBe('study');
+  });
+
+  it('returns family when family-capable and defaultAppContext is family', () => {
+    expect(resolveTabShape({ isParentProxy: false, defaultAppContext: 'family', isFamilyCapable: true })).toBe('family');
+  });
+
+  it('returns study override when isParentProxy is true (proxy chrome wins)', () => {
+    expect(resolveTabShape({ isParentProxy: true, defaultAppContext: 'family', isFamilyCapable: true })).toBe('study');
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect pass (Task 1 already wired these)**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.test.tsx --no-coverage
+```
+
+- [ ] **Step 3: Wire the real call site**
+
+In `_layout.tsx` replace the placeholder call from Task 1:
+
+```ts
+const tabShape = resolveTabShape({
+  isParentProxy,
+  defaultAppContext: activeProfile?.defaultAppContext ?? null,
+  isFamilyCapable: isFamilyCapableProfile(activeProfile),
+});
+```
+
+Add the import at the top of the file:
+
+```ts
+import { isFamilyCapableProfile } from '../../lib/profile';
+```
+
+- [ ] **Step 4: Update the tab visibility logic to use `computeVisibleTabs(tabShape)`**
+
+Replace any old `tabShape === 'guardian' ? GUARDIAN_TABS : LEARNER_TABS` patterns with `computeVisibleTabs(tabShape)`. The proxy subset remains a separate branch:
+
+```ts
+const visibleTabs = isParentProxy
+  ? PARENT_PROXY_TABS
+  : computeVisibleTabs(tabShape);
+```
+
+- [ ] **Step 5: Add a `recaps` Tabs.Screen entry**
+
+In the Tabs.Screen list (around lines 1738-1797), add:
+
+```tsx
+<Tabs.Screen
+  name="recaps"
+  options={{
+    title: 'Recaps',
+    tabBarLabel: 'Recaps',
+    tabBarTestID: 'tab-recaps',
+    tabBarIcon: /* existing icon pattern */,
+    href: visibleTabs.has('recaps') ? '/(app)/recaps' : null,
+    tabBarItemStyle: visibleTabs.has('recaps') ? undefined : { display: 'none' },
+  }}
+/>
+```
+
+Apply the same `href: visibleTabs.has(...) ? ... : null` + `tabBarItemStyle` pattern to every existing tab. This matches the Set semantics of the existing tab-visibility helper at `_layout.tsx:114-126` (do not switch to array `.includes(...)` — see adversarial review §CRITICAL-2).
+
+The Family home tab label is "Children" — when `tabShape === 'family'`, override the `home` tab's `tabBarLabel` to "Children":
+
+```tsx
+<Tabs.Screen
+  name="home"
+  options={{
+    title: 'Home',
+    tabBarLabel: tabShape === 'family' ? 'Children' : 'My Learning',
+    // ...
+  }}
+/>
+```
+
+The "My Learning" label for Study replaces what was formerly `own-learning`. (See Task 11 for `own-learning.tsx` route survival.)
+
+- [ ] **Step 6: Remove or update `resolveHomeTabPresentation()`**
+
+Per spec §MEDIUM-4, with explicit modes this resolver is redundant. Search for its callers:
+
+```bash
+```
+
+Use Grep with pattern `resolveHomeTabPresentation` in `apps/mobile/src/`. If only used in `_layout.tsx`, inline the logic at the call site (`tabShape === 'family' ? 'Family' : 'My Learning'`) and delete the helper. Update any test that imported the helper.
+
+- [ ] **Step 7: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.tsx src/lib/profile.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+`/commit` description: `feat(mobile): wire defaultAppContext and isFamilyCapable into tab shell`
+
+---
+
+## Task 6: First-run intent screen
+
+A new onboarding step hosted post-sign-up. Choice is ephemeral until profile creation. Spec §First-Run Intent + AC #34.
+
+**Files:**
+- Create: `apps/mobile/src/app/(app)/onboarding/intent.tsx`
+- Test: `apps/mobile/src/app/(app)/onboarding/intent.test.tsx`
+- Modify: `apps/mobile/src/app/(app)/onboarding/index.tsx` (route to intent.tsx first)
+
+- [ ] **Step 1: Determine current onboarding route order**
+
+Read `apps/mobile/src/app/(app)/onboarding/index.tsx` and `_layout.tsx`. Identify where the flow begins (typically a Stack with sequential routes). The intent screen must come before `language-setup` and `pronouns`.
+
+- [ ] **Step 2: Write failing test**
+
+`onboarding/intent.test.tsx`:
+
+```tsx
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { IntentScreen } from './intent';
+
+const mockReplace = jest.fn();
+// expo-router is a bare-specifier external module — NOT a GC1 violation, no
+// gc1-allow comment needed. GC1 gates only relative-path internal mocks.
+jest.mock('expo-router', () => ({
+  ...jest.requireActual('expo-router'),
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+describe('IntentScreen', () => {
+  it('renders Study and Family choices', () => {
+    const { getByTestId } = render(<IntentScreen />);
+    expect(getByTestId('intent-choice-study')).toBeTruthy();
+    expect(getByTestId('intent-choice-family')).toBeTruthy();
+  });
+
+  it('persists nothing in SecureStore (ephemeral choice)', () => {
+    const { getByTestId } = render(<IntentScreen />);
+    fireEvent.press(getByTestId('intent-choice-study'));
+    // assert no SecureStore.setItemAsync was called (spy on the SecureStore module if needed)
+  });
+
+  it('navigates forward with study intent via route state', async () => {
+    const { getByTestId } = render(<IntentScreen />);
+    fireEvent.press(getByTestId('intent-choice-study'));
+    fireEvent.press(getByTestId('intent-continue'));
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/(app)/onboarding/language-setup', // or whatever the next step is
+        params: { intent: 'study' },
+      }),
+    );
+  });
+
+  it('navigates forward with family intent via route state', async () => {
+    const { getByTestId } = render(<IntentScreen />);
+    fireEvent.press(getByTestId('intent-choice-family'));
+    fireEvent.press(getByTestId('intent-continue'));
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.objectContaining({ params: { intent: 'family' } }),
+      ),
+    );
+  });
+});
+```
+
+The `expo-router` mock uses a bare specifier (external boundary) and is unaffected by GC1, which only gates relative-path internal mocks. Do not add a `gc1-allow` comment to it.
+
+- [ ] **Step 3: Run failing test**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/onboarding/intent.test.tsx --no-coverage
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement `IntentScreen`**
+
+`intent.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { track } from '../../../lib/analytics';
+
+type Intent = 'study' | 'family';
+
+export function IntentScreen() {
+  const router = useRouter();
+  const [intent, setIntent] = useState<Intent | null>(null);
+
+  const onContinue = () => {
+    if (!intent) return;
+    track('mode_intent_chosen', { intent });
+    router.replace({
+      pathname: '/(app)/onboarding/language-setup',
+      params: { intent },
+    });
+  };
+
+  return (
+    <View>
+      <Text>How do you want to use MentoMate?</Text>
+      <Pressable
+        testID="intent-choice-study"
+        onPress={() => setIntent('study')}
+        accessibilityState={{ selected: intent === 'study' }}
+      >
+        <Text>Study (for myself)</Text>
+      </Pressable>
+      <Pressable
+        testID="intent-choice-family"
+        onPress={() => setIntent('family')}
+        accessibilityState={{ selected: intent === 'family' }}
+      >
+        <Text>Family (support my children's learning)</Text>
+      </Pressable>
+      <Pressable testID="intent-continue" disabled={!intent} onPress={onContinue}>
+        <Text>Continue</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default IntentScreen; // Expo Router page; default export per CLAUDE.md exception
+```
+
+Copy and styling can be polished later (spec Notes). Use semantic tokens, not hex.
+
+- [ ] **Step 5: Route the onboarding flow through intent first**
+
+In `apps/mobile/src/app/(app)/onboarding/index.tsx`, change the initial redirect/route to send users to `intent.tsx` first. The next-step screen (`language-setup.tsx`) reads `params.intent` and threads it onward until profile creation completes; the create-profile call writes the validated mode (Study always allowed; Family only if capability resolves OK — backend rejects otherwise per Task 3, and the client falls back to Study with plain copy).
+
+- [ ] **Step 6: Add the post-creation resolution**
+
+After profile creation succeeds (find the existing create-profile success handler in onboarding), branch on intent and current family capability. Per adversarial review §HIGH-1, an adult who picked Family but has no children yet must NOT silently fall through to Study — they land on a "Family setup" entry point so the intent is preserved.
+
+```ts
+import { isFamilyCapableProfile } from '../../lib/profile';
+
+const intent = params.intent as 'study' | 'family' | undefined;
+
+if (intent === 'family') {
+  // Only patch defaultAppContext='family' when capability already resolves.
+  // For the under-18 case the server would 403 anyway; for the no-children
+  // case we keep the user in a Family-setup landing state with capability
+  // unresolved (defaultAppContext stays null), and surface the empty state
+  // when the user opens (app)/home (see Task 8 — family-setup-empty).
+  if (isFamilyCapableProfile(createdProfile)) {
+    await mutateProfile({ defaultAppContext: 'family' });
+  }
+  // Either way, route to (app)/home. Mode-aware home renders Family setup
+  // when intent='family' && !isFamilyCapable, or the Children hub when
+  // capable.
+  router.replace({
+    pathname: '/(app)/home',
+    params: { intent: 'family' },
+  });
+} else {
+  // Study intent or unset — leave defaultAppContext as null; client defaults to study
+  router.replace('/(app)/home');
+}
+```
+
+Note: the `params.intent` thread through `/(app)/home` lets the Family-setup-empty branch read the intent. Persisting intent across cold launches is out of scope for Task 6 — a parent who quits before adding a child re-takes the intent screen on next launch.
+
+- [ ] **Step 7: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/onboarding/ --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 8: Commit**
+
+`/commit` description: `feat(mobile): add first-run Study/Family intent screen + post-create mode resolution`
+
+---
+
+## Task 7: Mode switch entry points + mutation hook
+
+A visible toggle (in More, plus a small affordance in Family home and Study home) lets a family-capable adult switch contexts. The mutation uses optimistic UI with rollback and stale-response protection per spec §Mode Mutation Contract.
+
+**Files:**
+- Create: `apps/mobile/src/hooks/use-mode-switch.ts`
+- Create: `apps/mobile/src/hooks/use-mode-switch.test.ts`
+- Modify: `apps/mobile/src/app/(app)/more.tsx` (or equivalent — locate via Grep)
+- Test: mode-switch integration in `_layout.test.tsx` and `more.test.tsx`
+
+- [ ] **Step 1: Write failing tests for the hook**
+
+`use-mode-switch.test.ts`:
+
+```ts
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useModeSwitch } from './use-mode-switch';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+describe('useModeSwitch', () => {
+  it('optimistically updates the profile query cache', async () => {
+    // arrange: seed profile cache with defaultAppContext: 'study'
+    // act: call mutate('family')
+    // assert: cache shows 'family' synchronously before await
+  });
+
+  it('rolls back on server 4xx', async () => {
+    // arrange: server returns 403
+    // act: call mutate('family')
+    // assert: cache reverts to 'study', error surfaced
+  });
+
+  it('rolls back on network error and shows retryable error', async () => {
+    // arrange: fetch throws
+    // act: call mutate
+    // assert: cache reverts, error.retry exists
+  });
+
+  it('ignores stale response when active profile changed mid-flight', async () => {
+    // arrange: start mutation with active profile A
+    // simulate: active profile changes to B before response
+    // assert: response is not applied to B's cache
+  });
+
+  it('single-flight via button disable: second tap is rejected while first is pending', async () => {
+    // arrange: render More tab with the switch button
+    // act: tap once, then tap again before the first resolves
+    // assert: only ONE PATCH fired; the button is disabled between the taps
+    // This is the primary single-flight defence — the inflightSeq ref only
+    // guards stale RESPONSES, not duplicate IN-FLIGHT REQUESTS.
+  });
+
+  it('stale-response guard handles out-of-order response arrival', async () => {
+    // arrange: simulate two PATCH requests racing (server processes in either order)
+    // act: mutate('family'), then mutate('study') back-to-back via the hook directly
+    // simulate: family response arrives AFTER study response
+    // assert: only the latest sequence number commits; older response is dropped
+  });
+});
+
+it('rolls back optimistic update to the SAME key on server 403', async () => {
+  // arrange: seed cache at ['profiles', userId] with defaultAppContext: 'study'
+  // arrange: server returns 403 (e.g. under-18, no children)
+  // act: mutate('family')
+  // assert: cache at ['profiles', userId] equals the pre-mutation snapshot
+  // CRITICAL: this test must use the real userId-scoped key. A bare ['profiles']
+  // key would silently mask the bug (adversarial review §CRITICAL-2).
+});
+```
+
+These map to AC #5, #6, #6a.
+
+- [ ] **Step 2: Implement the hook**
+
+```ts
+// use-mode-switch.ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
+import { useRouter, usePathname } from 'expo-router';
+import { client } from '../lib/api-client';
+import { track, hashProfileId } from '../lib/analytics';
+import { useUserId } from './use-user-id'; // confirm name; whatever surfaces Clerk userId in this app
+import type { AppContext, Profile } from '@eduagent/schemas';
+
+// Routes that are mode-incompatible — switching mode while on one of these
+// requires router.replace('/(app)/home') because the destination no longer
+// exists in the new mode. All other routes stay in place; query
+// invalidations refresh visible data.
+const FAMILY_ONLY_ROUTES = ['/(app)/recaps'];
+const STUDY_ONLY_ROUTES: string[] = []; // currently none; add if Study introduces exclusive routes
+
+export function useModeSwitch(activeProfile: Profile | null) {
+  const qc = useQueryClient();
+  const router = useRouter();
+  const pathname = usePathname();
+  const userId = useUserId();
+  const profilesKey = ['profiles', userId] as const; // CRITICAL: must match use-profiles.ts:28
+  const inflightSeq = useRef(0);
+  const activeProfileIdAtStart = useRef<string | null>(null);
+
+  return useMutation({
+    mutationFn: async (next: AppContext) => {
+      if (!activeProfile) throw new Error('no-active-profile');
+      const seq = ++inflightSeq.current;
+      activeProfileIdAtStart.current = activeProfile.id;
+
+      const res = await client.profiles[':id'].$patch({
+        param: { id: activeProfile.id },
+        json: { defaultAppContext: next },
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ModeSwitchError(res.status, body);
+      }
+      const data = await res.json();
+      return { seq, profile: data.profile as Profile, intended: next };
+    },
+    onMutate: async (next) => {
+      if (!activeProfile) return;
+      await qc.cancelQueries({ queryKey: profilesKey });
+      const previous = qc.getQueryData<Profile[]>(profilesKey);
+      qc.setQueryData<Profile[]>(profilesKey, (old) =>
+        (old ?? []).map((p) =>
+          p.id === activeProfile.id ? { ...p, defaultAppContext: next } : p,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_err, _next, ctx) => {
+      // CRITICAL: rollback uses the SAME key that onMutate snapshotted.
+      // A mismatched key here would leave the optimistic update in place forever.
+      if (ctx?.previous) {
+        qc.setQueryData(profilesKey, ctx.previous);
+      }
+    },
+    onSuccess: ({ seq, profile, intended }) => {
+      // Stale-response guard: only commit if (a) sequence is still the latest, and (b) active profile hasn't changed.
+      if (seq !== inflightSeq.current) return;
+      if (!activeProfile || activeProfile.id !== activeProfileIdAtStart.current) {
+        qc.invalidateQueries({ queryKey: profilesKey });
+        return;
+      }
+      qc.setQueryData<Profile[]>(profilesKey, (old) =>
+        (old ?? []).map((p) => (p.id === profile.id ? profile : p)),
+      );
+
+      // Scoped invalidations — only the switching profile's data needs refetch.
+      // Avoids the refetch storm of bare ['subjects'] / ['progress'] (which
+      // would blow caches for every profile in the session).
+      const pid = profile.id;
+      qc.invalidateQueries({ queryKey: ['progress', pid] });
+      qc.invalidateQueries({ queryKey: ['dashboard', pid] });
+      qc.invalidateQueries({ queryKey: ['recaps', pid] }); // parent-scoped recaps
+      qc.invalidateQueries({ queryKey: ['subjects', pid] });
+      qc.invalidateQueries({ queryKey: ['reports', pid] });
+
+      track('mode_switched', {
+        from: intended === 'family' ? 'study' : 'family',
+        to: intended,
+        profileIdHash: hashProfileId(pid),
+      });
+
+      // Conditional replace: only navigate if the current route is incompatible
+      // with the new mode. Switching mode while in More/Settings should NOT
+      // teleport the user away from where they are.
+      const incompatible =
+        (intended === 'study' && FAMILY_ONLY_ROUTES.some((r) => pathname.startsWith(r))) ||
+        (intended === 'family' && STUDY_ONLY_ROUTES.some((r) => pathname.startsWith(r)));
+      if (incompatible) {
+        router.replace('/(app)/home');
+      }
+    },
+  });
+}
+
+export class ModeSwitchError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`mode-switch-failed-${status}`);
+  }
+}
+```
+
+Query-key discipline (adversarial review §CRITICAL-2):
+- The key MUST be `['profiles', userId]` everywhere (`onMutate`, `onError`, `onSuccess`) — matches `use-profiles.ts:28`.
+- A test must seed the cache at `['profiles', userId]`, force a 403, and assert the cache returns to the snapshotted value. A green test against the wrong key would silently mask the rollback bug.
+
+Single-flight (adversarial review §HIGH-2):
+- The button caller (Task 7 Step 3 below) MUST disable while `isPending` is true. The `inflightSeq` ref only guards stale RESPONSES, not duplicate IN-FLIGHT REQUESTS. Without the button disable, a fast double-tap can fire two PATCHes whose server-processing order is undefined.
+
+- [ ] **Step 3: Add the switch UI to `more.tsx`**
+
+Find the More tab screen via:
+
+```bash
+```
+
+Use Glob `apps/mobile/src/app/(app)/more*`. Read it. Add a row for "Switch to Study"/"Switch to Family" visible only when:
+- the active profile is family-capable, AND
+- `!isParentProxy`
+
+```tsx
+const { mutate, isPending } = useModeSwitch(activeProfile);
+const current = activeProfile?.defaultAppContext ?? 'study';
+
+{isFamilyCapableProfile(activeProfile) && !isParentProxy && (
+  <Pressable
+    testID="mode-switch"
+    // disabled={isPending} is the single-flight defence — keep it.
+    // The hook's inflightSeq ref only guards stale RESPONSES; without this
+    // disable, a fast double-tap can fire two PATCHes whose server-
+    // processing order is undefined (adversarial review §HIGH-2).
+    disabled={isPending}
+    onPress={() => mutate(current === 'family' ? 'study' : 'family')}
+  >
+    <Text>{current === 'family' ? 'Switch to Study mode' : 'Switch to Family mode'}</Text>
+  </Pressable>
+)}
+```
+
+- [ ] **Step 4: Disable mode switch while a profile switch is in flight**
+
+Locate the `switchProfile` mutation (see `apps/api/src/services/profile.ts:371-384` server-side; mobile-side hook). The mode-switch button must read its `isPending` and disable. Use a context or a small `useIsProfileSwitchPending()` selector.
+
+- [ ] **Step 5: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/hooks/use-mode-switch.ts src/app/\(app\)/more --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+`/commit` description: `feat(mobile): mode switch hook with optimistic+rollback+stale-response guard, More-tab entry point`
+
+---
+
+## Task 8: Children tab + child curriculum bridge
+
+Family mode's Home tab is "Children". It must surface child curriculum management (add/manage subjects/books) without proxy mode — this answers spec §HIGH-2.
+
+**Files:**
+- Modify: `apps/mobile/src/components/home/ParentHomeScreen.tsx` (already the Family home content)
+- Possibly create: `apps/mobile/src/app/(app)/child/[profileId]/curriculum.tsx` (or extend existing child detail route)
+- Modify/extend: the (app)/home route to render a `family-setup-empty` branch when `intent === 'family' && !isFamilyCapable` (adversarial review §HIGH-1 fix — pairs with Task 6 Step 6)
+
+- [ ] **Step 0: Add the Family-setup-empty branch on (app)/home**
+
+In the home screen, after computing `tabShape`:
+
+```tsx
+const intentFromParams = useLocalSearchParams().intent;
+const wantsFamily = intentFromParams === 'family' || activeProfile?.defaultAppContext === 'family';
+
+if (wantsFamily && !isFamilyCapableProfile(activeProfile)) {
+  return (
+    <View testID="family-setup-empty">
+      <Text>Set up your family</Text>
+      <Text>Add a child profile to start tracking their learning.</Text>
+      <Pressable testID="family-setup-add-child" onPress={() => router.push('/(app)/add-child')}>
+        <Text>Add a child</Text>
+      </Pressable>
+      <Pressable testID="family-setup-skip-to-study" onPress={() => router.replace('/(app)/home')}>
+        <Text>Maybe later — use Study mode</Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+Co-located test asserts both buttons fire the right router/mutation calls. This satisfies the Task 19 Playwright case "Adult with Family intent but no child: sees Family setup, not tabs" without the silent Study fallback the original plan had.
+
+- [ ] **Step 1: Audit current child-card actions in `ParentHomeScreen.tsx`**
+
+Read `ParentHomeScreen.tsx:1110-1140` (child command cards). Identify whether each card currently:
+- routes via `router.push('/(app)/child/[profileId]')`, or
+- enters proxy mode via `switchProfile(child.id)`.
+
+Any card that enters proxy must be repointed at a parent-native route. The child detail route already exists per Files to Reference; verify with Grep for `'/(app)/child/'`.
+
+- [ ] **Step 2: Add a "Subjects & books" action on each child card**
+
+Decision: use a **sibling route** (not a query param view). Matches Expo Router conventions, gives a stable deep-link target, and keeps the back stack clean. The destination is:
+
+```ts
+router.push({
+  pathname: '/(app)/child/[profileId]/curriculum',
+  params: { profileId: child.id },
+});
+```
+
+Create `apps/mobile/src/app/(app)/child/[profileId]/curriculum.tsx` if it doesn't exist. The screen renders the child's subjects/books in parent-native chrome (no proxy banner). Reuse existing curriculum components but pass the child id explicitly rather than switching `X-Profile-Id`.
+
+- [ ] **Step 3: Server-side: confirm parent can read child subjects via family-link scope**
+
+Verify there's an existing parent-scoped subjects endpoint (or extend one). The endpoint must:
+- accept `?childProfileId=...`
+- verify `family_links.parent_profile_id = activeProfile.id` server-side
+- never require switching `X-Profile-Id` to the child
+
+If no such endpoint exists, create `apps/api/src/routes/family-curriculum.ts` (or extend an existing parent route). Follow the same pattern Task 9 uses for recaps.
+
+- [ ] **Step 4: Write tests**
+
+Co-located test in `ParentHomeScreen.test.tsx`:
+
+```tsx
+it('child card "Subjects & books" navigates to parent-native curriculum, not proxy', async () => {
+  const { getByTestId } = render(<ParentHomeScreen activeProfile={ownerProfile} />);
+  fireEvent.press(getByTestId(`child-card-${childId}-curriculum`));
+  expect(mockRouterPush).toHaveBeenCalledWith({
+    pathname: '/(app)/child/[profileId]/curriculum',
+    params: { profileId: childId },
+  });
+  expect(mockSwitchProfile).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/components/home/ParentHomeScreen.tsx --no-coverage
+pnpm exec nx run api:typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+`/commit` description: `feat(mobile): parent-native child curriculum access from Family Children tab (no proxy)`
+
+---
+
+## Task 9: Recaps API — service, route, shared schema
+
+Server-side recap feed. New shared schema in `packages/schemas/src/recaps.ts`, new route under `apps/api/src/routes/recaps.ts`, new service `apps/api/src/services/recaps.ts`. Reads existing `session_summaries` recap columns (`narrative`, `conversation_prompt`, `engagement_signal`). Spec AC #14 forbids new synonym columns.
+
+**Files:**
+- Create: `packages/schemas/src/recaps.ts`
+- Modify: `packages/schemas/src/index.ts` (re-export)
+- Create: `apps/api/src/services/recaps.ts`
+- Create: `apps/api/src/routes/recaps.ts`
+- Modify: `apps/api/src/index.ts` (wire the new route)
+- Test: `apps/api/src/routes/recaps.test.ts`, `apps/api/src/routes/recaps.integration.test.ts`
+
+- [ ] **Step 1: Define `parentRecapFeedItemSchema`**
+
+`packages/schemas/src/recaps.ts`:
+
+```ts
+import { z } from 'zod';
+import { engagementSignalSchema } from './sessions';
+
+export const parentRecapFeedItemSchema = z.object({
+  id: z.string().uuid(),
+  childProfileId: z.string().uuid(),
+  childDisplayName: z.string(),
+  sessionId: z.string().uuid(),
+  subjectId: z.string().uuid().nullable(),
+  subjectName: z.string().nullable(),
+  topicId: z.string().uuid().nullable(),
+  topicTitle: z.string().nullable(),
+  completedAt: z.string().datetime(),
+  activeDurationMinutes: z.number().int().nullable(),
+  narrative: z.string().nullable(),
+  conversationPrompt: z.string().nullable(),
+  engagementSignal: engagementSignalSchema.nullable(),
+});
+
+export type ParentRecapFeedItem = z.infer<typeof parentRecapFeedItemSchema>;
+
+export const parentRecapFeedResponseSchema = z.object({
+  items: z.array(parentRecapFeedItemSchema),
+  nextCursor: z.string().nullable(),
+});
+
+export const parentRecapFeedQuerySchema = z.object({
+  childProfileId: z.string().uuid().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+```
+
+No `highlight` field per spec §HIGH-2 round 4.
+
+- [ ] **Step 2: Re-export from barrel**
+
+In `packages/schemas/src/index.ts`, add (or rely on `export * from './recaps'` if the pattern matches):
+
+```ts
+export * from './recaps';
+```
+
+- [ ] **Step 3: Write failing integration test**
+
+`apps/api/src/routes/recaps.integration.test.ts`:
+
+```ts
+import { app } from '../index';
+
+describe('GET /recaps (parent feed)', () => {
+  it('returns recaps for all linked children of the active parent', async () => {
+    // arrange: seed parent owner + 2 child profiles + family_links + completed sessions with narrative
+    const res = await app.request('/recaps', { headers: { 'X-Profile-Id': parentId, /* auth */ } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items.length).toBeGreaterThan(0);
+    expect(body.items.every((i) => i.childProfileId === childA.id || i.childProfileId === childB.id)).toBe(true);
+  });
+
+  it('filters to one child via childProfileId', async () => {
+    const res = await app.request(`/recaps?childProfileId=${childA.id}`, { headers });
+    const body = await res.json();
+    expect(body.items.every((i) => i.childProfileId === childA.id)).toBe(true);
+  });
+
+  it('rejects child id outside the active parent family with the existing protected/not-found error shape', async () => {
+    const res = await app.request(`/recaps?childProfileId=${otherFamilyChildId}`, { headers });
+    expect(res.status).toBe(403); // or 404, match existing protected-data shape
+    const body = await res.json();
+    expect(body.items).toBeUndefined();
+  });
+
+  it('returns empty items when no completed sessions exist', async () => {
+    const res = await app.request('/recaps', { headers: parentWithChildButNoSessionsHeaders });
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+  });
+
+  it('selects narrative, conversation_prompt, engagement_signal only (no synonym columns)', async () => {
+    // Adversarial review §MEDIUM-7: tighten the regex so it cannot false-match
+    // on legitimate identifiers (e.g. the table name `sessionSummaries`, the
+    // type name `RecapSummary`, or any JSDoc containing the word "summary").
+    // Forbid only the exact column-access shapes that would indicate a
+    // synonym column being read from `sessionSummaries`.
+    const src = await fs.readFile(path.join(__dirname, '../services/recaps.ts'), 'utf-8');
+    expect(src).not.toMatch(/sessionSummaries\.summary\b/);
+    expect(src).not.toMatch(/sessionSummaries\.engagementLabel\b/);
+    expect(src).toMatch(/sessionSummaries\.narrative\b/);
+    expect(src).toMatch(/sessionSummaries\.conversationPrompt\b/);
+    expect(src).toMatch(/sessionSummaries\.engagementSignal\b/);
+  });
+
+  // Adversarial review §MEDIUM-5: before authoring this test, read the
+  // session_summaries Drizzle schema to determine whether engagement_signal
+  // is `text` (free), a Postgres `enum`, or has a CHECK constraint. If the
+  // column is typed/checked, the raw INSERT below will fail and the test
+  // cannot run — drop it (the invariant is enforced at the DB layer) OR
+  // rewrite it as a unit test that feeds the mapper an invalid string
+  // directly, bypassing the DB. Only keep the integration shape if the
+  // column is plain `text`.
+  it('returns engagementSignal=null and logs a warning when DB has an invalid value (no silent recovery)', async () => {
+    // arrange: insert a session_summary row with engagement_signal = 'happy' directly via raw SQL
+    // arrange: spy on the logger.warn call
+    const warnSpy = jest.spyOn(logger, 'warn');
+    const res = await app.request('/recaps', { headers });
+    const body = await res.json();
+    const item = body.items.find((i) => i.sessionId === seededInvalidSessionId);
+    expect(item.engagementSignal).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'invalid_engagement_signal',
+      expect.objectContaining({ rawValue: 'happy', sessionId: seededInvalidSessionId }),
+    );
+  });
+
+  it('cursor pagination is stable when two rows have identical completedAt (id tiebreaker)', async () => {
+    // arrange: seed two session_summaries with the exact same sessions.completed_at timestamp
+    const r1 = await app.request('/recaps?limit=1', { headers });
+    const b1 = await r1.json();
+    const firstId = b1.items[0].id;
+    expect(b1.nextCursor).not.toBeNull();
+    const r2 = await app.request(`/recaps?limit=1&cursor=${encodeURIComponent(b1.nextCursor)}`, { headers });
+    const b2 = await r2.json();
+    expect(b2.items[0].id).not.toBe(firstId); // second row not skipped, not duplicated
+  });
+
+  it('cursor pagination yields stable latest-first ordering', async () => {
+    const r1 = await app.request('/recaps?limit=2', { headers });
+    const b1 = await r1.json();
+    const r2 = await app.request(`/recaps?limit=2&cursor=${b1.nextCursor}`, { headers });
+    const b2 = await r2.json();
+    expect(b1.items[0].completedAt >= b1.items[1].completedAt).toBe(true);
+    expect(b2.items[0].completedAt < b1.items[1].completedAt).toBe(true);
+  });
+
+  it('works for parent-managed child profile with no linked child account', async () => {
+    // arrange: parent + child profile owned by parent's account (no separate Clerk user); session_summaries rows exist
+    const res = await app.request('/recaps', { headers: parentHeaders });
+    expect(res.status).toBe(200);
+    expect((await res.json()).items.length).toBeGreaterThan(0);
+  });
+
+  it('works for linked child learner account and respects consent', async () => {
+    // arrange: separate Clerk user as child, family_links set, consent active
+    const res = await app.request('/recaps', { headers });
+    expect((await res.json()).items.length).toBeGreaterThan(0);
+  });
+
+  it('returns the existing protected-data error shape when consent is withdrawn', async () => {
+    // arrange: consent_status = 'withdrawn' for the linked child
+    const res = await app.request(`/recaps?childProfileId=${withdrawnChildId}`, { headers });
+    expect(res.status).toBe(403); // or whatever the existing protected-data error shape uses
+  });
+});
+```
+
+- [ ] **Step 4: Run failing tests**
+
+```bash
+cd apps/api && pnpm exec jest src/routes/recaps.integration.test.ts --no-coverage
+```
+
+Expected: FAIL — service/route don't exist.
+
+- [ ] **Step 5: Implement the service**
+
+`apps/api/src/services/recaps.ts`:
+
+```ts
+import { sql, and, or, eq, desc, isNull, lt } from 'drizzle-orm';
+import type { Database } from '../db';
+import { sessionSummaries, sessions, subjects, curriculumTopics, profiles, familyLinks } from '@eduagent/database';
+import { engagementSignalSchema, type EngagementSignal } from '@eduagent/schemas';
+import type { ParentRecapFeedItem } from '@eduagent/schemas';
+import { logger } from '../logger'; // adjust to the existing logger import path
+
+export async function listParentRecaps(
+  db: Database,
+  params: {
+    parentProfileId: string;
+    childProfileId?: string;
+    cursor?: string; // ISO datetime
+    limit: number;
+  },
+): Promise<{ items: ParentRecapFeedItem[]; nextCursor: string | null }> {
+  // Authorization: ensure childProfileId (if given) belongs to parent via family_links.
+  if (params.childProfileId) {
+    const link = await db
+      .select({ id: familyLinks.id })
+      .from(familyLinks)
+      .innerJoin(profiles, eq(familyLinks.childProfileId, profiles.id))
+      .where(and(
+        eq(familyLinks.parentProfileId, params.parentProfileId),
+        eq(familyLinks.childProfileId, params.childProfileId),
+        isNull(profiles.archivedAt),
+      ))
+      .limit(1);
+    if (link.length === 0) {
+      throw new ProtectedDataError('recap-child-not-in-family');
+    }
+  }
+
+  // Cursor decoding: compound cursor of `{completedAt, id}` to break ties when
+  // two sessions completed at the same instant (autosave / batch finaliser /
+  // clock granularity). Plain `lt(completedAt)` would either skip or duplicate
+  // rows on the boundary (adversarial review §HIGH-4).
+  const cursor = params.cursor ? decodeCursor(params.cursor) : null;
+
+  // Direct db.select() with parent-chain WHERE — per CLAUDE.md, scoped repo cannot express multi-table joins; parent-chain pattern is sanctioned.
+  const rows = await db
+    .select({
+      id: sessionSummaries.id,
+      childProfileId: sessionSummaries.profileId,
+      childDisplayName: profiles.displayName,
+      sessionId: sessionSummaries.sessionId,
+      subjectId: subjects.id,
+      subjectName: subjects.name,
+      topicId: curriculumTopics.id,
+      topicTitle: curriculumTopics.title,
+      completedAt: sessions.completedAt,
+      activeDurationMinutes: sessions.activeDurationMinutes,
+      narrative: sessionSummaries.narrative,
+      conversationPrompt: sessionSummaries.conversationPrompt,
+      engagementSignal: sessionSummaries.engagementSignal,
+    })
+    .from(sessionSummaries)
+    .innerJoin(sessions, eq(sessionSummaries.sessionId, sessions.id))
+    .innerJoin(profiles, eq(sessionSummaries.profileId, profiles.id))
+    .innerJoin(familyLinks, eq(familyLinks.childProfileId, profiles.id))
+    .leftJoin(curriculumTopics, eq(sessions.topicId, curriculumTopics.id))
+    .leftJoin(subjects, eq(curriculumTopics.subjectId, subjects.id))
+    .where(and(
+      eq(familyLinks.parentProfileId, params.parentProfileId),
+      isNull(profiles.archivedAt),
+      params.childProfileId ? eq(sessionSummaries.profileId, params.childProfileId) : undefined,
+      // Compound-cursor predicate: completedAt < t  OR  (completedAt = t AND id < lastId)
+      cursor
+        ? or(
+            lt(sessions.completedAt, cursor.t),
+            and(eq(sessions.completedAt, cursor.t), lt(sessionSummaries.id, cursor.id)),
+          )
+        : undefined,
+    ))
+    .orderBy(desc(sessions.completedAt), desc(sessionSummaries.id))
+    .limit(params.limit + 1);
+
+  const hasMore = rows.length > params.limit;
+  const sliced = hasMore ? rows.slice(0, params.limit) : rows;
+  const last = sliced[sliced.length - 1];
+  const nextCursor = hasMore && last
+    ? encodeCursor({ t: last.completedAt, id: last.id })
+    : null;
+
+  const items: ParentRecapFeedItem[] = sliced.map((r) => {
+    // No silent .catch(null) on engagement signal — that hides DB invariant
+    // violations forever (CLAUDE.md "Silent recovery without escalation is
+    // banned"; adversarial review §HIGH-3). Use safeParse, surface invalid
+    // values via the logger, and degrade to null in the response.
+    const parsed = engagementSignalSchema.nullable().safeParse(r.engagementSignal);
+    let signal: EngagementSignal | null = null;
+    if (parsed.success) {
+      signal = parsed.data;
+    } else {
+      logger.warn('invalid_engagement_signal', {
+        rawValue: r.engagementSignal,
+        sessionId: r.sessionId,
+        sessionSummaryId: r.id,
+        context: 'recaps.listParentRecaps',
+      });
+    }
+    return {
+      id: r.id,
+      childProfileId: r.childProfileId,
+      childDisplayName: r.childDisplayName,
+      sessionId: r.sessionId,
+      subjectId: r.subjectId,
+      subjectName: r.subjectName,
+      topicId: r.topicId,
+      topicTitle: r.topicTitle,
+      completedAt: r.completedAt.toISOString(),
+      activeDurationMinutes: r.activeDurationMinutes,
+      narrative: r.narrative,
+      conversationPrompt: r.conversationPrompt,
+      engagementSignal: signal,
+    };
+  });
+
+  return { items, nextCursor };
+}
+
+// Compound-cursor helpers — keep encoding opaque to the client.
+// Adversarial review §MEDIUM-2: validate the decoded shape so a malformed
+// cursor cannot silently degenerate into `new Date('garbage')` (Invalid Date)
+// and produce a broken WHERE clause that returns 0 rows or duplicates page 1.
+const cursorPayloadSchema = z.object({
+  t: z.string().datetime(),
+  id: z.string().uuid(),
+});
+
+function encodeCursor(c: { t: Date; id: string }): string {
+  return Buffer.from(JSON.stringify({ t: c.t.toISOString(), id: c.id })).toString('base64url');
+}
+
+function decodeCursor(s: string): { t: Date; id: string } | null {
+  try {
+    const raw = JSON.parse(Buffer.from(s, 'base64url').toString('utf-8'));
+    const parsed = cursorPayloadSchema.safeParse(raw);
+    if (!parsed.success) {
+      logger.warn('invalid_recap_cursor', { rawValue: s, issues: parsed.error.issues });
+      return null;
+    }
+    return { t: new Date(parsed.data.t), id: parsed.data.id };
+  } catch {
+    logger.warn('invalid_recap_cursor_json', { rawValue: s });
+    return null;
+  }
+}
+```
+
+When `decodeCursor` returns `null` the query falls back to "first page" — equivalent to no cursor. Tests must seed an invalid cursor (e.g. `cursor=garbage`) and assert the response is the same as the no-cursor first page, plus the `warn` log fires.
+
+Engagement-signal handling (adversarial review §HIGH-3):
+- No `.catch(null)` — silent recovery is banned by CLAUDE.md.
+- `safeParse` + `logger.warn` makes invalid DB values visible in observability and queryable in 24-hour windows.
+- Tests must seed a row with an invalid value (e.g. `'happy'`) and assert (a) the response degrades to `engagementSignal: null` and (b) the warn log fires.
+
+Cursor pagination (adversarial review §HIGH-4):
+- Tests must seed two rows with identical `completedAt` and assert both appear, neither skipped nor duplicated, across page boundaries.
+
+- [ ] **Step 6: Implement the route**
+
+`apps/api/src/routes/recaps.ts`:
+
+```ts
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { parentRecapFeedQuerySchema, parentRecapFeedResponseSchema } from '@eduagent/schemas';
+import { listParentRecaps } from '../services/recaps';
+
+export const recapsRoute = new Hono()
+  .get(
+    '/',
+    zValidator('query', parentRecapFeedQuerySchema),
+    async (c) => {
+      const q = c.req.valid('query');
+      const result = await listParentRecaps(c.get('db'), {
+        parentProfileId: c.get('profileId'),
+        childProfileId: q.childProfileId,
+        cursor: q.cursor,
+        limit: q.limit,
+      });
+      return c.json(result);
+    },
+  );
+```
+
+ESLint G1/G5: route file has zero direct DB access. All DB calls in the service. The service does direct `db.select(...)` because the query joins through the parent chain — this is the sanctioned exception in CLAUDE.md ("for queries that join through a parent chain"). The WHERE clause enforces `family_links.parent_profile_id = parentProfileId`.
+
+- [ ] **Step 7: Wire into the Hono app**
+
+In `apps/api/src/index.ts`:
+
+```ts
+import { recapsRoute } from './routes/recaps';
+// ...
+const app = new Hono()
+  // ...existing routes...
+  .route('/recaps', recapsRoute);
+```
+
+- [ ] **Step 8: Run tests + lint + typecheck**
+
+```bash
+cd apps/api && pnpm exec jest src/routes/recaps.test.ts src/routes/recaps.integration.test.ts --no-coverage
+pnpm exec nx run api:lint
+pnpm exec nx run api:typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+`/commit` description: `feat(api): parent-native recaps feed at GET /recaps with family-link scoping`
+
+---
+
+## Task 10: Recaps mobile screen + hook
+
+Mobile route `apps/mobile/src/app/(app)/recaps.tsx`. New hook `use-parent-recaps.ts`. Child chips, latest-first feed, empty states, Learn-this-too CTA (CTA target wired in Task 13).
+
+**Files:**
+- Create: `apps/mobile/src/app/(app)/recaps.tsx`
+- Create: `apps/mobile/src/app/(app)/recaps.test.tsx`
+- Create: `apps/mobile/src/hooks/use-parent-recaps.ts`
+- Create: `apps/mobile/src/hooks/use-parent-recaps.test.ts`
+- Create: `apps/mobile/src/lib/engagement-signal-copy.ts` (translation-keyed engagement labels)
+
+- [ ] **Step 0: Ship the `useLearnThisToo` stub (so Task 10 compiles before Task 13)**
+
+Create `apps/mobile/src/hooks/use-learn-this-too.ts`:
+
+```ts
+// Task 10 stub. Task 13 replaces this with the entitlement-gated mutation.
+export function useLearnThisToo() {
+  return {
+    mutate: (_input: {
+      childProfileId: string;
+      childSessionId: string;
+      subjectId?: string;
+      topicId?: string;
+    }) => { /* no-op until Task 13 */ },
+    isPending: false,
+  };
+}
+```
+
+This keeps the Task 10 commit green on typecheck and tests without merging it with Task 13. Adversarial review §HIGH-6.
+
+- [ ] **Step 1: Engagement signal copy mapping**
+
+`engagement-signal-copy.ts`:
+
+```ts
+import type { EngagementSignal } from '@eduagent/schemas';
+
+// Translation-keyed positive/neutral copy. Maps raw signal to UI string.
+// AC #16 + spec §Engagement signal rules: never "struggled", "weak", "below grade level", "trouble".
+const COPY: Record<EngagementSignal, string> = {
+  curious: 'Curious and engaged',
+  focused: 'Focused',
+  breezing: 'Breezing through',
+  stuck: 'Needs more time',         // mapped from raw "stuck" to gentle label
+  scattered: 'Finding focus',       // mapped from raw "scattered"
+};
+
+export function engagementSignalCopy(signal: EngagementSignal | null): string | null {
+  return signal ? COPY[signal] : null;
+}
+```
+
+Add a co-located test that asserts no banned phrase appears in the COPY values:
+
+```ts
+import { engagementSignalCopy } from './engagement-signal-copy';
+import { ENGAGEMENT_SIGNALS } from '@eduagent/schemas';
+
+const BANNED = /struggl|weak|trouble|below grade|declining/i;
+
+test('no engagement copy contains banned negative-framing phrases', () => {
+  for (const s of ENGAGEMENT_SIGNALS) {
+    const copy = engagementSignalCopy(s);
+    expect(copy).not.toMatch(BANNED);
+  }
+});
+```
+
+This is a forward-only guard (per CLAUDE.md "Fix Development Rules" → sweep). Add it now so future signal additions are checked.
+
+- [ ] **Step 2: Hook**
+
+`use-parent-recaps.ts`:
+
+```ts
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { client } from '../lib/api-client';
+import type { ParentRecapFeedItem } from '@eduagent/schemas';
+
+export function useParentRecaps(opts: { childProfileId?: string }) {
+  return useInfiniteQuery({
+    queryKey: ['recaps', /* parentProfileId */, opts.childProfileId ?? 'all'],
+    queryFn: async ({ pageParam }) => {
+      const res = await client.recaps.$get({
+        query: {
+          childProfileId: opts.childProfileId,
+          cursor: pageParam,
+          limit: 20,
+        },
+      });
+      if (!res.ok) throw new Error('recaps-fetch-failed');
+      return res.json() as Promise<{ items: ParentRecapFeedItem[]; nextCursor: string | null }>;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+  });
+}
+```
+
+The `parentProfileId` must be in the query key — leak invariant. Inject via `useActiveProfile()` or equivalent.
+
+- [ ] **Step 3: Screen**
+
+`recaps.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { View, Text, FlatList, Pressable } from 'react-native';
+import { useParentRecaps } from '../../hooks/use-parent-recaps';
+import { useLinkedChildren } from '../../lib/profile';
+import { engagementSignalCopy } from '../../lib/engagement-signal-copy';
+import { ErrorFallback } from '../../components/common/ErrorFallback'; // verified path; existing per CLAUDE.md UX Resilience Rules
+import { useRouter } from 'expo-router';
+// Task 13 ships the real implementation. For Task 10 to compile and commit
+// independently, ship a stub at this path that exposes `mutate` as a no-op:
+//
+//   // apps/mobile/src/hooks/use-learn-this-too.ts (Task 10 stub)
+//   export function useLearnThisToo() {
+//     return { mutate: (_: unknown) => {}, isPending: false };
+//   }
+//
+// Task 13 replaces the stub with the entitlement-gated mutation. The Task 10
+// tests for "Learn this too triggers the hook" can stub `mutate` via
+// jest.spyOn — they don't depend on the real implementation existing yet.
+// (Adversarial review §HIGH-6.)
+import { useLearnThisToo } from '../../hooks/use-learn-this-too';
+
+export default function RecapsScreen() {
+  const router = useRouter();
+  const children = useLinkedChildren();
+  const [selectedChildId, setSelectedChildId] = useState<string | undefined>(undefined);
+  const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, refetch } =
+    useParentRecaps({ childProfileId: selectedChildId });
+  const learnThisToo = useLearnThisToo();
+
+  if (error) {
+    return <ErrorFallback onRetry={refetch} onBack={() => router.replace('/(app)/home')} />;
+  }
+
+  const items = data?.pages.flatMap((p) => p.items) ?? [];
+
+  return (
+    <View testID="recaps-screen">
+      <Text>Recaps</Text>
+      <Text>What your kids studied</Text>
+
+      <FlatList
+        testID="recaps-child-chips"
+        horizontal
+        data={[{ id: undefined, displayName: 'All' }, ...children.map((c) => ({ id: c.id, displayName: c.displayName }))]}
+        keyExtractor={(c) => c.id ?? 'all'}
+        renderItem={({ item }) => (
+          <Pressable
+            testID={`recaps-chip-${item.id ?? 'all'}`}
+            onPress={() => setSelectedChildId(item.id)}
+            accessibilityState={{ selected: selectedChildId === item.id }}
+          >
+            <Text>{item.displayName}</Text>
+          </Pressable>
+        )}
+      />
+
+      {items.length === 0 && !isLoading && (
+        <Text testID="recaps-empty">
+          {selectedChildId
+            ? `${children.find((c) => c.id === selectedChildId)?.displayName ?? 'This child'} hasn't completed a session yet.`
+            : 'Recaps appear after your children study.'}
+        </Text>
+      )}
+
+      <FlatList
+        testID="recaps-feed"
+        data={items}
+        keyExtractor={(r) => r.id}
+        onEndReached={() => hasNextPage && !isFetchingNextPage && fetchNextPage()}
+        renderItem={({ item }) => (
+          <View testID={`recap-card-${item.id}`}>
+            <Text>{item.childDisplayName} • {item.subjectName ?? '—'}</Text>
+            <Text>{item.topicTitle ?? '—'}</Text>
+            <Text>{new Date(item.completedAt).toLocaleString()}</Text>
+            <Text>{item.activeDurationMinutes ? `${item.activeDurationMinutes} min` : ''}</Text>
+            {item.narrative && <Text>{item.narrative}</Text>}
+            {item.conversationPrompt && <Text>Ask: {item.conversationPrompt}</Text>}
+            {item.engagementSignal && <Text>{engagementSignalCopy(item.engagementSignal)}</Text>}
+            <Pressable
+              testID={`recap-learn-this-too-${item.id}`}
+              onPress={() => learnThisToo.mutate({
+                childProfileId: item.childProfileId,
+                childSessionId: item.sessionId,
+                subjectId: item.subjectId ?? undefined,
+                topicId: item.topicId ?? undefined,
+              })}
+            >
+              <Text>Learn this too</Text>
+            </Pressable>
+            <Pressable
+              testID={`recap-open-detail-${item.id}`}
+              onPress={() => router.push({
+                pathname: '/(app)/child/[profileId]/session/[sessionId]',
+                params: { profileId: item.childProfileId, sessionId: item.sessionId, returnTo: 'family-recaps' },
+              })}
+            >
+              <Text>Open recap detail</Text>
+            </Pressable>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+```
+
+- [ ] **Step 4: Tests**
+
+`recaps.test.tsx`:
+
+```tsx
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import RecapsScreen from './recaps';
+
+describe('RecapsScreen', () => {
+  it('renders all-child feed by default with chips', async () => {
+    // seed query cache with 2 items across 2 children
+    const { getByTestId, findAllByTestId } = render(<RecapsScreen />);
+    expect(getByTestId('recaps-chip-all')).toBeTruthy();
+    expect((await findAllByTestId(/^recap-card-/)).length).toBe(2);
+  });
+
+  it('filters when a child chip is selected', async () => {
+    const { getByTestId, findAllByTestId } = render(<RecapsScreen />);
+    fireEvent.press(getByTestId(`recaps-chip-${childA.id}`));
+    const cards = await findAllByTestId(/^recap-card-/);
+    expect(cards.length).toBe(1);
+  });
+
+  it('renders all-children empty state when no items', async () => {
+    const { getByTestId } = render(<RecapsScreen />); // seed empty
+    expect(getByTestId('recaps-empty').props.children).toMatch(/recaps appear after your children study/i);
+  });
+
+  it('renders per-child empty state when filter selected', async () => {
+    const { getByTestId } = render(<RecapsScreen />);
+    fireEvent.press(getByTestId(`recaps-chip-${childA.id}`));
+    expect(getByTestId('recaps-empty').props.children).toMatch(/hasn't completed a session/i);
+  });
+
+  it('Learn this too triggers the hook with child context', async () => {
+    const { getByTestId } = render(<RecapsScreen />);
+    fireEvent.press(getByTestId(`recap-learn-this-too-${recapId}`));
+    expect(mockLearnThisTooMutate).toHaveBeenCalledWith(expect.objectContaining({
+      childProfileId: childA.id,
+      childSessionId: sessionId,
+    }));
+  });
+
+  it('renders translation-keyed engagement copy (not raw)', async () => {
+    // seed item with engagementSignal: 'stuck'
+    const { getByTestId } = render(<RecapsScreen />);
+    const card = getByTestId(`recap-card-${id}`);
+    expect(card).toHaveTextContent('Needs more time');
+    expect(card).not.toHaveTextContent('stuck');
+    expect(card).not.toHaveTextContent(/struggl/i);
+  });
+
+  it('shows ErrorFallback on fetch error', async () => {
+    // arrange: hook returns error
+    const { getByTestId } = render(<RecapsScreen />);
+    expect(getByTestId('error-fallback')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/recaps.tsx src/hooks/use-parent-recaps.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+`/commit` description: `feat(mobile): Recaps screen with child filter, latest-first feed, empty + error states`
+
+---
+
+## Task 11: Progress context filtering
+
+Family Progress: child/family only, no parent self picker. Study Progress: self only. Add explicit "Family Progress" vs "My Progress" header copy. Spec ACs #10, #11.
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/progress/index.tsx:493-557` (profile picker logic)
+- Modify: co-located test
+
+- [ ] **Step 1: Read the current picker logic**
+
+The existing logic uses `selectedProfileId` (line 509) and `isViewingSelf` (line 538). The picker offers all profiles. The new behavior:
+
+| Mode | Picker includes self? | Picker includes children? | Header |
+|------|-----------------------|---------------------------|--------|
+| Study | yes (always) | no | "My Progress" |
+| Family | no | yes (all visible children) | "Family Progress" |
+| Proxy override | child only | n/a | (existing proxy chrome) |
+
+- [ ] **Step 2: Write failing tests**
+
+In `progress/index.test.tsx`:
+
+```tsx
+describe('ProgressScreen — context filtering', () => {
+  it('Family mode: picker contains children only, not parent self', () => {
+    const { queryByTestId, getByTestId } = renderProgress({ mode: 'family' });
+    expect(getByTestId(`progress-picker-child-${childA.id}`)).toBeTruthy();
+    expect(getByTestId(`progress-picker-child-${childB.id}`)).toBeTruthy();
+    expect(queryByTestId(`progress-picker-self`)).toBeNull();
+  });
+
+  it('Study mode: picker contains self only, no child rows', () => {
+    const { queryByTestId, getByTestId } = renderProgress({ mode: 'study' });
+    expect(getByTestId('progress-picker-self')).toBeTruthy();
+    expect(queryByTestId(/^progress-picker-child-/)).toBeNull();
+  });
+
+  it('Family mode header reads "Family Progress"', () => {
+    const { getByTestId } = renderProgress({ mode: 'family' });
+    expect(getByTestId('progress-header')).toHaveTextContent('Family Progress');
+  });
+
+  it('Study mode header reads "My Progress"', () => {
+    const { getByTestId } = renderProgress({ mode: 'study' });
+    expect(getByTestId('progress-header')).toHaveTextContent('My Progress');
+  });
+
+  it('Family Progress query key includes app context + child filter', () => {
+    // assert via spy on useQuery / queryKey shape
+  });
+});
+```
+
+- [ ] **Step 3: Implement the filtering**
+
+In `progress/index.tsx`, derive `mode` from active profile + context:
+
+```ts
+const mode: 'study' | 'family' = isParentProxy
+  ? 'study'
+  : activeProfile?.defaultAppContext === 'family' && isFamilyCapableProfile(activeProfile)
+    ? 'family'
+    : 'study';
+
+const eligibleProfiles = mode === 'family'
+  ? linkedChildren                       // children only
+  : [activeProfile].filter(Boolean);     // self only
+
+const headerLabel = mode === 'family' ? 'Family Progress' : 'My Progress';
+```
+
+Update the pill/picker row to render `eligibleProfiles`. Update the header copy. Update the query keys that fetch progress data to include `mode` and the effective profile/child id:
+
+```ts
+useQuery({
+  queryKey: ['progress', mode, selectedProfileId, /* parentProfileId for family */],
+  // ...
+});
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/progress/index.tsx --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+`/commit` description: `feat(mobile): Progress mode-aware filtering — Family shows children only, Study shows self only`
+
+---
+
+## Task 12: Hide proxy from normal parent UX
+
+Spec §Proxy Handling — Phase 1. Remove "View account" path from `profiles.tsx`. Repoint to Recaps/Progress/child-detail. Synthetic proxy unit tests stay green.
+
+**Files:**
+- Modify: `apps/mobile/src/app/profiles.tsx:259-378`
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx:180-238` (ProxyBanner switch-back must `router.replace`)
+- Test: `apps/mobile/src/app/profiles.test.tsx`
+
+- [ ] **Step 0: Audit every `switchProfile(` callsite (adversarial review §HIGH-9)**
+
+Removing one entry point doesn't remove proxy capability. Grep `apps/mobile/src/` for `switchProfile(` and classify each callsite in the PR description:
+
+| File:line | Type | Verdict |
+|-----------|------|---------|
+| (audit output) | adult↔adult switch | keep |
+| (audit output) | parent→child proxy | repoint at parent-native route |
+| (audit output) | test-only synthetic | keep, asserted in Step 4 |
+
+Any callsite classified as "parent→child proxy" outside the explicitly-retained `ProxyBanner` flow must be repointed before the task completes. Use Grep with pattern `switchProfile\s*\(` in `apps/mobile/src/`. Notification handlers (Task 15), child cards (Task 8), and deep-link handlers are the highest-risk surfaces.
+
+- [ ] **Step 1: Write failing tests**
+
+In `profiles.test.tsx`:
+
+```tsx
+it('end-user profile row tap does not open a "View account" proxy modal', () => {
+  const { queryByText, getByTestId } = render(<ProfilesScreen />);
+  fireEvent.press(getByTestId(`profile-row-${childId}`));
+  expect(queryByText(/view account/i)).toBeNull();
+  expect(mockSwitchProfile).not.toHaveBeenCalledWith(childId, expect.objectContaining({ asProxy: true }));
+});
+
+it('end-user profile row tap navigates to parent-native child detail (Family) or own profile detail (Study)', () => {
+  // arrange: active profile is owner with family capability
+  const { getByTestId } = render(<ProfilesScreen />);
+  fireEvent.press(getByTestId(`profile-row-${childId}`));
+  expect(mockRouterPush).toHaveBeenCalledWith({
+    pathname: '/(app)/child/[profileId]',
+    params: { profileId: childId },
+  });
+});
+
+it('ProxyBanner Switch Back calls switchProfile and router.replace to canonical adult root', async () => {
+  // simulate isParentProxy = true
+  const { getByText } = render(<ProxyBanner childName="A" onSwitchBack={onSwitchBack} />);
+  fireEvent.press(getByText(/switch back/i));
+  expect(onSwitchBack).toHaveBeenCalled();
+  // and the caller (in _layout.tsx) must router.replace('/(app)/home') after the profile mutation succeeds
+});
+```
+
+- [ ] **Step 2: Remove "View account" flow**
+
+In `profiles.tsx:337-378`, delete the modal and the proxy entry path. Replace the row press handler:
+
+```tsx
+const onProfileRowPress = (target: Profile) => {
+  if (target.id === activeProfile?.id) return; // tapping self is a no-op or opens profile settings
+  if (target.isOwner) {
+    // switch to that owner profile (normal profile switch, not proxy)
+    switchProfile(target.id);
+    return;
+  }
+  // Non-owner (child) profile: navigate to parent-native child detail; do not switch profile.
+  router.push({ pathname: '/(app)/child/[profileId]', params: { profileId: target.id } });
+};
+```
+
+- [ ] **Step 3: Make ProxyBanner switch-back use `router.replace`**
+
+In `_layout.tsx:180-238`, the `ProxyBanner` is currently presentational. The `onSwitchBack` caller (the `_layout` body that wires the banner) currently calls `switchProfile(parentProfile.id)`. Wrap that call:
+
+```ts
+const onProxyExit = async () => {
+  await switchProfileMutation.mutateAsync(parentProfile.id);
+  router.replace('/(app)/home'); // canonical adult root; mode-aware home renders ParentHome or LearnerScreen
+};
+
+return <ProxyBanner childName={childProfile.displayName} onSwitchBack={onProxyExit} />;
+```
+
+This satisfies spec §Navigation Contract → "Proxy exit" and AC #30/32/33 (no stale child detail in back stack).
+
+- [ ] **Step 4: Keep synthetic proxy tests alive**
+
+Search:
+
+```bash
+```
+
+Use Grep with pattern `isParentProxy` in `apps/mobile/src/`. For each remaining test that asserts proxy behavior, verify the test still passes by synthesizing the proxy state (e.g., seeding `useParentProxy` mock or testing the `ProxyBanner` component directly). Per spec AC #23, retain those tests. They satisfy the "proxy chrome wins when isParentProxy is true" invariant even after end-user paths are removed.
+
+- [ ] **Step 5: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/profiles.tsx src/app/\(app\)/_layout.tsx --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+`/commit` description: `feat(mobile): remove "View account" proxy entry from normal profile picker; ProxyBanner switch-back uses router.replace`
+
+---
+
+## Task 13: Learn this too — quota pre-check + same-account Study switch
+
+The bridge from a child recap to adult Study. Pre-check adult entitlement before patching mode. Spec §Learn This Too Contract + AC #17/18/19/28.
+
+**Files:**
+- Create: `apps/mobile/src/hooks/use-learn-this-too.ts`
+- Create: `apps/mobile/src/hooks/use-learn-this-too.test.ts`
+- Possibly extend: `apps/api/src/routes/entitlement.ts` (or whichever existing endpoint exposes quota check). If none exists, the spec footnote points to `createProfileWithLimitCheck()` — that's profile-creation-specific, not session quota. Verify with research.
+
+- [ ] **Step 1: Add `GET /entitlement/study` (decision: option (a) per adversarial review §HIGH-8)**
+
+The existing quota predicate lives in `apps/api/src/middleware/metering.ts` (confirmed via grep). Expose it as a read-only HTTP endpoint. Option (b) — reusing session-start with `dryRun` — was rejected: it risks mutating metering counters and idempotency state if `dryRun` is ever wired imperfectly.
+
+Spec for the new endpoint:
+
+```ts
+// apps/api/src/routes/entitlement.ts
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { canStartSession } from '../middleware/metering'; // factor out the predicate
+
+export const entitlementSchema = z.object({
+  canStart: z.boolean(),
+  reason: z.enum(['daily-cap', 'monthly-cap', 'subscription']).optional(),
+});
+
+export const entitlementRoute = new Hono().get('/study', async (c) => {
+  const accountId = c.get('account').id;
+  const profileId = c.get('profileId');
+  const result = await canStartSession(c.get('db'), { accountId, profileId });
+  return c.json(entitlementSchema.parse(result));
+});
+```
+
+Wire `entitlementRoute` at `/entitlement` in `apps/api/src/index.ts`. The route is read-only — no metering counter increments, no idempotency-key writes, no Inngest dispatches.
+
+Add a service-side test that `canStartSession` is purely read-only (no mutations).
+
+- [ ] **Step 2: Write failing hook tests**
+
+```ts
+describe('useLearnThisToo', () => {
+  it('blocks before mode change when adult quota is exhausted', async () => {
+    // arrange: entitlement endpoint returns canStart: false, reason: 'daily-cap'
+    const { result } = renderHook(() => useLearnThisToo());
+    await act(() => result.current.mutateAsync({ childProfileId: 'c1', childSessionId: 's1' }));
+    expect(showQuotaExceededUI).toHaveBeenCalled();
+    expect(modeSwitchMutation.mutate).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(trackedEvents).toContainEqual({ name: 'learn_this_too_quota_blocked', /* props */ });
+  });
+
+  it('patches defaultAppContext=study then router.replaces to a Study entry with StudySourceContext', async () => {
+    // arrange: entitlement canStart: true
+    const { result } = renderHook(() => useLearnThisToo());
+    await act(() => result.current.mutateAsync({
+      childProfileId: 'c1', childSessionId: 's1', subjectId: 'sub1', topicId: 't1',
+    }));
+    expect(patchProfile).toHaveBeenCalledWith({ defaultAppContext: 'study' });
+    expect(mockRouterReplace).toHaveBeenCalledWith({
+      pathname: '/(app)/home', // or the Study entry route
+      params: expect.objectContaining({
+        studySource: 'child-recap',
+        childProfileId: 'c1',
+        childSessionId: 's1',
+        subjectId: 'sub1',
+        topicId: 't1',
+      }),
+    });
+    expect(trackedEvents).toContainEqual(expect.objectContaining({ name: 'learn_this_too_tapped' }));
+  });
+
+  it('writes happen on adult profile only — child IDs are metadata, never write scope', () => {
+    // arrange + assert: profile/session writes initiated subsequently use activeProfile.id, not childProfileId
+  });
+});
+```
+
+- [ ] **Step 3: Implement the hook**
+
+```ts
+// use-learn-this-too.ts
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import { client } from '../lib/api-client';
+import { track, hashProfileId } from '../lib/analytics';
+import { useActiveProfile } from './use-active-profile'; // assumed exists; locate exact path
+import type { StudySourceContext } from '@eduagent/schemas';
+
+export function useLearnThisToo() {
+  const router = useRouter();
+  const { activeProfile } = useActiveProfile();
+
+  return useMutation({
+    mutationFn: async (input: {
+      childProfileId: string;
+      childSessionId: string;
+      subjectId?: string;
+      topicId?: string;
+    }) => {
+      if (!activeProfile) throw new Error('no-active-profile');
+
+      track('learn_this_too_tapped', {
+        profileIdHash: hashProfileId(activeProfile.id),
+        hasSubject: Boolean(input.subjectId),
+      });
+
+      // Quota/entitlement pre-check
+      const ent = await client.entitlement.study.$get();
+      const entBody = await ent.json();
+      if (!entBody.canStart) {
+        track('learn_this_too_quota_blocked', {
+          profileIdHash: hashProfileId(activeProfile.id),
+          reason: entBody.reason,
+        });
+        showQuotaExceededUI(entBody.reason); // existing UI per CLAUDE.md UX Resilience Rules
+        return { blocked: true as const, reason: entBody.reason };
+      }
+
+      // Patch mode
+      await client.profiles[':id'].$patch({
+        param: { id: activeProfile.id },
+        json: { defaultAppContext: 'study' },
+      });
+
+      // Navigate with source context
+      router.replace({
+        pathname: '/(app)/home',
+        params: {
+          studySource: 'child-recap',
+          childProfileId: input.childProfileId,
+          childSessionId: input.childSessionId,
+          ...(input.subjectId ? { subjectId: input.subjectId } : {}),
+          ...(input.topicId ? { topicId: input.topicId } : {}),
+        },
+      });
+
+      return { blocked: false as const };
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Add `StudySourceContext` to the shared schemas**
+
+In `packages/schemas/src/recaps.ts` (already created in Task 9), add:
+
+```ts
+export const studySourceContextSchema = z.object({
+  source: z.literal('child-recap'),
+  childProfileId: z.string().uuid(),
+  childSessionId: z.string().uuid(),
+  subjectId: z.string().uuid().optional(),
+  topicId: z.string().uuid().optional(),
+});
+
+export type StudySourceContext = z.infer<typeof studySourceContextSchema>;
+```
+
+- [ ] **Step 5: Read `StudySourceContext` on the Study entry route**
+
+In `home.tsx` (or `LearnerScreen.tsx`), parse `useLocalSearchParams()` for `studySource === 'child-recap'`. If present, render a lightweight "Learn the basics" confirmation entry rather than silently creating a subject/book. Hand off the params to the existing learner entry flow.
+
+Crucially: the create-session/create-subject mutations must continue to scope writes to `activeProfile.id`. `StudySourceContext` is metadata only. Add a defensive assertion in the entry route:
+
+```ts
+useEffect(() => {
+  if (params.studySource === 'child-recap') {
+    // assert never sent to any write call
+  }
+}, [params.studySource]);
+```
+
+- [ ] **Step 6: Server-side break test**
+
+Add to `apps/api/src/routes/sessions.test.ts` (or wherever session writes are tested):
+
+```ts
+it('session create writes adult profileId even when the request body contains a child id metadata field', async () => {
+  const res = await app.request('/sessions', {
+    method: 'POST',
+    headers: { 'X-Profile-Id': adultId },
+    body: JSON.stringify({
+      subjectId,
+      topicId,
+      // intentional payload pollution:
+      studySourceChildProfileId: childId,
+    }),
+  });
+  const session = (await res.json()).session;
+  expect(session.profileId).toBe(adultId);
+  expect(session.profileId).not.toBe(childId);
+});
+
+it('the session-create request schema explicitly rejects studySourceChildProfileId (defense-in-depth)', () => {
+  // Adversarial review §MEDIUM-4: don't rely on Zod's default strip mode silently
+  // dropping the field — that protection vanishes the day someone adds .passthrough().
+  // Test the schema directly.
+  const { sessionCreateSchema } = require('@eduagent/schemas');
+  const parsed = sessionCreateSchema.safeParse({
+    subjectId: 'a', topicId: 'b', studySourceChildProfileId: 'c',
+  });
+  // Either: strict mode rejects, OR strip mode produces output without the polluting key
+  if (parsed.success) {
+    expect(parsed.data).not.toHaveProperty('studySourceChildProfileId');
+  }
+});
+```
+
+- [ ] **Step 7: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/hooks/use-learn-this-too.ts src/app/\(app\)/recaps.tsx --no-coverage
+cd apps/api && pnpm exec jest --findRelatedTests src/routes/sessions.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx run api:typecheck
+```
+
+- [ ] **Step 8: Commit**
+
+`/commit` description: `feat(mobile,api): Learn this too — adult quota pre-check, mode patch, router.replace into Study with StudySourceContext`
+
+---
+
+## Task 14: `own-learning.tsx` route survival
+
+Per spec §Route Survival: the top-level Own Learning tab is removed from Family mode, but the route survives as a compatibility/deep-link bridge that redirects eligible adults into Study mode.
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/own-learning.tsx`
+- Test: co-located
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+it('eligible adult opens /(app)/own-learning → switches to Study and replaces to /(app)/home', async () => {
+  // arrange: family-capable adult in Family mode
+  render(<OwnLearningScreen />);
+  await waitFor(() => {
+    expect(patchProfile).toHaveBeenCalledWith({ defaultAppContext: 'study' });
+    expect(mockRouterReplace).toHaveBeenCalledWith('/(app)/home');
+  });
+});
+
+it('Study-only user opens /(app)/own-learning → routes to /(app)/home (no mode patch)', async () => {
+  render(<OwnLearningScreen />);
+  await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/(app)/home'));
+  expect(patchProfile).not.toHaveBeenCalled();
+});
+
+it('ineligible non-owner (child profile) opens /(app)/own-learning → no-access fallback returning to Family home', async () => {
+  // arrange: active profile is a child on shared parent account
+  render(<OwnLearningScreen />);
+  expect(screen.getByTestId('own-learning-no-access')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Implement the bridge**
+
+Replace `own-learning.tsx` body with:
+
+```tsx
+import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { useActiveProfile } from '../../hooks/use-active-profile';
+import { isFamilyCapableProfile } from '../../lib/profile';
+import { useModeSwitch } from '../../hooks/use-mode-switch';
+import { View, Text, Pressable } from 'react-native';
+
+export default function OwnLearningRedirect() {
+  const router = useRouter();
+  const { activeProfile } = useActiveProfile();
+  const modeSwitch = useModeSwitch(activeProfile);
+
+  useEffect(() => {
+    if (!activeProfile) return;
+    if (activeProfile.defaultAppContext === 'family' && isFamilyCapableProfile(activeProfile)) {
+      // Adversarial review §HIGH-2: useModeSwitch.onSuccess only navigates when
+      // the current pathname is in FAMILY_ONLY_ROUTES. /own-learning is not in
+      // that list, so this bridge must drive its own router.replace after the
+      // mutation resolves.
+      modeSwitch.mutateAsync('study')
+        .then(() => router.replace('/(app)/home'))
+        .catch(() => router.replace('/(app)/home')); // even on failure, don't strand the user
+      return;
+    }
+    if (activeProfile.isOwner) {
+      router.replace('/(app)/home');
+      return;
+    }
+    // non-owner child profile: no-access fallback handled below
+  }, [activeProfile, modeSwitch, router]);
+
+  if (activeProfile && !activeProfile.isOwner) {
+    return (
+      <View>
+        <Text testID="own-learning-no-access">This space is for adult owners only.</Text>
+        <Pressable onPress={() => router.replace('/(app)/home')}>
+          <Text>Back to Family home</Text>
+        </Pressable>
+      </View>
+    );
+  }
+  return null;
+}
+```
+
+- [ ] **Step 3: Confirm the route is hidden from Family/Study tab bars**
+
+In `_layout.tsx`, ensure `own-learning` is not in `STUDY_TABS` or `FAMILY_TABS` (it is not, per Task 1). The Tabs.Screen entry for `own-learning` (if it exists) should use `href: null` + `display: 'none'` so it remains a deep-linkable route without appearing in either tab bar.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/own-learning.tsx --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+`/commit` description: `feat(mobile): own-learning.tsx becomes a Study-mode redirect bridge for deep links`
+
+---
+
+## Task 15: Notification routing — explicit context transitions
+
+Parent/family push taps switch into Family mode and replace into Recaps. During an active full-screen Study session, prompt/queue rather than silently interrupt. Spec §Technical Decisions + AC #29.
+
+**Files:**
+- Modify: `apps/mobile/src/hooks/use-notification-response-handler.ts`
+- Test: co-located
+
+- [ ] **Step 1: Identify notification types that should land in Family**
+
+Read `use-notification-response-handler.ts:23-51`. Existing case: `type === 'nudge'`. Add cases for parent-facing notifications:
+
+- `type === 'child_session_recap'` → Family + Recaps detail
+- `type === 'family_progress'` → Family + Progress
+
+Confirm what notification types the backend sends by Grepping `inngest.send` / `pushNotification` in `apps/api/src/inngest/`. Spec lists `weekly-progress-push.ts` and `recall-nudge-send.ts` as references.
+
+- [ ] **Step 2: Write failing test**
+
+```ts
+it('child_session_recap tap while in Study switches to Family and replaces to Recaps detail', async () => {
+  const handler = renderHookAndExtractHandler();
+  await handler({
+    notification: { request: { content: { data: { type: 'child_session_recap', childProfileId: 'c1', sessionId: 's1' } } } },
+  });
+  expect(patchProfile).toHaveBeenCalledWith({ defaultAppContext: 'family' });
+  expect(mockRouterReplace).toHaveBeenCalledWith({
+    pathname: '/(app)/child/[profileId]/session/[sessionId]',
+    params: { profileId: 'c1', sessionId: 's1', returnTo: 'family-recaps' },
+  });
+});
+
+it('child_session_recap tap during an active full-screen Study session prompts/queues instead of replacing', async () => {
+  // arrange: useActiveSession returns { isActive: true, isFullScreen: true }
+  await handler({ notification: { /* same */ } });
+  expect(showInterruptPrompt).toHaveBeenCalled();
+  expect(mockRouterReplace).not.toHaveBeenCalled();
+});
+
+it('family_progress tap while in Family stays in Family and replaces to Progress', async () => {
+  await handler({ notification: { request: { content: { data: { type: 'family_progress' } } } } });
+  expect(mockRouterReplace).toHaveBeenCalledWith('/(app)/progress');
+});
+```
+
+- [ ] **Step 3: Implement**
+
+```ts
+case 'child_session_recap': {
+  const { childProfileId, sessionId } = data;
+  if (isFullScreenStudySessionActive()) {
+    showInterruptPrompt({
+      onConfirm: () => completeFamilyTransition({ childProfileId, sessionId }),
+    });
+    return;
+  }
+  await completeFamilyTransition({ childProfileId, sessionId });
+  break;
+}
+
+async function completeFamilyTransition({ childProfileId, sessionId }) {
+  if (activeProfile && isFamilyCapableProfile(activeProfile) && activeProfile.defaultAppContext !== 'family') {
+    await modeSwitch.mutateAsync('family');
+  }
+  router.replace({
+    pathname: '/(app)/child/[profileId]/session/[sessionId]',
+    params: { profileId: childProfileId, sessionId, returnTo: 'family-recaps' },
+  });
+}
+```
+
+`isFullScreenStudySessionActive()` reads the existing session UI state. If no such helper exists, add a small selector against the session store/context.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/hooks/use-notification-response-handler.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+`/commit` description: `feat(mobile): notification taps switch context explicitly; prompt during active Study sessions`
+
+---
+
+## Task 16: Navigation hardening — extend existing `goBackOrReplace` / `homeHrefForReturnTo` with new return tokens
+
+Spec §Navigation Contract. **Both helpers already exist** at `apps/mobile/src/lib/navigation.ts:16-24` (`homeHrefForReturnTo`) and `apps/mobile/src/lib/navigation.ts:26-36` (`goBackOrReplace`). Adversarial review §CRITICAL-1 / §MEDIUM-1: do NOT create parallel implementations. Extend in place, keep the existing `Href` return type and `string | string[] | undefined` token shape (deep-link params are arrays).
+
+**Files:**
+- Modify: `apps/mobile/src/lib/navigation.ts` (extend existing tokens + switch)
+- Modify: `apps/mobile/src/lib/navigation.test.ts` (extend existing tests)
+- Modify: every detail screen that currently uses bare `router.back()` — locate via Grep
+
+- [ ] **Step 1: Audit existing tokens and consumers**
+
+Read `navigation.ts` end-to-end. Existing tokens: `'own-learning'`, `'learner-home'`, `'practice'`. Search for every `returnTo=` and `homeHrefForReturnTo(...)` call site:
+
+Use Grep with pattern `homeHrefForReturnTo|returnTo=|returnTo:` in `apps/mobile/src/`. Catalogue every token currently in use. The new tokens MUST not collide with these.
+
+- [ ] **Step 2: Add new return tokens + extend `homeHrefForReturnTo`**
+
+Append to `navigation.ts`:
+
+```ts
+export const FAMILY_RECAPS_RETURN_TO = 'family-recaps';
+export const FAMILY_RECAPS_HREF = '/(app)/recaps';
+export const FAMILY_PROGRESS_RETURN_TO = 'family-progress';
+export const FAMILY_PROGRESS_HREF = '/(app)/progress';
+export const STUDY_PROGRESS_RETURN_TO = 'study-progress';
+export const STUDY_PROGRESS_HREF = '/(app)/progress';
+export const FAMILY_CHILDREN_RETURN_TO = 'family-children';
+export const FAMILY_CHILDREN_HREF = '/(app)/home';
+```
+
+Extend `homeHrefForReturnTo` to switch on the new tokens. Keep its existing signature `(returnTo: string | string[] | undefined): Href` — deep-link params can be `string[]`:
+
+```ts
+export function homeHrefForReturnTo(
+  returnTo: string | string[] | undefined,
+): Href {
+  const token = firstParam(returnTo);
+  if (token === OWN_LEARNING_RETURN_TO) return OWN_LEARNING_HREF as Href;
+  if (token === LEARNER_HOME_RETURN_TO) return LEARNER_HOME_HREF as Href;
+  if (token === PRACTICE_RETURN_TO) return PRACTICE_HREF as Href;
+  if (token === FAMILY_RECAPS_RETURN_TO) return FAMILY_RECAPS_HREF as Href;
+  if (token === FAMILY_PROGRESS_RETURN_TO) return FAMILY_PROGRESS_HREF as Href;
+  if (token === STUDY_PROGRESS_RETURN_TO) return STUDY_PROGRESS_HREF as Href;
+  if (token === FAMILY_CHILDREN_RETURN_TO) return FAMILY_CHILDREN_HREF as Href;
+  return '/(app)/home' as Href;
+}
+```
+
+`goBackOrReplace` already exists with the right shape — do NOT modify its signature. Call sites pass `homeHrefForReturnTo(params.returnTo)` to get the fallback `Href`.
+
+- [ ] **Step 3: Extend tests (do not duplicate)**
+
+In the existing `navigation.test.ts`, add cases for each new token. Do not re-author the existing `goBackOrReplace` tests — they are already correct.
+
+```ts
+import {
+  homeHrefForReturnTo,
+  FAMILY_RECAPS_RETURN_TO,
+  FAMILY_RECAPS_HREF,
+  FAMILY_PROGRESS_RETURN_TO,
+  FAMILY_PROGRESS_HREF,
+  STUDY_PROGRESS_RETURN_TO,
+  FAMILY_CHILDREN_RETURN_TO,
+} from './navigation';
+
+describe('homeHrefForReturnTo — Study/Family tokens', () => {
+  it('resolves family-recaps token', () => {
+    expect(homeHrefForReturnTo(FAMILY_RECAPS_RETURN_TO)).toBe(FAMILY_RECAPS_HREF);
+  });
+  it('resolves family-progress token', () => {
+    expect(homeHrefForReturnTo(FAMILY_PROGRESS_RETURN_TO)).toBe(FAMILY_PROGRESS_HREF);
+  });
+  it('resolves study-progress token (same href, different intent)', () => {
+    expect(homeHrefForReturnTo(STUDY_PROGRESS_RETURN_TO)).toBe('/(app)/progress');
+  });
+  it('resolves family-children token to home', () => {
+    expect(homeHrefForReturnTo(FAMILY_CHILDREN_RETURN_TO)).toBe('/(app)/home');
+  });
+  it('accepts string[] from deep-link params (first element wins)', () => {
+    expect(homeHrefForReturnTo([FAMILY_RECAPS_RETURN_TO])).toBe(FAMILY_RECAPS_HREF);
+  });
+  it('falls back to /(app)/home for unknown token', () => {
+    expect(homeHrefForReturnTo('totally-bogus')).toBe('/(app)/home');
+  });
+});
+```
+
+- [ ] **Step 4: Apply in detail screens**
+
+Use Grep with pattern `router\.back\(\)` in `apps/mobile/src/app/`. For each match, identify the natural fallback href for that screen's context, then convert to:
+
+```ts
+goBackOrReplace(router, homeHrefForReturnTo(params.returnTo) ?? FAMILY_RECAPS_HREF);
+```
+
+Priority detail screens to update:
+- `apps/mobile/src/app/(app)/child/[profileId]/session/[sessionId].tsx` → fallback `FAMILY_RECAPS_HREF`
+- `apps/mobile/src/app/(app)/progress/[profileId]/...` → fallback `FAMILY_PROGRESS_HREF` or `STUDY_PROGRESS_HREF` depending on the rendered mode
+- Any recap-related detail screen added later
+
+A returned `Href` from `homeHrefForReturnTo` is never undefined, so the screen passes it directly to `goBackOrReplace` — no separate enum/record lookup required.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/navigation.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+`/commit` description: `feat(mobile): typed return targets + goBackOrReplace; refactor detail-screen back handlers`
+
+---
+
+## Task 17: Analytics events
+
+Required events: `mode_intent_chosen`, `mode_switched`, `learn_this_too_tapped`, `learn_this_too_quota_blocked`, `learn_this_too_completed`. All properties hashed/safe.
+
+**Files:** already touched in Tasks 6, 7, 13. This task is a sweep + a single test that all five events fire from their respective code paths with safe properties.
+
+- [ ] **Step 1: Add a forward-only analytics test**
+
+In `apps/mobile/src/lib/analytics.test.ts` (extend or create):
+
+```ts
+import { __getRecordedEvents, __resetRecordedEvents, track } from './analytics';
+
+beforeEach(() => __resetRecordedEvents());
+
+test('analytics event names are stable + properties never include raw profile ids or free-text PII', () => {
+  track('mode_intent_chosen', { intent: 'study' });
+  track('mode_switched', { from: 'study', to: 'family', profileIdHash: 'v2_abcd' });
+  track('learn_this_too_tapped', { profileIdHash: 'v2_abcd', hasSubject: true });
+  track('learn_this_too_quota_blocked', { profileIdHash: 'v2_abcd', reason: 'daily-cap' });
+  track('learn_this_too_completed', { profileIdHash: 'v2_abcd' });
+
+  const events = __getRecordedEvents();
+  for (const e of events) {
+    const json = JSON.stringify(e.properties);
+    expect(json).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}/i); // no raw UUIDs
+    if ('profileIdHash' in (e.properties ?? {})) {
+      expect((e.properties as any).profileIdHash).toMatch(/^v2_/);
+    }
+  }
+});
+```
+
+`__getRecordedEvents` / `__resetRecordedEvents` may need to be added as test hooks in `analytics.ts` if not already present. Use the existing Sentry breadcrumb capture pattern.
+
+- [ ] **Step 2: Add `learn_this_too_completed` emission**
+
+In the Study entry route receiving `studySource: 'child-recap'`, fire the completed event after the user actually starts the lightweight entry or confirms the seeded subject. Track only on the success path, not on tap (that's `learn_this_too_tapped`).
+
+- [ ] **Step 3: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/analytics.ts src/hooks/use-mode-switch.ts src/hooks/use-learn-this-too.ts --no-coverage
+```
+
+- [ ] **Step 4: Commit**
+
+`/commit` description: `feat(mobile): wire analytics for mode_intent_chosen / mode_switched / learn_this_too_* with safe props`
+
+---
+
+## Task 18: Leak hardening — query keys + invalidation on mode/profile switch
+
+Spec §Leak Invariants. Update query keys to include effective profile/context/child filter. Invalidate context-specific queries on mode switch.
+
+**Files:**
+- Modify: `use-parent-recaps.ts` (already added in Task 10)
+- Modify: progress queries (Task 11)
+- Modify: dashboard queries
+- Modify: subjects/books queries (if child-scoped)
+- Modify: sessions, reports
+- Modify: `useModeSwitch` onSuccess (Task 7) to invalidate the right keys
+
+- [ ] **Step 1: Inventory existing query keys**
+
+```bash
+```
+
+Use Grep with pattern `queryKey:\s*\[` in `apps/mobile/src/hooks/` and `apps/mobile/src/app/`. List every key. For each, decide:
+
+- **Already context-safe?** (e.g., `['recaps', parentId, childFilter]`) — done.
+- **Profile-scoped?** (e.g., `['progress', profileId]`) — ensure profile id is correct.
+- **Context-leaky?** (e.g., `['dashboard']` with no profile id) — must add profile id and, where the data is mode-specific, context.
+
+Produce an inline list in the PR description.
+
+- [ ] **Step 2: Confirm `useModeSwitch.onSuccess` invalidates scoped (not bare) keys**
+
+Task 7's hook already invalidates scoped keys — `['progress', pid]`, `['dashboard', pid]`, `['recaps', pid]`, `['subjects', pid]`, `['reports', pid]` — per adversarial review §MEDIUM-6. Bare `['progress']`-style invalidations would blow caches across every profile in the session (refetch storm on slow networks).
+
+If any additional context-sensitive caches surface during the Task 18 inventory (Step 1), add them as scoped invalidations to the existing list. Do not regress to bare prefixes.
+
+- [ ] **Step 3: Add a leak-invariant test**
+
+`apps/mobile/src/hooks/use-mode-switch.test.ts` (extend):
+
+```ts
+it('invalidates context-scoped queries on successful mode switch', async () => {
+  // seed cache with stale entries for 'progress', 'recaps', 'dashboard'
+  // act: mutate('family')
+  // assert: those queries are invalidated
+});
+```
+
+Plus a Recaps break test in `apps/api/src/routes/recaps.integration.test.ts` (already in Task 9) for cross-family child IDs.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/hooks/use-mode-switch.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+`/commit` description: `feat(mobile): leak hardening — context-scoped query keys + mode-switch invalidation`
+
+---
+
+## Task 19: Playwright web journeys
+
+Spec §Testing Strategy → Web/Playwright. Web parity for the new flows. Tests live under `apps/web/tests/e2e/` or wherever existing Playwright suites are; locate via Grep for `test.describe`.
+
+**Files:**
+- Create: `apps/web/tests/e2e/study-family-mode.spec.ts` (or extend existing)
+
+- [ ] **Step 1: Locate existing Playwright structure**
+
+```bash
+```
+
+Use Glob `apps/web/**/*.spec.ts` and `tests/**/*.spec.ts`. Identify the pattern for: doppler env (CLAUDE.md: `doppler run -c stg`), Clerk testing token, seed endpoint.
+
+- [ ] **Step 2: Write the journeys**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Study/Family mode navigation', () => {
+  test('Study-only adult: lands in Study tabs, no Recaps tab', async ({ page }) => {
+    await seedAdultWithoutChildren(page);
+    await page.goto('/(app)/home');
+    await expect(page.getByTestId('tab-recaps')).toBeHidden();
+    await expect(page.getByText('My Learning')).toBeVisible();
+  });
+
+  test('Adult with Family intent but no child: sees Family setup, not tabs', async ({ page }) => {
+    await seedAdultWithFamilyIntentNoChild(page);
+    await page.goto('/(app)/home');
+    await expect(page.getByTestId('family-setup-empty')).toBeVisible();
+  });
+
+  test('Family-capable adult: lands in default mode, can switch', async ({ page }) => {
+    await seedFamilyCapableAdult(page, { defaultAppContext: 'family' });
+    await page.goto('/(app)/home');
+    await expect(page.getByText('Children')).toBeVisible();
+    await page.goto('/(app)/more');
+    await page.getByTestId('mode-switch').click();
+    await expect(page.getByText('My Learning')).toBeVisible();
+  });
+
+  test('Family Recaps opens and filters by child', async ({ page }) => {
+    await seedFamilyCapableAdultWithRecaps(page);
+    await page.goto('/(app)/recaps');
+    await expect(page.getByTestId('recap-card-' + recapId)).toBeVisible();
+    await page.getByTestId(`recaps-chip-${childA.id}`).click();
+    await expect(page.getByTestId(`recap-card-${otherChildRecapId}`)).toBeHidden();
+  });
+
+  test('Children tab → child curriculum (no proxy)', async ({ page }) => {
+    await page.goto('/(app)/home');
+    await page.getByTestId(`child-card-${childA.id}-curriculum`).click();
+    await expect(page).toHaveURL(/\/child\//);
+    await expect(page.getByTestId('proxy-banner')).toBeHidden();
+  });
+
+  test('Normal profile picker no longer enters proxy', async ({ page }) => {
+    await page.goto('/profiles');
+    await page.getByTestId(`profile-row-${childA.id}`).click();
+    await expect(page.getByText(/view account/i)).not.toBeVisible();
+    await expect(page.getByTestId('proxy-banner')).not.toBeVisible();
+  });
+
+  test('Learn this too switches into Study as the adult', async ({ page }) => {
+    await page.goto('/(app)/recaps');
+    await page.getByTestId(`recap-learn-this-too-${recapId}`).click();
+    await expect(page.getByText('My Learning')).toBeVisible();
+    await expect(page.url()).toContain('studySource=child-recap');
+  });
+
+  test('Recaps detail Back returns to Recaps (deep link)', async ({ page }) => {
+    await page.goto(`/(app)/child/${childA.id}/session/${sessionId}?returnTo=family-recaps`);
+    await page.goBack();
+    await expect(page).toHaveURL(/\/recaps$/);
+  });
+
+  test('Learn this too followed by Back does not jump to stale Family route', async ({ page }) => {
+    await page.goto('/(app)/recaps');
+    await page.getByTestId(`recap-learn-this-too-${recapId}`).click();
+    await page.goBack();
+    await expect(page).not.toHaveURL(/\/recaps/);
+  });
+
+  test('Repeated Study/Family switches keep Back inside active context', async ({ page }) => {
+    await page.goto('/(app)/more');
+    await page.getByTestId('mode-switch').click(); // family → study
+    await page.getByTestId('mode-switch').click(); // study → family
+    await page.goBack();
+    // expect either family-home or 404, never a stale proxy/child detail
+    await expect(page.getByTestId('proxy-banner')).not.toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 3: Run Playwright smoke**
+
+```bash
+C:/Tools/doppler/doppler.exe run -c stg -- pnpm run test:e2e:web:smoke
+```
+
+If smoke passes, run full suite:
+
+```bash
+C:/Tools/doppler/doppler.exe run -c stg -- pnpm run test:e2e:web
+```
+
+- [ ] **Step 4: Commit**
+
+`/commit` description: `test(web): Playwright journeys for Study/Family mode, Recaps, Learn this too, navigation`
+
+---
+
+## Task 20: Final verification + branch-wide validation
+
+Per CLAUDE.md "Required Validation": run integration tests (skipped by pre-commit/pre-push hooks) and the change-class checker.
+
+- [ ] **Step 1: Run cross-package integration tests**
+
+```bash
+cd apps/api && pnpm exec jest --testMatch '**/*.integration.test.ts' --no-coverage
+cd apps/mobile && pnpm exec jest --testMatch '**/*.integration.test.ts' --no-coverage
+pnpm exec jest tests/integration --no-coverage
+```
+
+- [ ] **Step 2: Run change-class checker on the full branch**
+
+```bash
+bash scripts/check-change-class.sh --branch
+bash scripts/check-change-class.sh --run --branch
+```
+
+Address any class advisory it emits.
+
+- [ ] **Step 3: Full validation matrix**
+
+```bash
+pnpm exec nx run-many -t lint
+pnpm exec nx run-many -t typecheck
+pnpm exec nx run-many -t test
+```
+
+- [ ] **Step 4: Re-verify the deploy-order invariant**
+
+The migration commit must be applied to dev (Task 2 Step 5) AND to staging via the deploy pipeline BEFORE the API/mobile changes are pushed to production. Per CLAUDE.md "Schema and Deploy Safety": "A worker deploy does not migrate Neon. Apply the target migration before shipping code that reads new columns."
+
+If shipping today, confirm:
+- Migration `00NN_profiles_default_app_context.sql` exists in `apps/api/drizzle/` ✓
+- Rollback markdown exists ✓
+- API code that reads `defaultAppContext` will not deploy until migration applies ✓
+- Mobile code tolerates `defaultAppContext: null` (Task 4 helper returns false) ✓
+
+- [ ] **Step 5: AC sweep — answer each AC from the spec**
+
+For each acceptance criterion in `docs/specs/2026-05-19-study-and-family-mode-navigation.md` §Acceptance Criteria, point to the file and test that proves it:
+
+| AC # | Proven by |
+|------|-----------|
+| 1 | `_layout.test.tsx` — `computeVisibleTabs('study')` |
+| 2 | `_layout.test.tsx` — `computeVisibleTabs('family')` + capability gate |
+| 3 | `profile.test.ts` — under-18 owner with non-owner profile → `isFamilyCapableProfile` false |
+| 4 | `profile.test.ts` (server) — mode patch updates only `:id` |
+| 5 | `use-mode-switch.test.ts` — onError rollback + retryable toast |
+| 6 | `use-mode-switch.test.ts` — stale-response guard |
+| 6a | `use-mode-switch.test.ts` — single-flight double-tap |
+| 6b | `use-mode-switch.test.ts` — optimistic atomic tab render |
+| 7 | `use-mode-switch.test.ts` — profile switch does not overwrite |
+| 8 | `_layout.test.tsx` — `computeVisibleTabs('family')` exact set |
+| 9 | `_layout.test.tsx` — `computeVisibleTabs('study')` exact set |
+| 10 | `progress/index.test.tsx` — Family picker excludes self |
+| 11 | `progress/index.test.tsx` — Study picker excludes children |
+| 12 | `ParentHomeScreen.test.tsx` — child-card curriculum path |
+| 13 | `recaps.test.tsx` — feed + chips |
+| 14 | `recaps.integration.test.ts` — service source grep |
+| 15 | `recaps.test.tsx` — empty states |
+| 16 | `recaps.integration.test.ts` — schema parse + UI copy test |
+| 17 | `use-learn-this-too.test.ts` — `StudySourceContext` passed |
+| 18 | `use-learn-this-too.test.ts` — quota pre-check |
+| 19 | Study entry route test — lightweight entry, no silent subject create |
+| 20 | `recaps.integration.test.ts` — parent-managed child |
+| 21 | `recaps.integration.test.ts` — linked child + consent |
+| 22 | `profiles.test.tsx` — no proxy from picker |
+| 23 | retained synthetic proxy test |
+| 24 | nested layout assertion (if Recaps gets nested children, add `unstable_settings`) |
+| 25 | Study deep-link to `/(app)/recaps` → guard or fallback |
+| 26 | `own-learning.test.tsx` — eligible adult redirect |
+| 27 | `recaps.integration.test.ts` — cross-family child id rejected |
+| 28 | sessions break test — adult-only write scope |
+| 29 | `use-notification-response-handler.test.ts` — Study session prompt |
+| 30 | `use-mode-switch.test.ts` — `router.replace` after success |
+| 31 | `use-mode-switch.test.ts` — no replace on failure |
+| 32 | navigation/recap detail test — Back goes to Recaps |
+| 33 | `use-learn-this-too.test.ts` — Back behavior |
+| 34 | onboarding intent test — re-prompt predicate |
+| 35 | `analytics.test.ts` — events fire with safe props |
+
+Add the missing AC #25 test if not already covered:
+
+```tsx
+it('Study mode user opening /(app)/recaps deep link is redirected to study-home', () => {
+  // arrange: active profile in study mode, family-capable
+  render(<RecapsScreen />);
+  expect(mockRouterReplace).toHaveBeenCalledWith('/(app)/home');
+});
+```
+
+Add AC #24 unstable_settings guard if a nested `recaps/` layout was introduced.
+
+- [ ] **Step 6: Final commit + push**
+
+```bash
+git status
+```
+
+Confirm clean working tree. If anything is staged from a sweep, run `/commit`. Per CLAUDE.md → "Commit early + push after every commit": push has been happening through `/commit` already.
+
+**No PR creation** — per `feedback_no_pr_unless_asked`. The user opens the PR when ready.
+
+---
+
+## Notes for the executing engineer
+
+- **Subagents do not commit.** If you dispatch subagents to write code in parallel, they report which files they changed; the coordinator runs `/commit`.
+- **Internal mocks forbidden (GC1/GC6).** Any new internal `jest.mock('./...')` requires `// gc1-allow: <reason>` on the same line. Prefer `jest.requireActual()` overrides — see `apps/api/src/inngest/functions/interview-persist-curriculum.integration.test.ts` for the canonical pattern.
+- **External-boundary mocks OK.** `expo-router`, Stripe, Clerk JWKS, RevenueCat, push, email, `routeAndCall` — all bare-specifier mocks are fine.
+- **Pre-commit hook does NOT run integration tests.** Run them manually before shipping any task that touches DB behavior, auth/profile scoping, or cross-package contracts.
+- **ESLint G1/G4/G5.** Route files: no `drizzle-orm` imports, no `c.get('db').op()`, no `process.env`, no default exports. Service files do DB work. Recaps service uses the sanctioned parent-chain direct-select pattern.
+- **Drift trap.** If `db:push:dev` is ever needed, follow `project_dev_schema_drift_trap` — but for this plan, always `db:generate:dev` then `db:migrate:dev`.
+- **Persona-fossil-guard.** Do not reintroduce `personaFromBirthYear`, `isLearner`, or local `Persona` types — enforced by `persona-fossil-guard.test.ts`. Use `computeAgeBracket` from `@eduagent/schemas` only.
+
+---
+
+## Self-review against the spec
+
+- Spec §Family capability predicate → Task 4 helper + Task 2 server `hasFamilyLinks`.
+- Spec §Profile App Context Field → Task 2 (migration, Drizzle, schema) + Task 3 (mutation).
+- Spec §Mode Mutation Contract (idempotent, scope-matched, optimistic+rollback, stale-response) → Tasks 3 + 7.
+- Spec §Technical Decisions (no `X-App-Context`, startup no-flicker, proxy override, switchProfile rules) → Tasks 5, 7, 12.
+- Spec §Risk Hardening + §Leak Invariants → Task 18.
+- Spec §Navigation Contract → Task 16 (helpers) + Tasks 7, 12, 13, 14 (call sites) + Task 19 (Playwright).
+- Spec §First-Run Intent → Task 6.
+- Spec §Recaps Surface → Tasks 9 + 10.
+- Spec §Learn This Too Contract → Task 13.
+- Spec §Proxy Handling Phase 1 → Task 12.
+- Spec §Route Survival → Task 14.
+- Spec §Notification → Task 15.
+- Spec §Analytics → Tasks 6, 7, 13, 17.
+- Spec §Tests in Testing Strategy → Tasks 1-19 each include matching tests; Task 20 sweeps ACs.
+- Spec §Failure Modes table — every row is exercised by at least one test added in the relevant task (search "Step N — Write failing test" sections).

--- a/docs/plans/2026-05-19-study-and-family-mode-navigation-v0.md
+++ b/docs/plans/2026-05-19-study-and-family-mode-navigation-v0.md
@@ -1,0 +1,2108 @@
+# Study And Family Mode Navigation v0 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a client-only Study/Family mode split for family-capable adults — adds an in-memory mode context, mode-aware tab shell, mode-scoped query keys, Family home with recent-child-activity, and a single-chokepoint child-route guard. No DB migration, no API change.
+
+**Architecture:** Mode state lives in a new `AppContextProvider` (React context) mounted after `ProfileProvider`. Capability is derived from already-loaded `Profile` data via `isFamilyCapableProfile()`. The `(app)/_layout.tsx` tab shell composes visible tabs via a fixed precedence: proxy > boot-null > family-capable-mode > legacy shape. Cache leak between modes is prevented by adding a `mode` segment to mode-scoped query-key factories plus a `MODE_SCOPED_KEYS` predicate invalidation on switch. Child-route guard wraps `child/[profileId]/_layout.tsx` once so every nested child route is gated.
+
+**Tech Stack:** Expo Router, React Native, TanStack Query, Jest (co-located tests).
+
+**Spec source of truth:** `docs/specs/2026-05-19-study-and-family-mode-navigation-v0.md`. When this plan and the spec disagree, the spec wins — pause and amend.
+
+---
+
+## Conventions Used Throughout
+
+- **Working directory:** `apps/mobile` for jest runs unless noted.
+- **Test command:** `cd apps/mobile && pnpm exec jest --findRelatedTests <path> --no-coverage` (per CLAUDE.md handy commands). Use `--testPathPattern` for new test files that have no production sibling yet.
+- **Typecheck:** `cd apps/mobile && pnpm exec tsc --noEmit`.
+- **Lint:** `pnpm exec nx lint mobile`.
+- **Commits:** Always via `/commit` (per CLAUDE.md). **Coordinator only** — subagents NEVER run `git add`, `git commit`, `git push`, or `/commit`. Subagents write code, run tests, and report which files they changed; the coordinator runs `/commit` between tasks. (Adversarial Review Pass 2 HIGH-2.)
+- **No new internal `jest.mock()`** — use real implementations or `jest.requireActual()` with targeted overrides. External-boundary mocks (Stripe, Clerk JWKS, push) are unaffected. Each test-file edit also triggers GC6 boy-scout sweep — if you see existing `jest.mock('./...')` lines in a file you edit, follow `/my:mockfix` to remove them.
+- **Read existing patterns first.** Before writing tests, open one nearby co-located test (e.g. `apps/mobile/src/lib/profile.test.tsx`, `apps/mobile/src/app/(app)/_layout.test.tsx`) to match harness shape (renderHook, providers wrapper, etc.).
+
+---
+
+## File Inventory
+
+### New files
+
+- `apps/mobile/src/lib/app-context.tsx` — `AppContextProvider`, `useAppContext()`.
+- `apps/mobile/src/lib/app-context.test.tsx` — co-located unit tests.
+- `apps/mobile/src/lib/mode-scoped-keys.ts` — `MODE_SCOPED_KEYS` list + guard.
+- `apps/mobile/src/lib/mode-scoped-keys.test.ts` — invariants (non-empty, subset of `PROFILE_SCOPED_KEYS`).
+- `apps/mobile/src/components/guards/RequireFamilyContext.tsx` — child-route gate component.
+- `apps/mobile/src/components/guards/RequireFamilyContext.test.tsx` — gate behavior tests.
+
+### Modified files
+
+- `apps/mobile/src/lib/profile.ts` — add `isFamilyCapableProfile()`; **move** the inline `PROFILE_SCOPED_KEYS` (currently inside `switchProfile`, `profile.ts:252-307`) to a module-level `const` and export it. **No prefix additions needed** — `'session'` (line 262), `'session-summary'` (264), `'session-transcript'` (265), and `'parking-lot'` (294) are already present (Adversarial Review Pass 2 CRITICAL-1).
+- `apps/mobile/src/lib/profile.test.tsx` — `isFamilyCapableProfile` cases; `MODE_SCOPED_KEYS ⊆ PROFILE_SCOPED_KEYS` guard.
+- `apps/mobile/src/lib/query-keys.ts` — add `mode` segment to mode-scoped factories per §Task 8 table.
+- `apps/mobile/src/lib/query-keys.test.ts` — update expected key shapes.
+- `apps/mobile/src/lib/analytics.ts` — no signature change; only callers add a new event name. (Listed in front-matter as a touched-file because §Task 6 calls `track('mode_switched', …)`.)
+- `apps/mobile/src/lib/navigation.ts` — add `useGuardFamilyRoute()` helper.
+- `apps/mobile/src/app/(app)/_layout.tsx` — add `computeModeVisibleTabs()`; mount `AppContextProvider`; compose tab visibility per Hard Rule #10.
+- `apps/mobile/src/app/(app)/_layout.test.tsx` — visible-tab precedence tests.
+- `apps/mobile/src/app/(app)/home.tsx` — render mode chip; pass `mode` into `LearnerScreen`.
+- `apps/mobile/src/app/(app)/own-learning.tsx` — Route Survival `setMode('study')` for family-capable adult.
+- `apps/mobile/src/app/(app)/progress/index.tsx` — mode-aware profile picker; reset `selectedProfileId` to self on Family→Study flip; reject `?profileId=<childId>` deep-link param in Study mode (Adversarial Review Pass 2 CRITICAL-3, CRITICAL-4).
+- `apps/mobile/src/app/(app)/child/[profileId]/_layout.tsx` — wrap with `RequireFamilyContext`.
+- `apps/mobile/src/components/home/LearnerScreen.tsx` — accept `mode` prop; mode-driven `showParentHome` branch.
+- `apps/mobile/src/components/home/ParentHomeScreen.tsx` — add Recent-child-activity section + adult-study activation card.
+- `apps/mobile/src/hooks/use-dashboard.ts` — thread `mode` through dashboard factories.
+- `apps/mobile/src/hooks/use-progress.ts` — thread `mode` through progress factories. Also: tighten `enabled` on `useProfileSessions`, `useChildInventory`, `useChildProgressSummary`, `useProfileReports`, `useProfileWeeklyReports` to gate foreign-profile fetches behind `mode === 'family'` (Adversarial Review Pass 2 CRITICAL-3). Without this, a Study-mode user with a stale `selectedProfileId === childId` will fetch child data via `client.dashboard.children[':profileId']` — Hard Rule #2 violation.
+- `apps/mobile/src/hooks/use-sessions.ts` — thread `mode` through `sessions.detail`, `sessions.transcript`, `sessions.summary`, `sessions.parkingLot`, `sessions.topicParkingLot` (7 call sites at lines 530, 563, 657, 684, 727, 745). Also: rewrite the 2-element invalidations at lines 218 and 247 per Adversarial Review CRITICAL-1.
+- `apps/mobile/src/hooks/use-retry-filing.ts` — rewrite 2-element invalidations at lines 27 and 29 per Adversarial Review CRITICAL-1.
+
+### Files explicitly NOT modified
+
+- `apps/mobile/src/lib/sign-out.ts` — `signOutWithCleanup` already calls `queryClient.clear()` and resets api-client identity; the identity-keyed subscription in `AppContextProvider` handles mode reset. (Removed from front-matter per Adversarial Review LOW-2 / MEDIUM-5.)
+- API, schema, migration files — none touched in v0.
+
+---
+
+## Task 0: Feature flag for kill-switch rollback
+
+**Why this task exists.** v0 is a probe. Pre-launch, ship-then-flip is cheaper than ship-then-revert-PR. Adding a single env-driven flag at the entry chokepoint lets the user OTA the feature off in ~5 min without code edits or store re-submission. `project_pre_launch_no_users.md` says we have no users to protect, so the flag is purely for *operator* (=user) ergonomics during dogfooding.
+
+**Files:**
+- Modify: `apps/mobile/src/lib/feature-flags.ts` — add the new flag.
+- Modify: `apps/mobile/.env.example` — document the env var.
+- Doppler (no file edit) — add `EXPO_PUBLIC_ENABLE_MODE_NAV` to all environments (dev/stg/prd) via the Doppler CLI; `pnpm env:sync` then propagates to `eas.json` build profiles.
+
+**Gate sites (read in this task, applied in later tasks):**
+
+1. `AppContextProvider` (Task 2) — when flag is off, `mode` stays `null` forever; `setMode` is a no-op. All downstream consumers that already condition on `mode === 'family'` or `mode !== null` auto-collapse to the legacy path.
+2. `_layout.tsx` tab composition (Task 4.4) — `mode === null` already falls through to legacy `computeVisibleTabs` per Pass 2 HIGH-1. No additional gate needed.
+3. `LearnerScreen.tsx` (Task 6.5) — flag-off branch keeps today's `(hasLinkedChildren || isFamilyPlanOwner)` condition; flag-on branch uses `mode === 'family'`. Both branches stay in the file; the flag picks which one runs.
+4. `progress/index.tsx` (Task 9.3) — flag-off keeps today's picker behavior; flag-on adds the mode-aware filter + Family→Study reset + foreign-profile-id rejection. No `if (mode === null) return <LoadingState />` regression when the flag is off.
+5. `RequireFamilyContext` (Task 14.3) — flag-off renders `{children}` as a no-op pass-through (child layout protected only by the existing `resolveTabShape() !== 'guardian'` redirect on the non-capable user path).
+6. Task 13 (proxy hide-out) is **not** flag-gated — deleting user-facing `setProxyMode(true)` affordances is a Phase 1 cleanup that ships regardless. Per `project_pre_launch_no_users.md` there is no user-protection cost to leaving those deletions in even if mode nav is flipped off.
+
+The chip (Task 6), activation card (Task 7), Recent-child-activity (Task 8), Route Survival (Task 5), and mode-switch invalidation (Task 12) all already condition on `mode !== null` or `mode === 'family'`. Because `AppContextProvider` returns `mode = null` when the flag is off, none of those render — no additional per-site gate needed. This is the design payoff for routing every consumer through `useAppContext()`.
+
+- [ ] **Step 0.1: Add the flag to `feature-flags.ts`.**
+
+In `apps/mobile/src/lib/feature-flags.ts`:
+
+```ts
+export const FEATURE_FLAGS = {
+  COACH_BAND_ENABLED: true,
+  MIC_IN_PILL_ENABLED: true,
+  I18N_ENABLED: true,
+  // Study/Family mode navigation (v0 probe).
+  // Source of truth: EXPO_PUBLIC_ENABLE_MODE_NAV (Doppler-managed, baked into
+  // the bundle at build time). Flip via Doppler + `eas update` — no code edit
+  // and no store re-submission. Defaults to `false` so the feature ships dark;
+  // operator flips to `true` after the build lands on their device.
+  // Spec: docs/specs/2026-05-19-study-and-family-mode-navigation-v0.md
+  // Plan: docs/plans/2026-05-19-study-and-family-mode-navigation-v0.md
+  MODE_NAV_V0_ENABLED:
+    process.env.EXPO_PUBLIC_ENABLE_MODE_NAV === 'true',
+} as const;
+```
+
+The `=== 'true'` comparison is deliberate — `EXPO_PUBLIC_*` vars are always strings, and any non-`'true'` value (undefined, `'false'`, empty, typo) resolves to `false`. Safe default.
+
+- [ ] **Step 0.2: Document the env var in `.env.example`.**
+
+In `apps/mobile/.env.example`, append:
+
+```
+# Study/Family mode navigation v0 kill-switch (boolean string).
+# 'true' enables the mode-aware tab shell, chip, Recent-child-activity, etc.
+# Any other value (or absent) falls back to the pre-v0 behavior.
+EXPO_PUBLIC_ENABLE_MODE_NAV=false
+```
+
+- [ ] **Step 0.3: Add to Doppler.**
+
+```bash
+# For each environment: dev, stg, prd
+doppler secrets set EXPO_PUBLIC_ENABLE_MODE_NAV=false --config dev
+doppler secrets set EXPO_PUBLIC_ENABLE_MODE_NAV=false --config stg
+doppler secrets set EXPO_PUBLIC_ENABLE_MODE_NAV=false --config prd
+```
+
+Then sync to `eas.json` build profiles:
+
+```bash
+pnpm env:sync
+```
+
+Confirm the value lands in `apps/mobile/eas.json` under each profile's `env` block before the next build.
+
+- [ ] **Step 0.4: Write a unit test.**
+
+`apps/mobile/src/lib/feature-flags.test.ts` (create if absent):
+
+```ts
+describe('FEATURE_FLAGS.MODE_NAV_V0_ENABLED', () => {
+  // Module is module-level static; re-import after env mutation in beforeEach.
+  it('resolves to true only when env var is the literal string "true"', () => {
+    process.env.EXPO_PUBLIC_ENABLE_MODE_NAV = 'true';
+    jest.resetModules();
+    const { FEATURE_FLAGS } = require('./feature-flags');
+    expect(FEATURE_FLAGS.MODE_NAV_V0_ENABLED).toBe(true);
+  });
+
+  it.each(['false', '1', 'yes', 'TRUE', '', undefined])(
+    'resolves to false for value %p',
+    (value) => {
+      if (value === undefined) delete process.env.EXPO_PUBLIC_ENABLE_MODE_NAV;
+      else process.env.EXPO_PUBLIC_ENABLE_MODE_NAV = value;
+      jest.resetModules();
+      const { FEATURE_FLAGS } = require('./feature-flags');
+      expect(FEATURE_FLAGS.MODE_NAV_V0_ENABLED).toBe(false);
+    },
+  );
+});
+```
+
+- [ ] **Step 0.5: Typecheck + lint + commit via `/commit`.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx lint mobile
+```
+
+Stage `apps/mobile/src/lib/feature-flags.ts`, `apps/mobile/src/lib/feature-flags.test.ts`, and `apps/mobile/.env.example`. Commit via `/commit`.
+
+---
+
+## Flip workflow (operator runbook)
+
+When you (the operator) want to turn the feature **on** or **off** after the build is on a device:
+
+1. **Flip Doppler:**
+   ```bash
+   # turn ON
+   doppler secrets set EXPO_PUBLIC_ENABLE_MODE_NAV=true --config prd
+   # or turn OFF
+   doppler secrets set EXPO_PUBLIC_ENABLE_MODE_NAV=false --config prd
+   ```
+2. **Sync + OTA:**
+   ```bash
+   pnpm env:sync
+   pnpm exec eas update --branch production --message "mode-nav v0: <on|off>"
+   ```
+3. **On device:** force-close and reopen the app; the new bundle downloads and reads the new flag value. ~5 min end-to-end (per `project_eas_update_ota.md`).
+
+Per `feedback_no_ota_unless_asked.md`, an agent never runs `eas update` without explicit operator instruction. Use this runbook only when the operator says "flip the mode-nav flag" or similar.
+
+---
+
+## Preflight (run once before Task 1)
+
+- [ ] **Step P1: Verify `Profile` shape exposes `isOwner`, `birthYear`.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+If `profileSchema` is missing either field, **stop and amend the spec** — do not infer a hidden predicate.
+
+- [ ] **Step P2: Verify `useLinkedChildren()` is in place.**
+
+```bash
+# already cited in spec preflight; just confirm the file/function
+```
+
+Read: `apps/mobile/src/lib/profile.ts:85-104` — must contain `useLinkedChildren()` returning `Profile[]`.
+
+- [ ] **Step P3: Confirm baseline tests pass.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.ts src/lib/query-keys.ts --no-coverage
+```
+
+Expected: all green. If anything is red, fix or surface to the user **before** starting Task 1 — every later task assumes a green baseline.
+
+---
+
+## Task 1: `isFamilyCapableProfile()` capability helper
+
+**Files:**
+- Modify: `apps/mobile/src/lib/profile.ts` (add new exported function below `useHasLinkedChildren`, around line 104)
+- Modify: `apps/mobile/src/lib/profile.test.tsx` (add new describe block)
+
+- [ ] **Step 1.1: Write the failing tests.**
+
+Append to `apps/mobile/src/lib/profile.test.tsx`:
+
+```tsx
+import { isFamilyCapableProfile } from './profile';
+import type { Profile } from '@eduagent/schemas';
+
+const adultOwner = (overrides: Partial<Profile> = {}): Profile =>
+  ({
+    id: 'p-owner',
+    isOwner: true,
+    birthYear: 1985,
+    displayName: 'Owner',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    linkCreatedAt: null,
+    ...overrides,
+  }) as Profile;
+
+const child = (overrides: Partial<Profile> = {}): Profile =>
+  ({
+    id: 'p-child',
+    isOwner: false,
+    birthYear: 2015,
+    displayName: 'Kid',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    linkCreatedAt: '2024-01-02T00:00:00.000Z',
+    ...overrides,
+  }) as Profile;
+
+describe('isFamilyCapableProfile', () => {
+  it('returns true for adult owner with at least one non-owner linked profile', () => {
+    const active = adultOwner();
+    expect(isFamilyCapableProfile(active, [active, child()])).toBe(true);
+  });
+
+  it('returns false for adult owner with no linked non-owner profiles', () => {
+    const active = adultOwner();
+    expect(isFamilyCapableProfile(active, [active])).toBe(false);
+  });
+
+  it('returns false for under-18 owner even with a linked non-owner sibling', () => {
+    const active = adultOwner({ birthYear: 2012 });
+    expect(isFamilyCapableProfile(active, [active, child()])).toBe(false);
+  });
+
+  it('returns false for non-owner active profile', () => {
+    const active = child();
+    expect(isFamilyCapableProfile(active, [adultOwner(), active])).toBe(false);
+  });
+
+  it('returns false when activeProfile is null', () => {
+    expect(isFamilyCapableProfile(null, [adultOwner(), child()])).toBe(false);
+  });
+
+  it('does NOT consult subscription tier — linkage drives capability', () => {
+    // Solo Family-plan owner with no children is intentionally NOT family-capable.
+    const active = adultOwner();
+    expect(isFamilyCapableProfile(active, [active])).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests; verify they fail with "isFamilyCapableProfile is not a function".**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.test.tsx --no-coverage
+```
+
+Expected: `ReferenceError` / import error.
+
+- [ ] **Step 1.3: Implement the helper.**
+
+Add to `apps/mobile/src/lib/profile.ts` (immediately below `useHasLinkedChildren`):
+
+```ts
+import { computeAgeBracket } from '@eduagent/schemas';
+
+export function isFamilyCapableProfile(
+  activeProfile: Pick<Profile, 'id' | 'isOwner' | 'birthYear'> | null | undefined,
+  profiles: ReadonlyArray<Pick<Profile, 'id' | 'isOwner'>>,
+): boolean {
+  if (!activeProfile) return false;
+  if (activeProfile.isOwner !== true) return false;
+  if (computeAgeBracket(activeProfile.birthYear) !== 'adult') return false;
+  return profiles.some(
+    (p) => p.id !== activeProfile.id && p.isOwner === false,
+  );
+}
+```
+
+Notes:
+- Do **not** check archived state — `profileSchema` has no `archivedAt` in v0.
+- Do **not** read subscription tier.
+- Accept the narrower `Pick<...>` shape so tests can pass minimal fixtures.
+
+- [ ] **Step 1.4: Run tests; verify all green.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.ts src/lib/profile.test.tsx --no-coverage
+```
+
+- [ ] **Step 1.5: Typecheck + lint.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx lint mobile
+```
+
+- [ ] **Step 1.6: Commit via `/commit`.**
+
+Stage `apps/mobile/src/lib/profile.ts` and `apps/mobile/src/lib/profile.test.tsx`.
+
+---
+
+## Task 2: `AppContextProvider` and `useAppContext()`
+
+**Files:**
+- Create: `apps/mobile/src/lib/app-context.tsx`
+- Create: `apps/mobile/src/lib/app-context.test.tsx`
+
+- [ ] **Step 2.1: Write failing tests.**
+
+Create `apps/mobile/src/lib/app-context.test.tsx`:
+
+```tsx
+import { act, renderHook } from '@testing-library/react-native';
+import { type ReactNode } from 'react';
+import { AppContextProvider, useAppContext } from './app-context';
+import { ProfileContext, type ProfileContextValue } from './profile';
+import type { Profile } from '@eduagent/schemas';
+
+const adult: Profile = {
+  id: 'p-owner',
+  isOwner: true,
+  birthYear: 1985,
+  displayName: 'Owner',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  linkCreatedAt: null,
+} as Profile;
+
+const kid: Profile = {
+  id: 'p-kid',
+  isOwner: false,
+  birthYear: 2015,
+  displayName: 'Kid',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  linkCreatedAt: '2024-01-02T00:00:00.000Z',
+} as Profile;
+
+function makeWrapper(value: Partial<ProfileContextValue>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    // ProfileContextValue requires 7 fields (profile.ts:48-59). All seven are
+    // listed explicitly so the example typechecks as-written (Adversarial
+    // Review LOW-1).
+    const merged: ProfileContextValue = {
+      activeProfile: null,
+      profiles: [],
+      isLoading: false,
+      switchProfile: async () => ({ success: true }),
+      profileLoadError: null,
+      profileWasRemoved: false,
+      acknowledgeProfileRemoval: () => undefined,
+      ...value,
+    };
+    return (
+      <ProfileContext.Provider value={merged}>
+        <AppContextProvider>{children}</AppContextProvider>
+      </ProfileContext.Provider>
+    );
+  };
+}
+
+describe('AppContextProvider', () => {
+  it('holds mode=null while profiles are loading', () => {
+    const { result } = renderHook(() => useAppContext(), {
+      wrapper: makeWrapper({ isLoading: true }),
+    });
+    expect(result.current.mode).toBeNull();
+  });
+
+  it('resolves to "family" for a family-capable adult once profiles are loaded', () => {
+    const { result } = renderHook(() => useAppContext(), {
+      wrapper: makeWrapper({
+        activeProfile: adult,
+        profiles: [adult, kid],
+        isLoading: false,
+      }),
+    });
+    expect(result.current.mode).toBe('family');
+  });
+
+  it('resolves to "study" for an adult owner without linked children', () => {
+    const { result } = renderHook(() => useAppContext(), {
+      wrapper: makeWrapper({
+        activeProfile: adult,
+        profiles: [adult],
+        isLoading: false,
+      }),
+    });
+    expect(result.current.mode).toBe('study');
+  });
+
+  it('setMode("study") overrides default "family"', () => {
+    const { result } = renderHook(() => useAppContext(), {
+      wrapper: makeWrapper({
+        activeProfile: adult,
+        profiles: [adult, kid],
+        isLoading: false,
+      }),
+    });
+    act(() => result.current.setMode('study'));
+    expect(result.current.mode).toBe('study');
+  });
+
+  // Note: identity-loss reset and identity-swap recomputation tests live
+  // in the integration suite (Task 15) because rerendering the wrapper
+  // with a new ProfileContext value mirrors a real sign-out → sign-in.
+});
+```
+
+- [ ] **Step 2.2: Run tests; verify they fail (module not found).**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/app-context.test.tsx --no-coverage
+```
+
+- [ ] **Step 2.3: Implement `AppContextProvider` and `useAppContext`.**
+
+Create `apps/mobile/src/lib/app-context.tsx`:
+
+```tsx
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { isFamilyCapableProfile, useProfile } from './profile';
+
+export type AppMode = 'study' | 'family';
+
+export interface AppContextValue {
+  mode: AppMode | null;
+  setMode: (next: AppMode) => void;
+}
+
+const AppContext = createContext<AppContextValue>({
+  mode: null,
+  setMode: () => {
+    // no-op default; real provider supplies the setter
+  },
+});
+
+export function useAppContext(): AppContextValue {
+  return useContext(AppContext);
+}
+
+export function AppContextProvider({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  const { activeProfile, profiles, isLoading } = useProfile();
+  const [mode, setMode] = useState<AppMode | null>(null);
+
+  // Linked non-owner count — used as the capability subscription input so
+  // add-child mid-session flips capability on the next render.
+  const linkedNonOwnerCount = useMemo(
+    () => profiles.filter((p) => !p.isOwner).length,
+    [profiles],
+  );
+
+  // Identity-keyed recompute. Reset-before-recompute: if profiles are still
+  // loading OR active profile is null, collapse mode to null synchronously
+  // so the previous user's mode never renders against the new user's data
+  // (cross-account leak class, project_cross_account_leak_2026_05_10.md).
+  useEffect(() => {
+    if (isLoading || !activeProfile) {
+      setMode(null);
+      return;
+    }
+    const next: AppMode = isFamilyCapableProfile(activeProfile, profiles)
+      ? 'family'
+      : 'study';
+    setMode(next);
+  }, [
+    isLoading,
+    activeProfile?.id,
+    activeProfile?.isOwner,
+    activeProfile?.birthYear,
+    linkedNonOwnerCount,
+  ]);
+
+  const value = useMemo<AppContextValue>(
+    () => ({ mode, setMode: (next) => setMode(next) }),
+    [mode],
+  );
+
+  return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
+}
+```
+
+Notes:
+- The default `setMode` in the context fallback is a no-op (TypeScript-required); the real provider always supplies the setter.
+- v0 explicitly **does not** read or write SecureStore. If a later change adds persistence, that change must also extend `signOutWithCleanup`.
+- Identity-loss reset is what AC #27 + Failure Modes "Sign-in as a different user" require.
+- **Synchronous derivation REQUIRED (Adversarial Review Pass 2 HIGH-1).** The `useState<AppMode | null>(null) + useEffect` pattern shown above leaves at least one render where `mode === null` after profiles have already loaded. In Task 4.4's tab composition, `mode === null` returns an empty Set → every `Tabs.Screen` gets `href: null` → **zero tabs render** for a frame. Today's `_layout.tsx:108` defaults to learner shape (least-privilege) so the shell always shows a non-empty tab set. The empty-tab frame is the visible regression Spec AC #3 forbids. **Replace the useState + useEffect block above with a `useMemo` so `mode` is derived synchronously during render**:
+
+```tsx
+const [modeOverride, setModeOverride] = useState<AppMode | null>(null);
+const linkedNonOwnerCount = useMemo(
+  () => profiles.filter((p) => !p.isOwner).length,
+  [profiles],
+);
+const derivedMode = useMemo<AppMode | null>(() => {
+  // Task 0 kill-switch: when MODE_NAV_V0_ENABLED is false, mode stays null
+  // forever. Downstream consumers (chip, activation card, Recent-child-activity,
+  // Route Survival, mode-switch invalidation, Progress filter) all condition
+  // on `mode !== null` or `mode === 'family'` and auto-collapse to the legacy
+  // path. The tab composition (Task 4.4) also falls through to legacy
+  // `computeVisibleTabs` when mode is null.
+  if (!FEATURE_FLAGS.MODE_NAV_V0_ENABLED) return null;
+  if (isLoading || !activeProfile) return null;
+  return isFamilyCapableProfile(activeProfile, profiles) ? 'family' : 'study';
+}, [isLoading, activeProfile?.id, activeProfile?.isOwner, activeProfile?.birthYear, linkedNonOwnerCount]);
+// Override is cleared whenever the derivation key (identity) changes.
+useEffect(() => { setModeOverride(null); }, [activeProfile?.id]);
+const mode = modeOverride ?? derivedMode;
+const setMode = useCallback((next: AppMode) => setModeOverride(next), []);
+```
+
+This keeps Route Survival (Task 5) and the chip switch (Task 6) working — they call `setMode(next)` which pins an override until identity changes. The identity-loss reset (AC #27) still fires because `derivedMode` collapses to `null` synchronously when `activeProfile === null`, and the override-clear effect runs the moment `activeProfile?.id` swaps. The cross-account safety test (Task 15.2) verifies this. **Add a Task 4 / Task 15 assertion that `computeModeVisibleTabs` is never called with `null` once profiles have resolved.**
+
+- **Fallback option (only if the synchronous derivation above is rejected in review).** Fall back to the legacy `computeVisibleTabs(tabShape, isParentProxy)` whenever `mode === null` (Task 4.4 below) instead of returning ∅. This preserves the existing tab set during the boot frame. Pick one path; do not ship both.
+
+- [ ] **Step 2.4: Run tests; verify green.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/app-context.tsx --no-coverage
+```
+
+- [ ] **Step 2.5: Typecheck.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 2.6: Commit via `/commit`.**
+
+---
+
+## Task 3: Mount `AppContextProvider` in `(app)/_layout.tsx`
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx` (wrap the `<Tabs>` tree)
+
+**Important placement note (Adversarial Review HIGH-2).** `<ProfileProvider>` is mounted in the **root** `apps/mobile/src/app/_layout.tsx:570`, **not** in `(app)/_layout.tsx`. Do not look for it inside the `(app)` layout — `(app)/_layout.tsx` already consumes `useProfile()` via React context from above. `AppContextProvider` only needs to be somewhere below `<ProfileProvider>` in the tree.
+
+Two structural options. Pick the one that compiles:
+
+- **Option A (preferred):** Wrap the `<Tabs>` JSX subtree inside `AppLayout` (`(app)/_layout.tsx:1386`). Place `<AppContextProvider>` around the `<FeedbackProvider><View>…<Tabs>…</View></FeedbackProvider>` block returned at `_layout.tsx:1706-1836`. This is the smallest change.
+- **Option B (use only if `AppLayout` itself needs `useAppContext()`):** A provider's value is not visible to its own render. If `AppLayout` consumes `useAppContext()` directly to compose `visibleTabs`, mount `<AppContextProvider>` one level up — split `AppLayout` into an outer wrapper (`AppLayoutWithMode`) that mounts the provider and an inner component (`AppLayoutInner`) that consumes it. Tasks 4 and 6 read `mode` inside `AppLayout`, so **Option B is what v0 needs** unless Task 4 hoists the read into a child component.
+
+- [ ] **Step 3.1: Locate the JSX subtree.**
+
+Read `apps/mobile/src/app/(app)/_layout.tsx:1386-1836`. Identify the `<FeedbackProvider><View>…<Tabs>…</View></FeedbackProvider>` return block.
+
+- [ ] **Step 3.2: Implement Option B — split `AppLayout` into wrapper + inner.**
+
+Add import at top of file:
+
+```tsx
+import { AppContextProvider } from '../../lib/app-context';
+```
+
+Rename the existing `export default function AppLayout()` to `function AppLayoutInner()` (no default export). Add a new default export below it:
+
+```tsx
+export default function AppLayout(): React.ReactElement {
+  return (
+    <AppContextProvider>
+      <AppLayoutInner />
+    </AppContextProvider>
+  );
+}
+```
+
+This makes `useAppContext()` available inside `AppLayoutInner` (Task 4) and inside every screen below the tabs.
+
+- [ ] **Step 3.3: Typecheck and run existing layout tests.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.tsx --no-coverage
+```
+
+Expected: all existing tests still green; no new tests needed at this step (composition tests come in Task 4).
+
+- [ ] **Step 3.4: Commit via `/commit`.**
+
+---
+
+## Task 4: `computeModeVisibleTabs()` + tab visibility composition + mode-aware home tab title
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx` (add helper near existing `computeVisibleTabs`; extend `resolveHomeTabPresentation` to take `mode`)
+- Modify: `apps/mobile/src/app/(app)/_layout.test.tsx`
+
+- [ ] **Step 4.1: Write failing tests for `computeModeVisibleTabs` and precedence.**
+
+Append to `apps/mobile/src/app/(app)/_layout.test.tsx`:
+
+```tsx
+import {
+  computeModeVisibleTabs,
+  computeVisibleTabs,
+  resolveTabShape,
+} from './_layout';
+
+describe('computeModeVisibleTabs', () => {
+  it('returns Study tab set', () => {
+    expect(Array.from(computeModeVisibleTabs('study')).sort()).toEqual(
+      ['home', 'library', 'more', 'progress'],
+    );
+  });
+  it('returns Family tab set (no library, no own-learning)', () => {
+    expect(Array.from(computeModeVisibleTabs('family')).sort()).toEqual(
+      ['home', 'more', 'progress'],
+    );
+  });
+  it('returns empty set when mode === null (call site is responsible for falling back to the legacy path)', () => {
+    expect(computeModeVisibleTabs(null).size).toBe(0);
+  });
+});
+
+// Integration test for the composition at the call site (Adversarial Review
+// Pass 2 HIGH-1): assert that during the boot frame (mode === null + profiles
+// loading) the composition falls through to `computeVisibleTabs`, NOT to an
+// empty set. This guards against accidentally returning ∅ at the call site.
+
+// Precedence is tested via the real composition site in Task 15 integration
+// tests; the helper-level test above just locks the shapes.
+```
+
+- [ ] **Step 4.2: Run tests; verify they fail (function not exported).**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.test.tsx --no-coverage
+```
+
+- [ ] **Step 4.3: Add `computeModeVisibleTabs` to `_layout.tsx`.**
+
+Below the existing `LEARNER_TABS` / `GUARDIAN_TABS` / `PARENT_PROXY_TABS` declarations (around line 76-89), add:
+
+```ts
+const STUDY_MODE_TABS: ReadonlySet<string> = new Set([
+  'home',
+  'library',
+  'progress',
+  'more',
+]);
+
+const FAMILY_MODE_TABS: ReadonlySet<string> = new Set([
+  'home',
+  'progress',
+  'more',
+]);
+
+// New helper — keeps `computeVisibleTabs` (shape-based) intact.
+// See spec §Hard Rules #10 for the composition order this feeds.
+export function computeModeVisibleTabs(
+  mode: 'study' | 'family' | null,
+): ReadonlySet<string> {
+  if (mode === null) return new Set();
+  if (mode === 'family') return FAMILY_MODE_TABS;
+  return STUDY_MODE_TABS;
+}
+```
+
+- [ ] **Step 4.4: Compose visible-tab set in the component body (not the callback).**
+
+`visibleTabs` is currently computed by a `useMemo` at `_layout.tsx:1411-1414` in the component body (`AppLayoutInner` after Task 3); the `screenOptions` callback at line 1726 only reads `visibleTabs.has(route.name)`. **Edit the `useMemo` block, not the callback** (Adversarial Review MEDIUM-1).
+
+Pseudocode (adapt to current variable names — read the file first):
+
+```ts
+import { useAppContext } from '../../lib/app-context';
+import { isFamilyCapableProfile } from '../../lib/profile';
+
+// inside AppLayoutInner, alongside the existing useProfile() / useParentProxy()
+// reads (around _layout.tsx:1407):
+const { mode } = useAppContext();
+const familyCapable = isFamilyCapableProfile(activeProfile, profiles);
+
+// Replace the existing useMemo at _layout.tsx:1411-1414 with this composition.
+// Hard Rule #10 precedence: proxy > boot-null > family-capable mode > legacy.
+//
+// Adversarial Review Pass 2 HIGH-1: with the synchronous useMemo in Task 2,
+// `mode === null` only occurs when profiles are still loading (legitimate
+// boot frame). In that case fall through to the legacy `computeVisibleTabs`
+// path so the shell never renders zero tabs — `resolveTabShape` already
+// defaults to learner shape at `_layout.tsx:108`. Never return `new Set()`.
+const visibleTabs: ReadonlySet<string> = React.useMemo(
+  () =>
+    isParentProxy
+      ? new Set(PARENT_PROXY_TABS)
+      : mode !== null && familyCapable
+        ? computeModeVisibleTabs(mode)
+        : computeVisibleTabs(tabShape, isParentProxy),
+  [isParentProxy, mode, familyCapable, tabShape],
+);
+// The screenOptions callback at line 1726 already reads visibleTabs.has(route.name)
+// — no edit needed inside the callback.
+```
+
+Add a short comment block above the composition documenting the precedence (so it doesn't get reordered by future refactors):
+
+```ts
+// Precedence (spec §Hard Rules #10): isParentProxy > mode===null > family-capable mode > legacy shape.
+// Reordering this is a correctness regression — proxy chrome must win, and
+// boot-frame must render no mode-specific tabs.
+```
+
+- [ ] **Step 4.5: Make the home tab title mode-aware (Adversarial Review HIGH-1).**
+
+Today `resolveHomeTabPresentation(shape, isParentProxy)` at `_layout.tsx:128-149` returns `tabs.familyHub` when `shape === 'guardian' && !isParentProxy`. For a family-capable adult in Study mode, `tabShape === 'guardian'` (capability gate, not mode gate), so without this fix the home tab title stays "Family Hub / Children" while the chip and content say Study. Spec lines 222-223 require: "Family home tab label: Children. Study home tab label: My Learning."
+
+Extend the function signature:
+
+```ts
+export function resolveHomeTabPresentation(
+  shape: TabShape,
+  isParentProxy = false,
+  mode: 'study' | 'family' | null = null,
+): {
+  titleKey: 'tabs.familyHub' | 'tabs.myLearning';
+  accessibilityLabelKey: 'tabs.familyHubLabel' | 'tabs.myLearningLabel';
+  iconName: 'Home' | 'School';
+} {
+  // Family-capable adult mode override: when a guardian is in Study mode,
+  // the home tab points at My Learning, not the family hub.
+  if (shape === 'guardian' && !isParentProxy && mode === 'study') {
+    return {
+      titleKey: 'tabs.myLearning',
+      accessibilityLabelKey: 'tabs.myLearningLabel',
+      iconName: 'School',
+    };
+  }
+  if (shape === 'guardian' && !isParentProxy) {
+    return {
+      titleKey: 'tabs.familyHub',
+      accessibilityLabelKey: 'tabs.familyHubLabel',
+      iconName: 'Home',
+    };
+  }
+  return {
+    titleKey: 'tabs.myLearning',
+    accessibilityLabelKey: 'tabs.myLearningLabel',
+    iconName: 'School',
+  };
+}
+```
+
+Update the call site at `_layout.tsx:1415-1418` to thread `mode`:
+
+```ts
+const homeTabPresentation = resolveHomeTabPresentation(
+  tabShape,
+  isParentProxy,
+  mode,
+);
+```
+
+Add a unit test alongside `computeModeVisibleTabs` tests:
+
+```tsx
+it('home tab title flips to My Learning for guardian-shape adult in Study mode', () => {
+  expect(resolveHomeTabPresentation('guardian', false, 'study').titleKey)
+    .toBe('tabs.myLearning');
+  expect(resolveHomeTabPresentation('guardian', false, 'family').titleKey)
+    .toBe('tabs.familyHub');
+  expect(resolveHomeTabPresentation('guardian', false, null).titleKey)
+    .toBe('tabs.familyHub'); // boot frame defaults to family-hub for guardian
+  expect(resolveHomeTabPresentation('learner', false, 'study').titleKey)
+    .toBe('tabs.myLearning');
+});
+```
+
+- [ ] **Step 4.6: Run tests; verify green.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/_layout.tsx src/app/\(app\)/_layout.test.tsx --no-coverage
+```
+
+- [ ] **Step 4.7: Typecheck + lint.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx lint mobile
+```
+
+- [ ] **Step 4.8: Commit via `/commit`.**
+
+---
+
+## Task 5: `own-learning.tsx` Route Survival
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/own-learning.tsx`
+- Create / modify: `apps/mobile/src/app/(app)/own-learning.test.tsx` (create if absent)
+
+- [ ] **Step 5.1: Check for an existing test file.**
+
+```bash
+# If a co-located test file exists, edit it. Otherwise create.
+```
+
+- [ ] **Step 5.2: Write failing test.**
+
+Create or extend `apps/mobile/src/app/(app)/own-learning.test.tsx`:
+
+```tsx
+import { render } from '@testing-library/react-native';
+// Use the canonical pattern from index.test.tsx / _layout.test.tsx — build a
+// test wrapper that supplies ProfileContext + AppContextProvider with the
+// fixtures the screen needs. Do NOT jest.mock internal modules.
+
+// Required cases:
+// - family-capable adult in mode='family' lands on own-learning →
+//   setMode('study') fires before render → no redirect, learner UI renders.
+// - non-capable user → existing <Redirect href="/(app)/home"> still fires.
+// - family-capable adult already in mode='study' → no setMode call, renders.
+```
+
+Concrete assertion shape (adapt setMode to a spy that captures calls into the wrapper's state):
+
+```tsx
+it('switches mode to "study" when a family-capable adult deep-links to own-learning', () => {
+  const setModeSpy = jest.fn();
+  // Render with mode='family', activeProfile=adultOwner, profiles=[adult, kid],
+  // and an injected setMode spy (the test harness wraps AppContextProvider so
+  // setMode is observable).
+  // After render: expect(setModeSpy).toHaveBeenCalledWith('study');
+});
+```
+
+- [ ] **Step 5.3: Run test; verify it fails.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/own-learning.tsx --no-coverage
+```
+
+- [ ] **Step 5.4: Implement Route Survival.**
+
+Edit `apps/mobile/src/app/(app)/own-learning.tsx`. Add `useEffect` **before** the existing `<Redirect>` guard:
+
+```tsx
+import { useEffect } from 'react';
+import { useAppContext } from '../../lib/app-context';
+import { isFamilyCapableProfile } from '../../lib/profile';
+
+// inside OwnLearningScreen, immediately after destructuring:
+const { mode, setMode } = useAppContext();
+
+useEffect(() => {
+  if (isFamilyCapableProfile(activeProfile, profiles) && mode === 'family') {
+    setMode('study');
+  }
+}, [mode, setMode, activeProfile, profiles]);
+```
+
+Keep the existing `resolveTabShape() !== 'guardian'` redirect for non-capable users — it handles solo-learner and child-on-parent-account cases.
+
+**Tripwire note (Adversarial Review LOW-2).** After Route Survival fires `setMode('study')`, the user is on `/(app)/own-learning` with `returnToTab = OWN_LEARNING_RETURN_TO = 'own-learning'`. In Study mode the own-learning tab is hidden — deep navigations from this screen will return to a route whose tab button is invisible (home is still reachable). Existing behavior is identical for solo-learners that deep-link to `/(app)/own-learning`; v0 simply makes the path more reachable for family-capable adults. No fix in v0; v1 may want to normalize `returnToTab` to `'home'` after a mode-flip.
+
+- [ ] **Step 5.5: Run tests; verify green.**
+
+- [ ] **Step 5.6: Typecheck + lint.**
+
+- [ ] **Step 5.7: Commit via `/commit`.**
+
+---
+
+## Task 6: Mode switch UI (chip in `home.tsx`)
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/home.tsx`
+- Modify: `apps/mobile/src/components/home/LearnerScreen.tsx` (accept `mode` prop; mode-driven `showParentHome` branch)
+- Modify: `apps/mobile/src/lib/analytics.ts` — no signature change; v0 simply adds a new event-name call site. (Listed in spec front-matter for traceability.)
+
+- [ ] **Step 6.1: Read current `LearnerScreen` branch at lines 456-466.**
+
+Confirm shape matches the spec quote. Plan adjustment to replace `(hasLinkedChildren || isFamilyPlanOwner)` with `mode === 'family'`.
+
+- [ ] **Step 6.2: Write failing tests.**
+
+In `apps/mobile/src/app/(app)/home.test.tsx` (create if missing) add:
+
+```tsx
+// Cases:
+// 1. family-capable adult, mode='family' → chip renders with label "My Learning",
+//    context label reads "Family". setMode('study') + router.replace fires on tap.
+// 2. family-capable adult, mode='study' → chip renders with label "Family",
+//    context label reads "My Learning".
+// 3. non-family-capable user → no chip is rendered.
+// 4. Boot frame (mode=null) → no chip, no Family chrome.
+// 5. Rapid tap test (reentrancy guard) — two taps fire setMode only once.
+// 6. Analytics: track('mode_switched', { from, to, profileIdHash, accountAgeBucket })
+//    is called exactly once on tap.
+```
+
+Implementation tip: do not jest.mock the analytics module — read the breadcrumb buffer via a Sentry shim, or spy on the exported `track` import per repo convention. If unsure how analytics is tested in this repo, search for an existing analytics call-site test.
+
+**Test mock posture (Adversarial Review MEDIUM-4).** `home.tsx` transitively pulls hooks (`useDashboard`, `useLearnerProfile`, celebration hooks) that touch SecureStore via `ProfileProvider`. Existing screen tests handle this with `jest.mock('../../lib/profile' /* gc1-allow: ProfileProvider uses SecureStore native storage */, ...)` — see canonical example at `apps/mobile/src/app/(app)/progress/reports/index.test.tsx:55` and `apps/mobile/src/app/(app)/library.test.tsx:304`. For v0 tests, prefer the same `<ProfileContext.Provider value={...}>` wrapper pattern used in Task 2 to inject fixtures directly — that avoids needing the `gc1-allow` exception. If you must mock an internal module, annotate the same line with `// gc1-allow: <reason>` and explain in the commit body. **Never** add a bare `jest.mock('./...')` without the annotation — GC1 ratchet will fail CI.
+
+- [ ] **Step 6.3: Run; verify red.**
+
+- [ ] **Step 6.4: Implement the chip in `home.tsx`.**
+
+In `apps/mobile/src/app/(app)/home.tsx`:
+
+```tsx
+import { useRef } from 'react';
+import { useAppContext } from '../../lib/app-context';
+import { isFamilyCapableProfile } from '../../lib/profile';
+import { bucketAccountAge, hashProfileId, track } from '../../lib/analytics';
+
+// inside HomeScreen, after celebration setup:
+const { mode, setMode } = useAppContext();
+const familyCapable = isFamilyCapableProfile(activeProfile, profiles);
+const switchingRef = useRef(false);
+
+const onModeSwitch = () => {
+  if (!mode || !activeProfile) return;
+  if (switchingRef.current) return; // reentrancy guard
+  switchingRef.current = true;
+  const next = mode === 'family' ? 'study' : 'family';
+  track('mode_switched', {
+    from: mode,
+    to: next,
+    profileIdHash: hashProfileId(activeProfile.id),
+    accountAgeBucket: bucketAccountAge(activeProfile.createdAt),
+  });
+  setMode(next);
+  router.replace('/(app)/home');
+  // Release the guard on next tick so navigation can settle.
+  setTimeout(() => {
+    switchingRef.current = false;
+  }, 0);
+};
+```
+
+Render the chip above `<LearnerScreen>` inside the existing return JSX, only when `familyCapable && mode !== null`. Pass `mode` to `<LearnerScreen mode={mode}>` as a new prop.
+
+Visual shape (placeholder copy — match existing chip components for styling):
+
+```tsx
+{familyCapable && mode !== null ? (
+  <View className="px-5 pt-3">
+    <View className="flex-row items-center justify-between">
+      <Text className="text-body-sm text-text-secondary">
+        {mode === 'family' ? 'Family' : 'My Learning'}
+      </Text>
+      <Pressable
+        onPress={onModeSwitch}
+        accessibilityRole="button"
+        accessibilityLabel={`Switch to ${mode === 'family' ? 'My Learning' : 'Family'}`}
+        testID="mode-switch-chip"
+      >
+        <Text className="text-body-sm text-primary">
+          {mode === 'family' ? 'My Learning' : 'Family'}
+        </Text>
+      </Pressable>
+    </View>
+  </View>
+) : null}
+```
+
+- [ ] **Step 6.5: Update `LearnerScreen.tsx` to accept `mode` and use it to drive `showParentHome`.**
+
+In `apps/mobile/src/components/home/LearnerScreen.tsx` lines 456-466:
+
+```tsx
+// Add `mode?: 'study' | 'family' | null` to LearnerScreenProps.
+// Replace the existing block with a flag-gated branch:
+
+import { FEATURE_FLAGS } from '../../lib/feature-flags';
+
+const showParentHomeForMode = FEATURE_FLAGS.MODE_NAV_V0_ENABLED
+  ? mode === 'family'
+  : hasLinkedChildren || isFamilyPlanOwner; // legacy fallback
+
+if (showParentHome && !isParentProxy && showParentHomeForMode) {
+  return <ParentHomeScreen activeProfile={activeProfile} now={now} />;
+}
+```
+
+**Keep** the `isFamilyPlanOwner` variable AND the `hasLinkedChildren` lookup — they're consumed by the flag-off branch. Task 0 needs both code paths in the file so the flip works without a rebuild. Confirm no other callers expect either variable to be gone.
+
+- [ ] **Step 6.6: Run tests; verify green.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/app/\(app\)/home.tsx src/components/home/LearnerScreen.tsx --no-coverage
+```
+
+- [ ] **Step 6.7: Typecheck + lint.**
+
+- [ ] **Step 6.8: Commit via `/commit`.**
+
+---
+
+## Task 7: Family home — adult-study activation card
+
+**Files:**
+- Modify: `apps/mobile/src/components/home/ParentHomeScreen.tsx`
+- Modify: its co-located test file (or create)
+
+- [ ] **Step 7.1: Write failing test.**
+
+Cases:
+1. Family-capable adult in Family mode → card renders, action labelled "Go to My Learning".
+2. Tapping the card calls `setMode('study')` and `router.replace('/(app)/home')` — same path as the header chip.
+3. Card is hidden in proxy mode and for Study mode users.
+
+- [ ] **Step 7.2: Run; verify red.**
+
+- [ ] **Step 7.3: Implement the card.**
+
+In `ParentHomeScreen.tsx`, add a quiet card below the main child/family summary content. Use a shared switch handler that mirrors the header behavior. Suggested copy:
+
+```tsx
+import { useAppContext } from '../../lib/app-context';
+
+const { mode, setMode } = useAppContext();
+const router = useRouter();
+
+const onGoToMyLearning = () => {
+  setMode('study');
+  router.replace('/(app)/home');
+};
+
+{mode === 'family' && !isParentProxy ? (
+  <View className="mx-5 mt-4 p-4 bg-surface rounded-card border border-border">
+    <Text className="text-body-sm font-semibold text-text-primary">
+      Want to study too?
+    </Text>
+    <Text className="text-body-sm text-text-secondary mt-1">
+      Build your own progress alongside your child.
+    </Text>
+    <Pressable
+      onPress={onGoToMyLearning}
+      className="mt-3 self-start"
+      accessibilityRole="button"
+      accessibilityLabel="Go to My Learning"
+      testID="activation-card-go-my-learning"
+    >
+      <Text className="text-body text-primary">Go to My Learning</Text>
+    </Pressable>
+  </View>
+) : null}
+```
+
+- [ ] **Step 7.4: Run tests; verify green.**
+
+- [ ] **Step 7.5: Typecheck + lint.**
+
+- [ ] **Step 7.6: Commit via `/commit`.**
+
+---
+
+## Task 8: Family home — Recent child activity section
+
+**Files:**
+- Modify: `apps/mobile/src/components/home/ParentHomeScreen.tsx`
+- Modify: its co-located test file
+
+- [ ] **Step 8.1: Confirm `DashboardChild` shape.**
+
+Read `packages/schemas/src/progress.ts:310-340`. Verify fields: `sessionsThisWeek`, `sessionsLastWeek`, `totalTimeThisWeek`, `totalTimeLastWeek`, `currentStreak`, `trend`. No `lastActivityAt`. No per-session array. **Do not add either** — that's v1.
+
+- [ ] **Step 8.2: Write failing tests.**
+
+Cases:
+1. Family mode + children with `sessionsThisWeek > 0` → tiles render, ordered `sessionsThisWeek desc` then `totalTimeThisWeek desc`.
+2. Family mode + all children `sessionsThisWeek === 0` → named empty state copy "waiting for first session this week".
+3. Tile tap navigates to `/(app)/child/[profileId]`.
+4. Study mode → section is not rendered.
+
+**Test mock posture (Adversarial Review MEDIUM-4).** `ParentHomeScreen.tsx` calls `useDashboard()` at line 775, which touches the api-client + SecureStore. Prefer the `<ProfileContext.Provider value={...}>` + a mocked QueryClient with pre-seeded data over `jest.mock('../../lib/profile')`. If a `gc1-allow`-annotated mock is unavoidable, add `// gc1-allow: ProfileProvider uses SecureStore native storage` on the same `jest.mock(` line. Follow the canonical pattern at `apps/mobile/src/app/(app)/progress/reports/index.test.tsx:55`.
+
+- [ ] **Step 8.3: Run; verify red.**
+
+- [ ] **Step 8.4: Implement the section.**
+
+In `ParentHomeScreen.tsx`:
+
+```tsx
+// `useDashboard()` is already called in this file. Read `dashboard?.children`.
+const recentChildren = useMemo(() => {
+  const children = dashboard?.children ?? [];
+  return [...children].sort((a, b) => {
+    if (b.sessionsThisWeek !== a.sessionsThisWeek) {
+      return b.sessionsThisWeek - a.sessionsThisWeek;
+    }
+    return b.totalTimeThisWeek - a.totalTimeThisWeek;
+  });
+}, [dashboard?.children]);
+
+const anyActivity = recentChildren.some((c) => c.sessionsThisWeek > 0);
+
+{mode === 'family' ? (
+  <View className="mx-5 mt-4" testID="recent-child-activity">
+    <Text className="text-h3 font-semibold text-text-primary">
+      Recent child activity
+    </Text>
+    {anyActivity ? (
+      recentChildren.map((c) => (
+        <Pressable
+          key={c.profileId}
+          onPress={() => router.push(`/(app)/child/${c.profileId}` as Href)}
+          accessibilityRole="button"
+          accessibilityLabel={`${c.displayName} activity`}
+          testID={`child-activity-tile-${c.profileId}`}
+          className="mt-3 p-3 bg-surface rounded-card border border-border"
+        >
+          <Text className="text-body font-semibold text-text-primary">
+            {c.displayName}
+          </Text>
+          {/*
+            Adversarial Review Pass 2 MEDIUM-1: do NOT render `c.trend` raw —
+            its enum values are 'up' | 'down' | 'stable', and "5 sessions this
+            week · up" is broken UX. The trend visualization is deferred to
+            v1 along with the rest of Recaps; v0's tile is intentionally
+            minimal. Also avoids triggering `feedback_positive_framing_no_struggle`
+            for the 'down' value.
+           */}
+          <Text className="text-body-sm text-text-secondary">
+            {c.sessionsThisWeek} sessions this week
+          </Text>
+        </Pressable>
+      ))
+    ) : (
+      <View className="mt-3 p-3 bg-surface rounded-card border border-border">
+        <Text className="text-body-sm text-text-secondary">
+          Waiting for first session this week.
+        </Text>
+      </View>
+    )}
+  </View>
+) : null}
+```
+
+- [ ] **Step 8.5: Run tests; verify green.**
+
+- [ ] **Step 8.6: Typecheck + lint.**
+
+- [ ] **Step 8.7: Commit via `/commit`.**
+
+---
+
+## Task 9: Progress filtering by mode
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/progress/index.tsx`
+- Modify: its co-located test file
+
+- [ ] **Step 9.1: Write failing tests.**
+
+Cases:
+1. Family mode → profile picker exposes child profiles only; default selection = most-recently-active child (by `sessionsThisWeek` or existing logic — read current picker behaviour).
+2. Family mode → adult self profile is hidden.
+3. Study mode → picker is hidden; data scope = adult self.
+4. Boot frame (`mode === null`) → render a loading state; do not fetch.
+5. **Mode flip Family→Study while `selectedProfileId` is a child id** (Adversarial Review Pass 2 CRITICAL-3) → `selectedProfileId` resets to `activeProfile.id` and the dashboard.children fetch never fires after the flip. Mock `client.dashboard.children[':profileId'].sessions.$get` and assert zero calls post-flip.
+6. **Deep-link `?profileId=<childId>` in Study mode** (Adversarial Review Pass 2 CRITICAL-4) → `requestedProfileId` is ignored when `mode === 'study'` and `requestedProfileId !== activeProfile.id`. The screen renders adult-self data, not the child.
+
+- [ ] **Step 9.2: Run; verify red.**
+
+- [ ] **Step 9.3: Implement filtering.**
+
+In `progress/index.tsx`, read `mode` from `useAppContext()`. Wrap the mode-aware behavior in a flag check so flag-off keeps today's picker:
+
+```tsx
+import { FEATURE_FLAGS } from '../../../lib/feature-flags';
+
+const { mode } = useAppContext();
+
+// Task 0 kill-switch: when the flag is off, mode is always null. Skip the
+// mode-aware filter, loading state, and resets entirely — fall through to
+// today's behavior (selectableProfiles = self + linked children).
+if (FEATURE_FLAGS.MODE_NAV_V0_ENABLED) {
+  // While mode resolves, render the existing loading state.
+  if (mode === null) return <LoadingState />; // adapt to current loading UI
+
+  const selectableProfiles =
+    mode === 'family'
+      ? profiles.filter((p) => p.id !== activeProfile?.id && !p.isOwner)
+      : profiles.filter((p) => p.id === activeProfile?.id);
+
+  // Default-selection rule for Family mode: pick the child with the highest
+  // sessionsThisWeek (fall back to first child if none have activity).
+} else {
+  // Legacy behavior: today's `selectableProfiles` derivation (self + all linked).
+  // Leave the existing logic in place; do NOT delete it. The flag-off path
+  // depends on it.
+}
+```
+
+Hide the picker entirely when `selectableProfiles.length <= 1`.
+
+**Note for implementer:** rather than literal `if/else` blocks around large sections, use a single derived `selectableProfiles` value with a ternary on `FEATURE_FLAGS.MODE_NAV_V0_ENABLED`, and gate the loading state + reset effects on the flag. Keep both paths in the same file so the OTA flip works without a rebuild.
+
+**Reset `selectedProfileId` on Family→Study flip (Adversarial Review Pass 2 CRITICAL-3).** The existing `selectedProfileId` useState (`progress/index.tsx:512-519`) seeds from `requestedProfileId` or `activeProfile.id` and persists across renders. When the user flips from Family to Study with `selectedProfileId === childId`, the downstream `useProfileSessions(selectedProfileId)` will (a) include `mode='study'` in the queryKey AND (b) hit `client.dashboard.children[':profileId'].sessions.$get` because the existing `enabled` clause only checks `isOwner === true`. Result: child data fetched into Study cache. Fix at this layer by resetting `selectedProfileId` to self the moment mode flips out of Family:
+
+```tsx
+useEffect(() => {
+  if (mode === 'study' && selectedProfileId && selectedProfileId !== activeProfile?.id) {
+    setSelectedProfileId(activeProfile?.id ?? '');
+  }
+}, [mode, selectedProfileId, activeProfile?.id]);
+```
+
+**Reject deep-link `?profileId=<foreign>` in Study mode (Adversarial Review Pass 2 CRITICAL-4).** The two existing `requestedProfileId` seed paths at `progress/index.tsx:512-531` accept any linked-child id. In Study mode, reject the request:
+
+```tsx
+// In both useState initializer and the requestedProfileId useEffect:
+const knownRequestedProfileId =
+  requestedProfileId &&
+  (requestedProfileId === activeProfile?.id ||
+    (mode === 'family' && linkedChildren.some((child) => child.id === requestedProfileId)));
+```
+
+Add a defense-in-depth gate to the fetch hooks themselves (see Task 11b update below) so a future refactor that misses this reset still cannot leak.
+
+- [ ] **Step 9.4: Run tests; verify green.**
+
+- [ ] **Step 9.5: Typecheck + lint.**
+
+- [ ] **Step 9.6: Commit via `/commit`.**
+
+---
+
+## Task 10: `MODE_SCOPED_KEYS` + extract `PROFILE_SCOPED_KEYS` to module-level
+
+**Files:**
+- Create: `apps/mobile/src/lib/mode-scoped-keys.ts`
+- Create: `apps/mobile/src/lib/mode-scoped-keys.test.ts`
+- Modify: `apps/mobile/src/lib/profile.ts` (move inline `PROFILE_SCOPED_KEYS` to module-level `const` and export it — see Adversarial Review Pass 2 CRITICAL-1: the four mode-scoped prefixes are **already present** in the existing list at `profile.ts:262, 264, 265, 294`. No additions needed. Earlier review-pass note "forward-only bug fix" was stale.)
+- Modify: `apps/mobile/src/lib/profile.test.tsx` (guard test)
+
+- [ ] **Step 10.1: Write the guard test.**
+
+Create `apps/mobile/src/lib/mode-scoped-keys.test.ts`:
+
+```ts
+import { MODE_SCOPED_KEYS } from './mode-scoped-keys';
+import { PROFILE_SCOPED_KEYS_FOR_TEST } from './profile';
+
+describe('MODE_SCOPED_KEYS', () => {
+  it('is non-empty', () => {
+    expect(MODE_SCOPED_KEYS.length).toBeGreaterThan(0);
+  });
+
+  it('every mode-scoped key is also profile-scoped', () => {
+    for (const key of MODE_SCOPED_KEYS) {
+      expect(PROFILE_SCOPED_KEYS_FOR_TEST).toContain(key);
+    }
+  });
+
+  it('includes the six required prefixes', () => {
+    expect(MODE_SCOPED_KEYS).toEqual(
+      expect.arrayContaining([
+        'progress',
+        'dashboard',
+        'session',
+        'session-transcript',
+        'session-summary',
+        'parking-lot',
+      ]),
+    );
+  });
+});
+```
+
+- [ ] **Step 10.2: Run test; verify red (file missing).**
+
+- [ ] **Step 10.3: Create `mode-scoped-keys.ts`.**
+
+```ts
+// Single source of truth for which queryKey[0] prefixes get invalidated on a
+// mode switch. See spec §Step 8 and §Hard Rule #7.
+//
+// The list intentionally uses singular 'session' (not plural). The plural
+// 'sessions' in PROFILE_SCOPED_KEYS is a latent dead entry — out of scope to
+// remove in v0.
+export const MODE_SCOPED_KEYS = [
+  'progress',
+  'dashboard',
+  'session',
+  'session-transcript',
+  'session-summary',
+  'parking-lot',
+] as const;
+
+export type ModeScopedKey = (typeof MODE_SCOPED_KEYS)[number];
+```
+
+- [ ] **Step 10.4: Move `PROFILE_SCOPED_KEYS` to module-level in `profile.ts` and export for tests.**
+
+In `apps/mobile/src/lib/profile.ts`:
+
+1. **Copy the existing array verbatim** from `profile.ts:252-307` to module-level. Do not retype, trim, or reorder — the live list has 52 entries. **Do not add anything** — the four mode-scoped prefixes (`'session'`, `'session-summary'`, `'session-transcript'`, `'parking-lot'`) are already in the list (lines 262, 264, 265, 294). The plan revision history previously claimed they needed to be added; that claim was based on an out-of-date read of the file (Adversarial Review Pass 2 CRITICAL-1 / CRITICAL-2). Re-read the file before the move.
+
+```ts
+// Module-level so the test guard and consumers can import.
+// SOURCE OF TRUTH: copy verbatim from the existing inline array in
+// switchProfile (`profile.ts:252-307` pre-move). Do NOT retype — copy the
+// literal so no entry is lost. Adversarial Review Pass 2 CRITICAL-2 caught
+// an earlier draft that dropped ~27 entries (`all-notes`, `bookmarks`,
+// `celebrations`, `consent`, `topic-notes`, `library`, `vocabulary`,
+// `learner-profile`, `quiz-round*`, `language-progress`, `resume-nudge`, …).
+// Each missing entry would silently regress profile-switch invalidation.
+export const PROFILE_SCOPED_KEYS_FOR_TEST = [
+  // ← paste the 52-entry array from profile.ts:252-307 here, unchanged.
+] as const;
+```
+
+2. Inside `switchProfile`, replace the inline literal with a reference to the module-level constant.
+
+3. After the move, run `git diff profile.ts` and visually confirm: (a) the inline array body is gone from `switchProfile`; (b) the module-level array has **exactly** the same entries — same count, same order, no additions, no removals.
+
+The `_FOR_TEST` suffix communicates "this is exported only because a test needs the list" — production code reads it via `switchProfile`.
+
+- [ ] **Step 10.5: Run tests; verify green.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/mode-scoped-keys.ts src/lib/profile.ts --no-coverage
+```
+
+- [ ] **Step 10.6: Typecheck + lint.**
+
+- [ ] **Step 10.7: Commit via `/commit`.**
+
+---
+
+## Task 11: Query-key factory mode-segmentation
+
+This task touches every mode-scoped factory in `query-keys.ts` and every consuming hook. It's mechanical but wide. Do it in three sub-commits to keep diffs reviewable.
+
+**Files (Task 11 total):**
+- Modify: `apps/mobile/src/lib/query-keys.ts`
+- Modify: `apps/mobile/src/lib/query-keys.test.ts`
+- Modify: `apps/mobile/src/hooks/use-progress.ts`
+- Modify: `apps/mobile/src/hooks/use-dashboard.ts`
+- Modify: `apps/mobile/src/hooks/use-sessions.ts` (Adversarial Review CRITICAL-2) — 7 `queryKeys.sessions.*` call sites at lines 530, 563, 657, 684, 727, 745. ALSO rewrite 2-element invalidations at lines 218 (`['session-transcript', sessionId]`) and 247 (`['session', sessionId]`) per CRITICAL-1.
+- Modify: `apps/mobile/src/hooks/use-retry-filing.ts` (Adversarial Review CRITICAL-1) — 2-element invalidations at lines 27 and 29.
+- Modify: any other callers found by grep before editing.
+
+### Task 11a: Update `query-keys.ts` factories
+
+- [ ] **Step 11a.1: Read the current factory definitions** in `apps/mobile/src/lib/query-keys.ts` (lines 26-210).
+
+- [ ] **Step 11a.2: Write failing test updates.**
+
+Edit `apps/mobile/src/lib/query-keys.test.ts`. For each factory in the table below, update the expected key shape:
+
+| Factory | Old shape | New shape |
+|---|---|---|
+| `progress.subject` | `['progress', 'subject', subjectId, profileId]` | `['progress', mode, 'subject', subjectId, profileId]` |
+| `progress.overview` | `['progress', 'overview', profileId]` | `['progress', mode, 'overview', profileId]` |
+| `progress.continue` | `['progress', 'continue', profileId]` | `['progress', mode, 'continue', profileId]` |
+| `progress.resumeTarget` | `['progress', 'resume-target', profileId, …]` | `['progress', mode, 'resume-target', profileId, …]` |
+| `progress.activeSessionForTopic` | `['progress', 'topic', topicId, 'active-session', profileId]` | `['progress', mode, 'topic', topicId, 'active-session', profileId]` |
+| `progress.resolveTopicSubject` | `['progress', 'topic', topicId, 'resolve', profileId]` | `['progress', mode, 'topic', topicId, 'resolve', profileId]` |
+| `progress.reviewSummary` | `['progress', 'review-summary', profileId]` | `['progress', mode, 'review-summary', profileId]` |
+| `progress.overdueTopics` | `['progress', 'overdue-topics', profileId]` | `['progress', mode, 'overdue-topics', profileId]` |
+| `progress.topicProgress` | `['progress', 'topic', subjectId, topicId, profileId]` | `['progress', mode, 'topic', subjectId, topicId, profileId]` |
+| `progress.inventory` | `['progress', 'inventory', profileId]` | `['progress', mode, 'inventory', profileId]` |
+| `progress.history` | `['progress', 'history', profileId, query]` | `['progress', mode, 'history', profileId, query]` |
+| `progress.milestones` | `['progress', 'milestones', profileId, limit]` | `['progress', mode, 'milestones', profileId, limit]` |
+| `progress.profileSessions` | `['progress', 'profile', profileId, 'sessions', activeProfileId]` | `['progress', mode, 'profile', profileId, 'sessions', activeProfileId]` |
+| `progress.profileReports` | same | `['progress', mode, 'profile', profileId, 'reports', activeProfileId]` |
+| `progress.profileWeeklyReports` | same | `['progress', mode, 'profile', profileId, 'weekly-reports', activeProfileId]` |
+| `progress.profileReportDetail` | `['progress', 'profile', activeProfileId, 'report', reportId]` | `['progress', mode, 'profile', activeProfileId, 'report', reportId]` |
+| `progress.profileWeeklyReportDetail` | `['progress', 'profile', activeProfileId, 'weekly-report', reportId]` | `['progress', mode, 'profile', activeProfileId, 'weekly-report', reportId]` |
+| `dashboard.root` | `['dashboard', profileId]` | `['dashboard', mode, profileId]` |
+| `dashboard.childDetail` | `['dashboard', 'child', childProfileId]` | `['dashboard', mode, 'child', childProfileId]` |
+| `dashboard.childSubject` | same shape, mode after `'dashboard'` |
+| `dashboard.childSessions` | same |
+| `dashboard.childSessionDetail` | same |
+| `dashboard.childMemory` | same |
+| `dashboard.childInventory` | same |
+| `dashboard.childHistory` | same |
+| `dashboard.childProgressSummary` | same |
+| `dashboard.childReports` | same |
+| `dashboard.childReportDetail` | same |
+| `dashboard.childWeeklyReports` | same |
+| `dashboard.childWeeklyReportDetail` | same |
+| `sessions.detail` | `['session', sessionId, profileId]` | `['session', mode, sessionId, profileId]` |
+| `sessions.transcript` | `['session-transcript', sessionId, profileId]` | `['session-transcript', mode, sessionId, profileId]` |
+| `sessions.summary` | same shape, mode after the domain string |
+| `sessions.parkingLot` | same |
+| `sessions.topicParkingLot` | `['parking-lot', 'topic', subjectId, topicId, profileId]` | `['parking-lot', mode, 'topic', subjectId, topicId, profileId]` |
+
+Note: `mode` here means the `AppMode | null` runtime value. When `mode === null`, the hook returns `{ enabled: false }` and the query never fires.
+
+**Cold-refetch cost on every mode toggle (Adversarial Review Pass 2 MEDIUM-3).** Inserting `mode` at `queryKey[1]` partitions the cache between Family and Study. Each toggle dirties the new-mode key and forces a full refetch of `dashboard.root` (the parent dashboard with all child info) and every `progress.*` query the user has visited. For v0 this is an acceptable trade-off — the partition is what guarantees Hard Rule #6 (no cross-mode cache leak) without server work. Do NOT try to seed the new-mode key from the old-mode key via `setQueryData` in v0; the seed is only safe if you can prove the response shape is mode-independent for every factory, which the spec does not guarantee. v1 may pre-seed once the server-backed mode lands.
+
+Test assertion example (apply to every changed factory):
+
+```ts
+it('progress.overview includes mode segment', () => {
+  expect(queryKeys.progress.overview('family', 'p1')).toEqual([
+    'progress', 'family', 'overview', 'p1',
+  ]);
+});
+```
+
+- [ ] **Step 11a.3: Run test; verify red.**
+
+- [ ] **Step 11a.4: Update factory signatures.**
+
+For each factory, prepend a `mode: 'study' | 'family' | null` argument **after** the leading domain string slot. Example:
+
+```ts
+overview: (mode: AppMode | null, profileId: string | undefined) =>
+  ['progress', mode, 'overview', profileId] as const,
+```
+
+Define `AppMode` import at top of `query-keys.ts`:
+
+```ts
+import type { AppMode } from './app-context';
+```
+
+- [ ] **Step 11a.5: Run query-keys tests; verify green.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/query-keys.ts --no-coverage
+```
+
+This will leave many **consumer** call sites broken (typecheck failures). That's expected — fix in 11b.
+
+- [ ] **Step 11a.6: Do NOT commit yet (Adversarial Review LOW-3).**
+
+The factory signature change leaves consumer call sites broken at typecheck. The pre-commit hook runs `tsc --noEmit` — a typecheck-red commit will be blocked, and per `CLAUDE.md → feedback_precommit_typecheck` we never bypass the hook. Stage the factory edits but defer the commit until 11c is complete; commit Tasks 11a + 11b + 11c as a single unit at the end of Task 11c.5 (renumbered below). No commit on disk is typecheck-red.
+
+### Task 11b: Thread `mode` through `use-progress.ts` and `use-dashboard.ts`
+
+- [ ] **Step 11b.1: Read each hook in `use-progress.ts` and `use-dashboard.ts`.**
+
+- [ ] **Step 11b.2: At the top of each consuming hook, read `mode` from `useAppContext()` and pass it into the factory.**
+
+```ts
+const { mode } = useAppContext();
+// inside useQuery options:
+useQuery({
+  queryKey: queryKeys.progress.overview(mode, activeProfile?.id),
+  enabled: mode !== null && Boolean(activeProfile?.id),
+  // …
+});
+```
+
+Apply the pattern across every consumer of factories in the §11a table.
+
+- [ ] **Step 11b.2a: Tighten `enabled` for foreign-profile hooks (Adversarial Review Pass 2 CRITICAL-3 — defense in depth).**
+
+The following hooks accept a `profileId` argument that can refer to a non-self profile and dispatch to `client.dashboard.children[':profileId'].*`. Today their `enabled` clause only checks `activeProfile.isOwner === true` — a Study-mode user with a stale `selectedProfileId === childId` (e.g., from a Family→Study flip or a `?profileId=<childId>` deep link) will fetch child data into the Study cache. Tighten each:
+
+| Hook | File:line | Add to `enabled` |
+|---|---|---|
+| `useProfileSessions` | `use-progress.ts:449-452` | `&& (mode === 'family' \|\| profileId === activeProfile.id)` |
+| `useProfileReports` | grep `enabled` in the same file | same |
+| `useProfileWeeklyReports` | same | same |
+| `useChildInventory` | same | `&& mode === 'family'` (child-only endpoint) |
+| `useChildProgressSummary` | same | `&& mode === 'family'` (child-only endpoint) |
+
+This is **defense in depth**: Task 9's `selectedProfileId` reset is the primary fix; this gate stops a future refactor that misses the reset from leaking data anyway. Add a test that primes `selectedProfileId=childId`, sets `mode='study'`, and asserts no call to `client.dashboard.children[':profileId'].*` is observed.
+
+- [ ] **Step 11b.3: Run hook tests and typecheck.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/hooks/use-progress.ts src/hooks/use-dashboard.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+Typecheck will still be red at this point if `use-sessions.ts` consumer sites in Task 11c are not yet updated. That's expected. Do **not** commit yet — 11c follows immediately (Adversarial Review LOW-3).
+
+### Task 11c: Thread `mode` through `sessions.*` callers + rewrite 2-element session invalidations
+
+- [ ] **Step 11c.1: Grep for every call site.**
+
+```bash
+# Use Grep tool with:
+# pattern: "queryKeys\\.sessions\\."
+# This catches detail / transcript / summary / parkingLot / topicParkingLot.
+# Expected hits include: apps/mobile/src/hooks/use-sessions.ts (7 sites at
+# lines 530, 563, 657, 684, 727, 745).
+```
+
+- [ ] **Step 11c.2: Update each call site to pass `mode` from `useAppContext()`.**
+
+Pattern repeats from 11b. Where the call site is outside a component (e.g. a service helper), the helper signature gets a `mode` argument and the caller threads it in.
+
+- [ ] **Step 11c.3: Rewrite 2-element session-prefix invalidations (Adversarial Review CRITICAL-1).**
+
+After `mode` is inserted at queryKey[1], the new session-domain keys are:
+- `sessions.detail`: `['session', mode, sessionId, profileId]`
+- `sessions.transcript`: `['session-transcript', mode, sessionId, profileId]`
+
+There are existing **2-element prefix invalidations** in the codebase that match positionally — they will silently fail after the insertion because position 1 is now `mode`, not `sessionId`:
+
+| File | Line | Current call | Why it breaks |
+|---|---|---|---|
+| `apps/mobile/src/hooks/use-retry-filing.ts` | 27 | `queryClient.invalidateQueries({ queryKey: ['session', sessionId] })` | After v0: `queryKey[1]` is the mode literal, not `sessionId`. No match. |
+| `apps/mobile/src/hooks/use-retry-filing.ts` | 29 | `queryClient.invalidateQueries({ queryKey: ['session-transcript', sessionId] })` | Same. |
+| `apps/mobile/src/hooks/use-sessions.ts` | 218 | `queryClient.invalidateQueries({ queryKey: ['session-transcript', sessionId] })` | Same. |
+| `apps/mobile/src/hooks/use-sessions.ts` | 247 | `queryClient.invalidateQueries({ queryKey: ['session', sessionId] })` | Same. |
+
+User-visible consequence if left untouched: after retry-filing or session-close, session detail + transcript caches are not invalidated; the screen continues showing stale data until the next manual refresh.
+
+Rewrite each site to use a **factory-co-located predicate** so the position contract sits next to the factory definition (Adversarial Review Pass 2 MEDIUM-2). In `apps/mobile/src/lib/query-keys.ts`, alongside `sessions.detail` / `sessions.transcript`, export:
+
+```ts
+// Returns a TanStack Query predicate that matches the session-detail and/or
+// session-transcript keys for a given sessionId across every mode segment.
+// Co-located here so the "sessionId lives at queryKey[2] after the mode
+// insertion at [1]" contract is enforced beside the factory that creates it.
+sessions: {
+  // … existing factories …
+  matchAnyMode: (sessionId: string) =>
+    (q: { queryKey: ReadonlyArray<unknown> }) =>
+      (q.queryKey[0] === 'session' || q.queryKey[0] === 'session-transcript') &&
+      q.queryKey[2] === sessionId,
+  matchDetailAnyMode: (sessionId: string) =>
+    (q: { queryKey: ReadonlyArray<unknown> }) =>
+      q.queryKey[0] === 'session' && q.queryKey[2] === sessionId,
+},
+```
+
+Then rewrite each call site to use the predicate:
+
+```ts
+// use-retry-filing.ts:26-31 — replace both invalidations with:
+void queryClient.invalidateQueries({
+  predicate: queryKeys.sessions.matchAnyMode(sessionId),
+});
+
+// use-sessions.ts:218 — replace with:
+void queryClient.invalidateQueries({
+  predicate: queryKeys.sessions.matchAnyMode(sessionId),
+});
+
+// use-sessions.ts:247 — `['session', sessionId]` only, so use the detail-only variant:
+void queryClient.invalidateQueries({
+  predicate: queryKeys.sessions.matchDetailAnyMode(sessionId),
+});
+```
+
+The user-visible consequence if left untouched is the same as the previous-review note: after retry-filing or session-close, session detail + transcript caches are not invalidated and the screen continues showing stale data.
+
+Add a test in `use-retry-filing.test.ts` (or extend an existing one) that primes the cache with `['session', 'study', sessionId, profileId]` and `['session', 'family', sessionId, profileId]` entries, fires the retry-filing mutation, and asserts both are invalidated regardless of mode.
+
+- [ ] **Step 11c.4: `_layout.tsx` + `invalidateSessionDerivedQueries` broad invalidations are unchanged.**
+
+The header comment in `query-keys.ts:10-12` notes:
+> Broad-prefix invalidations (`['progress']`, `['dashboard']`, etc.) in `_layout.tsx` and `invalidateSessionDerivedQueries` are handled in PR 10 and remain as inline literals for now.
+
+`invalidateSessionDerivedQueries` (`use-sessions.ts:45-60`) uses 1-element prefixes (`['progress']`, `['dashboard']`, `['retention']`, `['language-progress']`, `['resume-nudge']`). These match `queryKey[0]` only and **remain correct** after the `mode` insertion at `queryKey[1]`. Add a one-line comment at each broad-invalidation site:
+
+```ts
+// queryKey[0] === 'progress' still matches; mode segment added at [1] in v0.
+```
+
+This step is **only** for the 1-element prefixes. The 2-element `['session', sessionId]` invalidations are handled in 11c.3 above — they are NOT safe.
+
+- [ ] **Step 11c.5: Run full validation, then commit Tasks 11a + 11b + 11c as ONE commit (Adversarial Review LOW-3).**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/hooks/use-sessions.ts src/hooks/use-retry-filing.ts src/lib/query-keys.ts --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx lint mobile
+```
+
+When all three are green, commit via `/commit` with a message that lists all three sub-tasks. No earlier commit was made; this is the single Task 11 commit.
+
+---
+
+## Task 12: Mode-switch query invalidation
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/home.tsx` (extend the existing `onModeSwitch` handler from Task 6)
+- Modify: `apps/mobile/src/components/home/ParentHomeScreen.tsx` (extend the activation-card handler from Task 7)
+
+- [ ] **Step 12.1: Write failing test in `home.test.tsx`.**
+
+```tsx
+it('invalidates MODE_SCOPED_KEYS on switch', async () => {
+  // Prime the queryClient with a query whose key[0] is 'progress' AND a query
+  // whose key[0] is 'subjects' (NOT in MODE_SCOPED_KEYS).
+  // Render home, tap the chip.
+  // Assert: 'progress' query is in 'invalidated' state; 'subjects' query is not.
+});
+```
+
+- [ ] **Step 12.2: Implement the invalidation predicate.**
+
+Extend the `onModeSwitch` handler:
+
+```ts
+import { useQueryClient } from '@tanstack/react-query';
+import { MODE_SCOPED_KEYS } from '../../lib/mode-scoped-keys';
+
+const queryClient = useQueryClient();
+
+const onModeSwitch = () => {
+  // … reentrancy guard, analytics …
+  setMode(next);
+  void queryClient.invalidateQueries({
+    predicate: (q) =>
+      MODE_SCOPED_KEYS.includes(
+        String(q.queryKey[0]) as (typeof MODE_SCOPED_KEYS)[number],
+      ),
+  });
+  router.replace('/(app)/home');
+};
+```
+
+Apply the same call in the activation-card handler in `ParentHomeScreen.tsx`.
+
+- [ ] **Step 12.3: Run tests; verify green.**
+
+- [ ] **Step 12.4: Commit via `/commit`.**
+
+---
+
+## Task 13: Proxy normal-path hide-out
+
+**Files:**
+- Identify and remove user-facing `setProxyMode(true)` call sites.
+- Preserve: the `setProxyMode` function itself, `signOutWithCleanup`'s `setProxyMode(false)`, `PARENT_PROXY_KEY` SecureStore handling, `PARENT_PROXY_TABS`, and `onSwitchBack` in `_layout.tsx:1685`.
+
+- [ ] **Step 13.1: Enumerate call sites.**
+
+```
+Grep pattern: "setProxyMode\\(true\\)"
+File scope: apps/mobile/src/**
+```
+
+- [ ] **Step 13.2: Classify each match.**
+
+For each match, decide: is the call reachable from a user-visible tap (profile row, profile picker, More screen, Settings) — or is it internal/synthetic? Write the classification into a scratch note in the commit message.
+
+- [ ] **Step 13.3: Write the forward-only guard test.**
+
+Create `apps/mobile/src/lib/proxy-entry-guard.test.ts`:
+
+```ts
+import { readFileSync } from 'fs';
+import { glob } from 'glob';
+
+it('no user-facing component calls setProxyMode(true)', async () => {
+  const files = await glob('apps/mobile/src/{components/profile,app/(app)/more}/**/*.{ts,tsx}');
+  const offenders: string[] = [];
+  for (const f of files) {
+    const src = readFileSync(f, 'utf8');
+    if (src.includes('setProxyMode(true)')) offenders.push(f);
+  }
+  expect(offenders).toEqual([]);
+});
+```
+
+(If the repo's existing forward-only-guard tests use a different harness — e.g. `persona-fossil-guard.test.ts` — match that shape.)
+
+- [ ] **Step 13.4: Delete the identified user-facing call sites.**
+
+For each user-facing match, remove the call (and the affordance that triggered it, e.g. a profile-row Pressable that previously offered "view as child").
+
+- [ ] **Step 13.5: Run tests; verify green.**
+
+- [ ] **Step 13.6: Typecheck + lint.**
+
+- [ ] **Step 13.7: Commit via `/commit`.**
+
+---
+
+## Task 14: Family route guard at `child/[profileId]/_layout.tsx`
+
+**Files:**
+- Create: `apps/mobile/src/components/guards/RequireFamilyContext.tsx`
+- Create: `apps/mobile/src/components/guards/RequireFamilyContext.test.tsx`
+- Modify: `apps/mobile/src/lib/navigation.ts` (add `useGuardFamilyRoute`)
+- Modify: `apps/mobile/src/app/(app)/child/[profileId]/_layout.tsx`
+- Modify: layout's co-located test
+
+- [ ] **Step 14.1: Write failing test for `RequireFamilyContext`.**
+
+```tsx
+// Cases:
+// 1. mode='family' → renders children immediately, no nav.
+// 2. mode='study' AND family-capable adult → setMode('family') fires, then renders.
+// 3. mode='study' AND non-capable user → renders a no-access fallback; never
+//    renders children.
+// 4. mode=null (boot) → renders nothing / a loading shim; defers decision.
+```
+
+- [ ] **Step 14.2: Run; verify red.**
+
+- [ ] **Step 14.3: Implement `RequireFamilyContext.tsx`.**
+
+```tsx
+import { useEffect, type ReactNode } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useAppContext } from '../../lib/app-context';
+import { isFamilyCapableProfile, useProfile } from '../../lib/profile';
+
+export function RequireFamilyContext({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  // Task 0 kill-switch: when MODE_NAV_V0_ENABLED is false, render children
+  // as a no-op pass-through. Today's protection for child routes is the
+  // existing `resolveTabShape() !== 'guardian'` redirect path on the
+  // non-capable user, which continues to work without this guard.
+  if (!FEATURE_FLAGS.MODE_NAV_V0_ENABLED) return <>{children}</>;
+
+  const { mode, setMode } = useAppContext();
+  const { activeProfile, profiles } = useProfile();
+  const router = useRouter();
+  const capable = isFamilyCapableProfile(activeProfile, profiles);
+
+  useEffect(() => {
+    if (mode === 'study' && capable) {
+      setMode('family');
+    }
+  }, [mode, capable, setMode]);
+
+  if (mode === null) return null; // boot — defer
+  if (mode === 'family') return <>{children}</>;
+  if (capable) return null; // mid-switch; next render renders children
+  // Non-capable user reached this route via deep link or notification:
+  return (
+    <View className="flex-1 items-center justify-center bg-background px-6" testID="require-family-fallback">
+      <Text className="text-body text-text-secondary text-center">
+        This view is only available in Family mode.
+      </Text>
+      <Pressable
+        onPress={() => router.replace('/(app)/home')}
+        className="mt-4 bg-primary rounded-button px-6 py-3 min-h-[48px] items-center justify-center"
+        accessibilityRole="button"
+        testID="require-family-go-home"
+      >
+        <Text className="text-text-inverse text-body font-semibold">Go to Home</Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+Also add `useGuardFamilyRoute()` to `apps/mobile/src/lib/navigation.ts`:
+
+```ts
+import { useEffect } from 'react';
+import { useAppContext } from './app-context';
+import { isFamilyCapableProfile, useProfile } from './profile';
+
+export function useGuardFamilyRoute(): { ready: boolean; capable: boolean } {
+  const { mode, setMode } = useAppContext();
+  const { activeProfile, profiles } = useProfile();
+  const capable = isFamilyCapableProfile(activeProfile, profiles);
+
+  useEffect(() => {
+    if (mode === 'study' && capable) setMode('family');
+  }, [mode, capable, setMode]);
+
+  return { ready: mode === 'family', capable };
+}
+```
+
+- [ ] **Step 14.4: Wrap the child layout.**
+
+Edit `apps/mobile/src/app/(app)/child/[profileId]/_layout.tsx`:
+
+```tsx
+import { Stack } from 'expo-router';
+import { useThemeColors } from '../../../../lib/theme';
+import { RequireFamilyContext } from '../../../../components/guards/RequireFamilyContext';
+
+export const unstable_settings = { initialRouteName: 'index' };
+
+export default function ChildDetailLayout() {
+  const colors = useThemeColors();
+  return (
+    <RequireFamilyContext>
+      <Stack
+        initialRouteName="index"
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: colors.background },
+        }}
+      >
+        <Stack.Screen name="session/[sessionId]" getId={({ params }) => params?.sessionId} />
+        <Stack.Screen name="report/[reportId]" getId={({ params }) => params?.reportId} />
+        <Stack.Screen name="weekly-report/[weeklyReportId]" getId={({ params }) => params?.weeklyReportId} />
+        <Stack.Screen name="subjects/[subjectId]" getId={({ params }) => params?.subjectId} />
+        <Stack.Screen name="topic/[topicId]" getId={({ params }) => params?.topicId} />
+      </Stack>
+    </RequireFamilyContext>
+  );
+}
+```
+
+- [ ] **Step 14.5: Update `_layout.test.tsx`.**
+
+Add tests covering at least **three distinct nested routes** — **one static** (`index`, `mentor-memory`, or `reports`) **and at least one dynamic** (`session/[sessionId]`, `report/[reportId]`, `weekly-report/[weeklyReportId]`, `subjects/[subjectId]`, or `topic/[topicId]`). The guard's purpose is route-class coverage, not one-path proof. **Why both shapes (Adversarial Review Pass 2 LOW-1):** static routes are auto-detected by Expo Router and are NOT listed in the `<Stack.Screen>` children of `_layout.tsx` — a regression that wraps only the dynamic screens explicitly would still leave static routes unguarded if the layout wrap itself were broken. Picking one of each shape proves the layout-level wrap covers both auto-detection paths.
+
+- [ ] **Step 14.6: Run tests; verify green.**
+
+- [ ] **Step 14.7: Typecheck + lint.**
+
+- [ ] **Step 14.8: Commit via `/commit`.**
+
+---
+
+## Task 15: Integration & cross-account safety tests
+
+**Files:**
+- Create/extend integration tests under `apps/mobile/src/lib/app-context.test.tsx` (or a dedicated `app-context.integration.test.tsx`).
+
+- [ ] **Step 15.1: Identity-loss reset test (AC #27).**
+
+```tsx
+it('synchronously resets mode to null when activeProfile transitions to null', () => {
+  // Render the hook with activeProfile=adult+kid → mode='family'.
+  // Rerender with activeProfile=null → expect mode === null in the same render pass.
+  // Then rerender with a NEW adultOwner (different id) + kid → expect mode='family'.
+  // Asserts no value of 'family' from the previous user is observable.
+});
+```
+
+- [ ] **Step 15.2: Cross-account safety test.**
+
+```tsx
+it('recomputes mode when activeProfile id changes without unmount', () => {
+  // User A: adult+kid → mode='family'.
+  // User B: solo adult → mode='study'.
+  // Verify the React context never carries 'family' into User B.
+});
+```
+
+- [ ] **Step 15.3: Rapid-toggle test (AC #21).**
+
+**Test the guard directly, not via simulated UI taps (Adversarial Review MEDIUM-2).** RN's `Pressable.onPress` events arrive sequentially as separate React commits, so two `.press()` calls inside `act(() => { press(); press(); })` would pass even if the `useRef` guard were removed — the test would assert success on a property the guard doesn't actually provide. Exercise the guard at its actual reentry vector: call `onModeSwitch()` twice synchronously within the same JS microtask.
+
+```tsx
+it('reentrant onModeSwitch within one tick is a no-op on the second call', () => {
+  const setModeSpy = jest.fn();
+  const trackSpy = jest.fn();
+  // Hoist onModeSwitch out of HomeScreen into a thin testable helper, OR
+  // render HomeScreen and reach into the handler via a testID-keyed event
+  // bus. Then:
+  // 1) Fire onModeSwitch() — synchronously.
+  // 2) BEFORE the setTimeout(() => switchingRef.current = false, 0) macrotask
+  //    flushes, fire onModeSwitch() again — synchronously, in the same tick.
+  // 3) Assert setModeSpy was called exactly once and trackSpy was called exactly once.
+  // 4) jest.runAllTimers(); call onModeSwitch() a third time — assert it now
+  //    fires (guard released).
+});
+```
+
+If hoisting the handler isn't practical, the next-best test is to extract the `useRef` + reentrancy logic into a tiny `useReentrancyGuard()` hook and unit-test that hook in isolation. Either way, do NOT assert reentrancy via `fireEvent.press(...); fireEvent.press(...)` — that path doesn't reach the guard.
+
+- [ ] **Step 15.4: Cache leak test.**
+
+```tsx
+it('switching from Family to Study invalidates MODE_SCOPED_KEYS and does not render stale child data', async () => {
+  // Prime cache with a family-scoped query.
+  // Switch mode.
+  // Assert: invalidated; subsequent render in Study mode does not display
+  //         any child data.
+});
+```
+
+- [ ] **Step 15.5: Detail-back fallback test.**
+
+```tsx
+it('goBackOrReplace lands on /(app)/home when opening child session detail via deep link and pressing back', () => {
+  // Mount detail directly; trigger back; assert router.replace called with /(app)/home.
+});
+```
+
+- [ ] **Step 15.6: Direct-child-route-while-Study test (covering 3+ routes).**
+
+For each of `child/[profileId]/index`, `child/[profileId]/session/[sessionId]`, `child/[profileId]/reports`:
+
+```tsx
+it('blocks child data render until mode flips to Family (route: <name>)', () => {
+  // Start in mode='study', family-capable adult.
+  // Mount the nested route.
+  // Assert RequireFamilyContext fires setMode('family') BEFORE any child data renders.
+});
+```
+
+- [ ] **Step 15.7: Boot-frame flicker test (AC #3).**
+
+```tsx
+it('does not flicker between Study and Family tab sets during initial profile load', () => {
+  // While useProfile().isLoading === true, mode === null and computeModeVisibleTabs
+  // returns ∅ — neither tab set is rendered.
+});
+```
+
+- [ ] **Step 15.8: Run the full integration test file.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/app-context.test.tsx --no-coverage
+```
+
+- [ ] **Step 15.9: Run a broader sanity sweep.**
+
+```bash
+cd apps/mobile && pnpm exec jest --no-coverage
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx lint mobile
+```
+
+Any failure here is a real regression — fix root cause, never weaken the failing assertion (per CLAUDE.md "Tests Must Reflect Reality").
+
+- [ ] **Step 15.10: Commit via `/commit`.**
+
+---
+
+## Task 16: Final acceptance criteria sweep
+
+- [ ] **Step 16.1: Walk every AC in the spec (§Acceptance Criteria #1-#27).**
+
+For each AC, locate the test that asserts it. Build a small AC → test mapping table in the PR description (or in a scratch note that lands in the `/commit` body).
+
+- [ ] **Step 16.2: Verify no `jest.mock()` was added for internal modules in this branch.**
+
+```
+Grep across the diff for new "jest.mock\\(['\"]\\.{1,2}/" or "jest.mock\\(['\"]@eduagent/" — should be zero.
+```
+
+If anything appears, refactor to `jest.requireActual` with targeted overrides (canonical: `apps/api/src/inngest/functions/interview-persist-curriculum.integration.test.ts`).
+
+- [ ] **Step 16.3: Verify `MODE_SCOPED_KEYS ⊆ PROFILE_SCOPED_KEYS` guard still passes.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/mode-scoped-keys.test.ts --no-coverage
+```
+
+- [ ] **Step 16.4: Verify no SecureStore mode-state leak.**
+
+```
+Grep for SecureStore keys containing "mode" or "app-context". Expected: zero matches.
+```
+
+If a match exists, the spec's hard rule was violated — remove the persistence and document in PR body.
+
+- [ ] **Step 16.5: Run change-class checker for the full branch diff.**
+
+```bash
+bash scripts/check-change-class.sh --branch
+```
+
+Address every reported validation step.
+
+- [ ] **Step 16.6: Final commit / push via `/commit`** (only if any cleanup remains; otherwise nothing to commit).
+
+---
+
+## Out-of-scope tripwires (do not implement)
+
+If any of the following come up during implementation, **stop and surface to the user** — they are deliberately deferred to v1:
+
+- `profiles.default_app_context` column, migration, rollback markdown.
+- `PATCH /profiles/:id` app-context mutation.
+- `/recaps` route, service, or feed endpoint.
+- First-run intent screen (`/(app)/onboarding/intent.tsx`).
+- `Learn this too` bridge, `StudySourceContext`.
+- Push notification routing rewrite (route-level guard at `child/[profileId]/_layout.tsx` is in scope; handler rewrite is not).
+- Cross-device mode persistence (no SecureStore, no API).
+- `X-App-Context` request header.
+- Any `archivedAt`, `hasFamilyLinks`, or shortcut-capability field on `profileSchema`.
+- `mode_intent_chosen`, `learn_this_too_*` analytics events.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Every spec §Step (1-10) and AC (#1-#27) maps to a task above. AC mapping summary:
+  - AC #1 → Task 4 (tab visibility for non-family-capable)
+  - AC #2 → Task 1 (`isFamilyCapableProfile` cases)
+  - AC #3, #15 → Tasks 4, 6, 15.7
+  - AC #4, #5 → Task 4.1
+  - AC #6, #7 → Task 6
+  - AC #8, #9 → Task 7
+  - AC #10, #11 → Task 9
+  - AC #12, #13 → Task 8
+  - AC #14 → Task 15.5 + existing `goBackOrReplace`
+  - AC #16 → Task 12
+  - AC #17 → Tasks 2, 15.2
+  - AC #18 → Task 13
+  - AC #19, #20 → Task 5
+  - AC #21 → Task 6 (reentrancy) + Task 15.3
+  - AC #22 → Task 8
+  - AC #23 → Task 14 (covers 3+ nested routes)
+  - AC #24 → Task 4 (proxy precedence)
+  - AC #25 → Task 10 (guard test)
+  - AC #26 → Task 1 + Task 6 (`LearnerScreen` mode-driven branch)
+  - AC #27 → Tasks 2, 15.1
+  - **Kill-switch (Task 0, not in spec ACs):** verified via a dedicated test that asserts `MODE_NAV_V0_ENABLED=false` collapses the whole v0 path — `useAppContext().mode === null` for a family-capable adult, tab shell renders the legacy `computeVisibleTabs` set, `LearnerScreen` follows the `(hasLinkedChildren || isFamilyPlanOwner)` branch, no chip / activation card / Recent-child-activity / RequireFamilyContext fallback renders. Add this as `feature-flag.integration.test.tsx` alongside the Task 15 integration suite.
+
+- **Type consistency check:**
+  - `AppMode = 'study' | 'family'` defined in `app-context.tsx`, consumed by `query-keys.ts` and `mode-scoped-keys.ts`.
+  - `mode: AppMode | null` is the runtime value everywhere except inside `MODE_SCOPED_KEYS` (which is a list of string prefixes only).
+  - `computeModeVisibleTabs(mode: AppMode | null)` matches the call sites.
+  - `isFamilyCapableProfile(activeProfile, profiles)` signature is identical in all consumers.
+
+- **Placeholder scan:** No "TBD", no "add appropriate error handling", no "similar to Task N". Every code step shows the actual code.
+
+---
+
+## Handoff
+
+After saving this plan, the user picks the execution path:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks (per `superpowers:subagent-driven-development`).
+2. **Inline Execution** — batch execution with checkpoints (per `superpowers:executing-plans`).
+
+---
+
+## Adversarial Review Changes (2026-05-19)
+
+Pass 1 + 2 of the `challenge` skill applied to this plan. Findings folded in:
+
+| ID | Issue | Resolution |
+|---|---|---|
+| CRITICAL-1 | 2-element `['session'/'session-transcript', sessionId]` invalidations break after `mode` insertion at queryKey[1] — Task 11c.4 originally claimed "no edit needed" (false) | Added Step 11c.3 enumerating 4 broken call sites (`use-retry-filing.ts:27,29`, `use-sessions.ts:218,247`) with predicate-rewrite pattern; added `use-retry-filing.ts` to Task 11 Files; added regression test requirement |
+| CRITICAL-2 | `use-sessions.ts` consumers (7 call sites) missing from Task 11 file inventory | Added `use-sessions.ts` and `use-retry-filing.ts` to top-level Modified files, to Task 11 Files block, and to the 11c.1 grep expectations |
+| HIGH-1 | `resolveHomeTabPresentation` not made mode-aware — home tab title contradicts mode for guardian-shape Study-mode adults | New Step 4.5 extends signature to take `mode`, threads it at the call site `_layout.tsx:1415`, adds unit-test cases |
+| HIGH-2 | Task 3.2 mount example wraps inside `<ProfileProvider>` — but ProfileProvider lives in root `app/_layout.tsx:570`, not `(app)/_layout.tsx` | Rewrote Task 3 with two structural options; chose Option B (split `AppLayout` into outer wrapper + `AppLayoutInner`) because Tasks 4 and 6 consume `useAppContext()` inside the same component |
+| MEDIUM-1 | Step 4.4 told implementer to edit "inside the `screenOptions` callback" — but `visibleTabs` is a useMemo at `_layout.tsx:1411-1414` in the component body | Rewrote Step 4.4 to target the useMemo with corrected deps array; clarified the callback already reads `visibleTabs.has(route.name)` and needs no edit |
+| MEDIUM-2 | Task 15.3 rapid-toggle test would pass even if the reentrancy guard were removed — `fireEvent.press()` calls already commit separately | Rewrote 15.3 to call `onModeSwitch()` synchronously twice within one tick; added option to extract `useReentrancyGuard()` for isolated unit testing |
+| MEDIUM-3 | `enabled: mode !== null` strictly orders mode resolution before any mode-scoped fetch — one extra render delay vs. today | Added explicit note in Task 2 Notes block; suggested measurement-driven relaxation if it regresses Home/Progress load |
+| MEDIUM-4 | Tests for `home.tsx` / `ParentHomeScreen.tsx` transitively pull SecureStore via ProfileProvider — mock posture not pinned | Added MEDIUM-4 implementation note to Task 6 Step 6.2 and Task 8 Step 8.2; referenced canonical `gc1-allow` pattern at `progress/reports/index.test.tsx:55` |
+| LOW-1 | Task 2 test wrapper omitted 4 required `ProfileContextValue` fields (`switchProfile`, `profileLoadError`, `profileWasRemoved`, `acknowledgeProfileRemoval`) | Wrapper now pre-populates all 7 fields explicitly so the example typechecks as-written |
+| LOW-2 | `OWN_LEARNING_RETURN_TO = 'own-learning'` after Route Survival returns to a tab-less surface in Study mode | Added tripwire note in Task 5.4; defers a v1 fix to normalize `returnToTab` on mode flip |
+| LOW-3 | Step 11a.6 originally allowed a typecheck-red commit between 11a and 11c | Reworked 11a.6 / 11b.3 / 11c.5 so all three sub-tasks land as one commit; no commit on disk is typecheck-red, pre-commit hook never bypassed |
+
+Either path: the coordinator (not the subagents) does the `/commit` at each task boundary per CLAUDE.md "Subagents must never run `git add`, `git commit`, or `git push`".
+
+---
+
+## Adversarial Review Pass 2 (2026-05-19)
+
+Second adversarial pass — challenged Pass 1's output against current code. Findings applied:
+
+| ID (Pass 2) | Issue | Evidence | Resolution |
+|---|---|---|---|
+| CRITICAL-1 | Task 10 claimed `'session'` / `'session-transcript'` / `'session-summary'` / `'parking-lot'` must be added to `PROFILE_SCOPED_KEYS` — all four are already in the live list | `profile.ts:262, 264, 265, 294` | Rewrote Task 10 header + Step 10.4 to "move, do not add"; updated File Inventory note |
+| CRITICAL-2 | Step 10.4's example `PROFILE_SCOPED_KEYS_FOR_TEST` list undercounted reality by ~27 entries — applying as-written would delete `all-notes`, `bookmarks`, `celebrations`, `consent`, `topic-notes`, `library`, `vocabulary`, `learner-profile`, `quiz-round*`, `language-progress`, `resume-nudge`, etc. | `profile.ts:252-307` actual array vs plan's 29-line example | Replaced inline literal with "copy verbatim from profile.ts:252-307; do not retype" + post-move diff check |
+| CRITICAL-3 | Hard Rule #2 leak — `useProfileSessions` (`use-progress.ts:421-454`) switches to `client.dashboard.children[':profileId'].sessions.$get` when `profileId !== activeProfile.id`; `enabled` only checks `isOwner === true`, NOT mode. Family→Study flip with stale `selectedProfileId === childId` fetches child data into the Study cache. Same hole in `useChildInventory`, `useChildProgressSummary`, `useProfileReports`, `useProfileWeeklyReports` | `use-progress.ts:421-454` | Task 9 now resets `selectedProfileId` on mode flip; Task 11b.2a adds a mode gate to every foreign-profile hook's `enabled` (defense in depth); File Inventory updated |
+| CRITICAL-4 | Progress accepts `?profileId=<childId>` deep-link param (`progress/index.tsx:512-531`) and seeds `selectedProfileId` to a foreign profile even in Study mode — the picker filter alone doesn't block this | `progress/index.tsx:512-531` | Task 9 now rejects `requestedProfileId` when `mode === 'study'` and the id is not self |
+| HIGH-1 | Task 2's `useState + useEffect` pattern produces a render where `mode === null` AFTER profiles have already loaded → Task 4.4's `mode === null → ∅` returns zero tabs → visible regression vs. today's least-privilege-learner fallback at `_layout.tsx:108`. The earlier review's "sub-frame" framing was wrong | Confirmed by reading `app-context.tsx` skeleton in Task 2 + composition in Task 4.4 | Mandated synchronous `useMemo`-based derivation in Task 2; rewrote Task 4.4 composition to fall through to legacy `computeVisibleTabs` when `mode === null` instead of returning ∅ |
+| HIGH-2 | Conventions block told a reader (including subagents) "After each task: stage the files, run `/commit`, push" — direct contradiction of CLAUDE.md "Subagents must never commit" | Plan line 21 vs. CLAUDE.md | Rewrote Conventions to "Coordinator only" with explicit prohibition on subagent commits |
+| MEDIUM-1 | Task 8.4 tile rendered raw `c.trend` enum → "5 sessions this week · up" UX bug; also conflicts with `feedback_positive_framing_no_struggle` for the `down` value | Plan Task 8.4 + `packages/schemas/src/progress.ts:307` | Dropped `c.trend` from v0 tile copy; defer trend visualization to v1 |
+| MEDIUM-2 | Task 11c.3 hardcoded `q.queryKey[2] === sessionId` in two call sites — position contract lives away from the factory definition, brittle to refactor | Plan Task 11c.3 | Added co-located `queryKeys.sessions.matchAnyMode(sessionId)` + `matchDetailAnyMode(sessionId)` predicates; rewrote both call sites to use them |
+| MEDIUM-3 | Mode-flip forces a `dashboard.root` cold refetch every toggle (cache partitioned at queryKey[1]); not documented as an accepted trade-off | Plan §Step 8 / Task 11a factory table | Added explicit "Cold-refetch cost" note in Task 11a; rejected `setQueryData` seeding in v0 |
+| LOW-1 | Task 14.5 said "three distinct nested routes" but didn't distinguish static vs dynamic; static routes (`index`, `mentor-memory`, `reports`) aren't in the `<Stack.Screen>` children — explicit wrap-each-screen regression would leave them unguarded | `apps/(app)/child/[profileId]/_layout.tsx` lists only 5 dynamic screens; filesystem shows 3 static routes | Updated Step 14.5 to require at least one static + one dynamic route, with rationale |
+
+**Carry-forward to the spec.** Pass 2 CRITICAL-1 (stale "add four prefixes" claim) and CRITICAL-3 (`selectedProfileId` reset + foreign-profile `enabled` gate) also affect the spec source-of-truth (`docs/specs/2026-05-19-study-and-family-mode-navigation-v0.md` §Hard Rule #7 last sentence and §Step 7). Surface to the spec owner; per the plan preamble "when this plan and the spec disagree, the spec wins — pause and amend." The plan's Pass 2 edits are the implementation-side hardening; the spec should also drop the "forward-only bug fix" sentence in §Hard Rule #7 and add the `selectedProfileId` reset + foreign-profile `enabled` rules to §Hard Rule #2 / §Step 7.

--- a/docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
+++ b/docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
@@ -12,6 +12,33 @@
 
 ---
 
+## Adversarial Review Round 3 — Findings Applied (2026-05-19)
+
+Third pass. Round 2 left one substantive deliverable unfinished ([HIGH-B2] — adult-age gate listed in the summary but not actually written into Task 13). Round 3 finishes that work AND critiques the Round-1+Round-2 deltas themselves (the least-reviewed code in the plan), plus a handful of codebase claims earlier rounds asserted without verifying. Inline `[ID3]` markers below cite Round-3 findings.
+
+- **[OPT-C]** Coordinator decision (post-Round-3): defense-in-depth on the underage-parent problem. Both the client gate ([HIGH-A3]) AND a new server-side rule (Task 13b, added below) ship behind an **independent feature flag** `ADULT_OWNER_GATE_ENABLED` (mobile + API). This addresses the spec-vs-plan contradiction surfaced in [MEDIUM-E3] and closes the missing-server-rule gap surfaced in [HIGH-D3], while giving us a kill switch that toggles the gate off without disabling the whole preview-onboarding feature (`PREVIEW_ONBOARDING_ENABLED` stays separate). Cross-refs: [HIGH-D3] surfaced the missing server rule; [MEDIUM-E3] surfaced the spec-vs-plan contradiction; [HIGH-A3] is the client-side gate. With BOTH `ADULT_OWNER_GATE_ENABLED` flags OFF the system is identical to today's behaviour (no adult-age constraint). With BOTH ON, the client gate is pre-flight UX and the server rule is the actual barrier — if a request bypasses the client, the server returns 403 `ADULT_OWNER_REQUIRED`.
+
+- **[HIGH-A3]** Round 2's `[HIGH-B2]` follow-through was NOT done — Task 13 still ships without an adult-age gate. Now added in Step 1 (failing tests) + Step 3 (component code) of Task 13. Uses `computeAgeBracket(parentBirthYear) === 'adult'` (canonical helper exported from `@eduagent/schemas`, `packages/schemas/src/age.ts:39-49`) — the same definition `isAdultOwner()` uses (`packages/schemas/src/age.ts:51-62`) and the same shape `more/index.tsx:118` consumes for the existing "show add child" gate. Tests assert: underage parent (birth year giving < 18) cannot submit when `needsChild` is true; exactly 18 (boundary) DOES proceed; check is skipped entirely when `target === 'self'` (no child involved, server's 11+ floor is the only gate).
+- **[CRITICAL-A3]** The Task 11 gate ordering (the new code most likely to ship with a bug) has TWO latent gaps that the Round-2 sketch does not address. Both fixed inline below:
+  1. **Wizard branch fires for a signed-OUT user.** `useUser()`/`useAuth()` may report `isSignedIn=false` (e.g. token expiry mid-OAuth, sign-out race) AFTER the wizard branch reads `previewProbeState === 'present'`. The Round-2 ordering puts the wizard branch ABOVE the `if (!isSignedIn) return <Redirect href="/sign-in">` gate (`_layout.tsx:1539-1548` evidence) only because the wizard branch lives below the `isProfileLoading` check, but neither the plan text nor the sketch makes the auth precedence explicit. The wizard MUST sit after `!isSignedIn` (and after `isProfileLoading`/`profileLoadError`) — never before. Updated ordering: `!isLoaded` spinner → `!isSignedIn` redirect → `pendingAuthRedirect` spinner → `isProfileLoading` spinner → `profileLoadError` fallback → preview-probe-loading spinner → SaveWizardGate branch → `!activeProfile` CreateProfileGate → consent gates → Tabs.
+  2. **`previewProbeState === 'loading'` blocks the existing pending-auth-redirect spinner.** If the gate runs the new probe-loading spinner BEFORE the pending-auth-redirect block (`_layout.tsx:1550-1576`), users coming back from OAuth see the new spinner instead of the existing auth-redirect spinner, and the replay timeout (`pendingRedirectTimedOut`, `_layout.tsx:1437`) starts measuring against the wrong loader. The probe-loading spinner MUST sit AFTER the pending-auth-redirect block, not before. The Round-2 sketch's wording ("immediately BEFORE the `if (!activeProfile)` branch") IS the correct placement, but the loading-spinner inside that branch is duplicative with the existing pending-redirect spinner — the probe is fast (single `getItemAsync`) so the cleanest fix is to render `null` (or fall through to the existing `isProfileLoading` spinner if the probe is still resolving when `isProfileLoading` flips false). Updated below.
+- **[CRITICAL-B3]** The Round-2 plan removed `clearPreviewState()` from the layout effect but the Step-3 success path in Task 14 (lines 2326) STILL calls `await clearPreviewState()` — verified. However the wizard-as-inline-gate setup wires `onComplete()` from the wizard to the layout BEFORE clearing the state, and the success path navigates with `router.replace` before clearing on certain branches. Reading Task 14's `onLand` (lines 2316-2340): `switchProfile` → `clearPreviewState` → `router.replace`. Correct order. Confirmed: no leak. Marked verified inline.
+- **[HIGH-B3]** `simulateProfileCreated` is referenced in Task 11's failing-test sketch (around line 1488 area in the existing file — coordinator confirm exact line) but DOES NOT exist in `_layout.test.tsx`. Grep returns zero matches in the test file. Added a TODO with the contract the harness must satisfy (mutates `useProfile()` mock's `activeProfile`/`profiles` returns + flushes microtasks) so the implementer doesn't get stuck spelunking.
+- **[HIGH-C3]** `SaveWizardGate` defined inline inside `(app)/_layout.tsx` (1859 LOC file, multiple components already co-located: `CreateProfileGate` at line 640, `ConsentPendingGate`, `ConsentWithdrawnGate`, gate-content helpers). Adding one more function does NOT trigger `import/no-default-export` (the file's default export is `AppLayout`; other named functions are fine). Verified by reading file structure (`grep -n "^function\|^export default" _layout.tsx`). No nx-module-boundaries risk — same package, same directory. Import depth check: imports in `SaveWizardGate` (defined in `(app)/_layout.tsx`) must use `../../lib/...` (two levels up — `_layout.tsx` → `(app)/` → `app/` → `src/`), NOT `../../../lib/...`. The Round-2 Task 12 sketch (line 1635) correctly says `../../lib/...` in its narrative note but the test snippet on line 1639 still has the three-dot path. Fixed inline.
+- **[HIGH-D3]** Server has NO 18+ owner rule. `apps/api/src/services/profile.ts:184-191` enforces only the 11+ minimum (`belowMinimumAge`). The spec's Failure Modes table (`docs/specs/2026-05-18-...md:388`) claims "API rejects via existing 18+ rule on `createProfileWithLimitCheck()`" — that rule does not exist. So **the client gate added in [HIGH-A3] is the ONLY barrier** to a 13-year-old creating themselves as `isOwner=true` with a child linked underneath. This also means [HIGH-A3] is not redundant defense-in-depth; it is the entire defense. Flagged as an open question for the coordinator (server-side adult-owner check should probably exist too, but that's an API change outside this plan's scope).
+- **[MEDIUM-A3]** Plan asserts `ProfileProvider` at `profile.ts:154-174` "auto-activates the first profile the moment `profiles.length > 0`." The effect ACTUALLY only fires when `!savedExists` (line 158) — i.e. when there is no saved ID, or the saved ID doesn't match any profile in `profiles`. The Round-2 framing reads as if activation is unconditional. Net effect on the wizard is unchanged (after signup the user has no saved `ACTIVE_PROFILE_KEY`, so `!savedExists` is true, so auto-activate DOES fire) — but the wording is sloppy and could mislead the implementer. Corrected inline.
+- **[MEDIUM-B3]** `simulateProfileCreated` test harness contract documented in Task 11 (see [HIGH-B3]). Without this annotation an implementer will spend time grepping for a helper that does not exist.
+- **[MEDIUM-C3]** No telemetry plan. Per CLAUDE.md `safeSend()` convention for non-core dispatches: this feature should fire funnel events at `preview_intent_seen`, `preview_intent_selected`, `preview_topic_submitted`, `preview_value_prop_seen`, `preview_signup_started`, `preview_signup_completed`, `save_wizard_step_1`, `save_wizard_step_2`, `save_wizard_step_3`, `save_wizard_completed`. Currently the plan ships zero analytics. Without funnel events the feature is unmeasurable — exactly the "wired-but-untriggered" failure mode CLAUDE.md warns against. Added a small section in Task 15 noting this as deferred-to-follow-up (since the codebase's analytics conventions aren't grounded in this plan) but it MUST be on the post-merge punch list.
+- **[MEDIUM-D3]** Tab-shape handoff in Task 14 sits on a hardcoded `'/(app)/home'` route for the parent path AND for the `target === 'self'` solo path. Per CLAUDE.md profile-shapes table: solo owner (`target='self'`, no children) → learner tab shape, lands on `LearnerScreen`; parent with linked children (`target='child'` or `target='both'`) → guardian tab shape, lands on `ParentHomeScreen`. Both shapes appear to mount under `/(app)/home` (home tab is route `home`, presentation switches by `resolveTabShape` — see `_layout.tsx:1410`), so `/(app)/home` IS the correct destination for both. Confirmed not a bug — but the Task 14 test only asserts `replace` was called with `expect.stringMatching(/^\/\(app\)\//)` which is loose. Tightened the assertion inline.
+- **[MEDIUM-E3]** Spec Failure Modes line 388 says "no client-side pre-validation in v0" — this is in tension with [HIGH-A3]. The spec's framing assumed a server-side 18+ rule existed; since [HIGH-D3] shows it does not, the client gate is now the only barrier. Coordinator should decide: (a) ship client gate AND open a server-side ticket, or (b) skip the client gate and accept the risk for v0 since stores are blocked / no live users (per `project_pre_launch_no_users.md`). The plan now ships option (a); flagged for explicit confirmation. **[OPT-C] RESOLVED:** Coordinator chose defense-in-depth — client gate ([HIGH-A3], in Task 13) AND server rule (new Task 13b), both gated by independent `ADULT_OWNER_GATE_ENABLED` flag (mobile + API). The spec's "no client-side pre-validation" line is intentionally overridden by this decision. Follow-up: the spec doc (`docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md:388`) should be amended in a separate PR to remove that line; spec amendment is out of scope for this plan-doc update.
+- **[MEDIUM-F3]** Failure Modes table in the plan (lines 2217-2223) does NOT have a row for "underage user attempts to save as owner with child" even after Round 2 named the [HIGH-B2] gate. Added a row inline.
+- **[MEDIUM-G3]** Task 15 AC coverage table maps 16 ACs and matches the spec's 16-AC count (verified by re-reading `docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md:359-376`). No gap there. Confirmed.
+- **[LOW-A3]** Existing project canonical SecureStore API is `getItemAsync` / `setItemAsync` / `deleteItemAsync` (Async-suffixed), verified at `apps/mobile/src/lib/secure-storage.ts:80,94,112`. Task 3's module already uses the correct API. Confirmed.
+- **[LOW-B3]** `useProfiles` cache key IS `['profiles', userId]` (verified `apps/mobile/src/hooks/use-profiles.ts:28`). Round-1 claim accurate. Confirmed.
+- **[LOW-C3]** `pending-auth-redirect.ts:17` IS an in-memory variable (`let pendingAuthRedirectRecord: PendingAuthRedirectRecord | null = null`) — Round-2 `[MEDIUM-A2]` claim accurate. Confirmed.
+
+---
+
 ## Adversarial Review Round 2 — Findings Applied (2026-05-19)
 
 Second review pass after Round 1 missed two structural bugs in how the wizard mounts. Inline `[ID2]` markers below cite Round-2 findings.
@@ -91,15 +118,25 @@ Round-1 findings (folded in earlier in the day). Inline `[ID]` markers below cit
 
 ---
 
-## Task 0: Session-Start Helper Spike (BLOCKER, do not skip)
+## Task 0: Session-Start Helper Spike — RESOLVED (dual landing, branch on target)
 
-**Why:** Spec §First Session Handoff requires a decision *before* implementation: either (a) lift the existing session-start call site into a reusable helper and add it to scope, or (b) defer the topic-prefill leg and update wizard CTA copy. This spike eliminates the "pause mid-implementation" loop.
+**Resolution (2026-05-19):** Landing branches on the wizard's existing `target` / `intent` flag — no new branching logic, no new scope beyond the session-helper extraction below.
+
+- **`target = self` (solo adult OR any under-18 with own profile)** → **land in a session** for the saved `topicText`. Highest momentum; the actor at the device IS the learner. Requires a small session-start helper extraction (see Step 1).
+- **`target = child` (adult parent, `needsChild = true`)** → **land on `/(app)/home`**. The parent has finished the wizard but no child profile is linked yet at this point in the flow; dropping them into a session would attach progress to the wrong profile. Home is where they orient and tap "Add child" next.
+- **`target = both` with `bothPriority = self_first`** → treat as `self` (land in session for the parent themselves).
+- **`target = both` with `bothPriority = child_first`** → treat as `child` (land on home).
+
+**Why this beats a one-arm answer:**
+- Conversion driver for solo/kid learners is the first-session moment — they typed in a topic, they want to do it now.
+- Conversion driver for parents is "orient + hand off" — they need to see the app shell, find Add Child, and pre-vet what their kid will see. Forcing them into a session attached to the wrong profile undermines both.
+- The wizard already collects this signal; landing just reads it.
 
 **Files:**
 - Read: `apps/mobile/src/app/(app)/home.tsx` (or whichever screen owns the "Start a new session" affordance)
 - Read: `apps/mobile/src/hooks/use-create-session.ts` (or equivalent — discover via grep)
 
-- [ ] **Step 1: Find every existing session-start entry point.**
+- [ ] **Step 1: Find every existing session-start entry point and decide the helper shape.**
 
 Run from repo root:
 ```bash
@@ -107,26 +144,23 @@ grep -rn "sessions.\$post\|createSession\|startSession\|session-start" apps/mobi
 ```
 Open each hit. For each, note: (a) is it a hook/util or screen-local handler? (b) does it accept a topic string param? (c) does it `router.push` to the session route after success?
 
-- [ ] **Step 2: Decide (a) or (b).**
+Decision rule:
+- If a reusable hook (e.g., `useCreateSession`) already accepts a topic and navigates → use it directly in Task 14, no refactor needed.
+- If the only call site is buried in a screen component → extract the minimum slice into `apps/mobile/src/hooks/use-create-session.ts` (or matching neighbour). Keep extraction scoped: accept `{ topicText }`, return `{ start(): Promise<{ sessionId: string } | { error: string }> }`. Do NOT pull unrelated logic out of the host screen.
 
-Decision tree:
-- If a reusable hook (e.g., `useCreateSession`) already accepts a topic and navigates → option (a), zero additional scope. Use it directly in Task 14.
-- If the only call site is buried in a screen component → option (b) is the default to avoid scope creep. Add a one-line decision to spec §First Session Handoff.
+This extraction only runs on the `self` branch — the `child` branch has no session-start call, so it is unaffected by whatever shape the helper takes.
 
-- [ ] **Step 3: Record the decision in this plan.**
+- [ ] **Step 2: Record the helper path (or "inline hook reused as-is") in Task 14's spike-outcome line.**
 
 Open this file and replace the line below in Task 14:
 
-> **Spike outcome (fill in before starting Task 14):** [option (a) — helper at `<path>` / option (b) — defer topic prefill, CTA reads "Go to my learning"]
+> **Spike outcome (resolved 2026-05-19):** Dual landing — `target=self` → session via helper at `<path>`, `target=child` → `/(app)/home`. See Task 0.
 
-- [ ] **Step 4: Commit the spike decision.**
+- [ ] **Step 3: Commit the spike decision (if helper path differs from what is recorded here).**
 
-```bash
-git add docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
-git commit -m "docs(plan): record session-start spike outcome for trial v0"
-```
+If Step 1 surfaced a helper path not yet captured in Task 14, update this file and run `/commit` — never raw `git commit`. If the existing recorded shape is accurate, no commit needed in Task 0; it folds into Task 14's commit.
 
-No code shipped in Task 0.
+No production code shipped in Task 0 — only doc updates and helper-path discovery. The helper extraction itself ships in Task 14.
 
 ---
 
@@ -134,8 +168,9 @@ No code shipped in Task 0.
 
 **Files:**
 - Modify: `apps/mobile/src/lib/feature-flags.ts`
+- Modify: `apps/api/src/config.ts` (or whichever module exports the typed `config` object — confirm via grep; G4 governance lock: only `config.ts` may touch raw `process.env` outside the small allowlist) [OPT-C]
 
-- [ ] **Step 1: Add the flag.**
+- [ ] **Step 1: Add the mobile flags.**
 
 Edit `apps/mobile/src/lib/feature-flags.ts`:
 
@@ -152,25 +187,67 @@ export const FEATURE_FLAGS = {
   //   - (app)/_layout.tsx: preview/save tab entry not registered (defensive; route is unreachable anyway).
   // isFamilyCapableProfile() and the mentomate_preview_intent entry in sign-out-cleanup ship UNCONDITIONALLY.
   PREVIEW_ONBOARDING_ENABLED: true,
+
+  // [OPT-C] Independent adult-owner gate flag — toggles the 18+ requirement
+  // for a parent creating a child profile. Defense-in-depth: paired with the
+  // API-side ADULT_OWNER_GATE_ENABLED config (apps/api/src/config.ts).
+  //
+  // When false:
+  //   - save.tsx ProfileBasicsStep: the adult-age UI gate is bypassed.
+  //     `canSubmit` falls back to today's behaviour (only the existing
+  //     display-name + valid-4-digit-year checks; no adult-age check).
+  //     The `save-basics-adult-required` warning view is not rendered.
+  //   - With this flag OFF and the API flag also OFF, the system is
+  //     identical to today (no adult-age constraint exists anywhere).
+  //
+  // This flag is INDEPENDENT of PREVIEW_ONBOARDING_ENABLED. The preview
+  // feature can ship while the adult-owner gate stays off (or vice versa).
+  ADULT_OWNER_GATE_ENABLED: true,
 } as const;
 ```
 
-- [ ] **Step 2: Typecheck.**
+- [ ] **Step 2: Add the API config entry.** [OPT-C]
+
+Edit `apps/api/src/config.ts` (the canonical typed-config module — G4 governance pins this file; per `.archon/governance-constraints.md:94` it is the only place raw `process.env` may be read outside the small allowlist). Follow the existing patterns in that file (the implementer reads it to match the zod-parsed schema and `config.x` access style):
+
+1. Declare a new field on the config schema, e.g. `ADULT_OWNER_GATE_ENABLED: z.coerce.boolean().default(true)`.
+2. Parse it in the existing `init`/factory.
+3. Expose it as `config.ADULT_OWNER_GATE_ENABLED` (or whatever the existing camelCase/SCREAMING_SNAKE convention is — match the surrounding entries; do not invent a new style).
+
+Doppler note: this is a non-secret config value but follows the same "all environment values flow through Doppler" convention per CLAUDE.md (`doppler run -c <env>` injects it into `process.env` at start-up; the typed config reads from there). No new secret to add — just a boolean flag with a sensible default so it works locally without explicit configuration.
+
+**Default:** `true` (gate enforced by default in all environments).
+
+**When false:** Task 13b's server-side adult-owner rule is skipped entirely. The route falls through to today's behaviour (only the existing 11+ minimum-age check at `apps/api/src/services/profile.ts:184-191`).
+
+**Combination matrix:**
+
+| Mobile flag | API flag | Behaviour |
+|---|---|---|
+| ON | ON | Defense-in-depth. Client gate is pre-flight UX; server is the actual barrier. |
+| ON | OFF | Client gate enforced; server passes through. Acceptable if API has a hotfix to disable but mobile build is in flight. |
+| OFF | ON | Client allows underage submission; server rejects with 403 `ADULT_OWNER_REQUIRED` (surfaces as a toast — see Task 13b). Useful for testing the server rule from a non-gated client. |
+| OFF | OFF | **Today's behaviour.** No adult-age constraint anywhere. Acceptable only when the gate has been deliberately turned off (e.g. emergency rollback). |
+
+- [ ] **Step 3: Typecheck.**
 
 Run:
 ```bash
 cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx run api:typecheck
 ```
 Expected: passes.
 
-- [ ] **Step 3: Commit.**
+- [ ] **Step 4: Commit.**
 
 Use `/commit` (do NOT use raw `git commit`). Suggested message:
 ```
-feat(mobile): add PREVIEW_ONBOARDING_ENABLED feature flag
+feat: add PREVIEW_ONBOARDING_ENABLED + ADULT_OWNER_GATE_ENABLED feature flags
 
 Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
-Gate sites listed in feature-flags.ts comment.
+Mobile flags in feature-flags.ts; API flag in config.ts (G4 allowlist).
+ADULT_OWNER_GATE_ENABLED is independent of PREVIEW_ONBOARDING_ENABLED —
+toggling it OFF restores today's behaviour (no adult-age constraint). [OPT-C]
 ```
 
 ---
@@ -1479,8 +1556,24 @@ describe('AppLayout no-profile gate — preview branch', () => {
 
   // [CRITICAL-A2 / HIGH-A2] Wizard outlives the auto-activation transition.
   // First-profile POST flips profiles to non-empty; ProfileProvider auto-sets
-  // activeProfile (profile.ts:154-174). The wizard branch must remain above
-  // !activeProfile in the gate ordering so the wizard stays mounted.
+  // activeProfile via the !savedExists fallback (profile.ts:154-174 —
+  // [MEDIUM-A3]: the effect only fires when no valid saved id exists, which
+  // IS the post-signup state because the user has no ACTIVE_PROFILE_KEY yet).
+  // The wizard branch must remain above !activeProfile in the gate ordering
+  // so the wizard stays mounted across that transition.
+  //
+  // [HIGH-B3 / MEDIUM-B3] `simulateProfileCreated` is NOT a real helper in
+  // the existing _layout.test.tsx — grep returns zero hits. The implementer
+  // must add this harness during Task 11 Step 1. Required contract:
+  //   simulateProfileCreated(profile: Partial<Profile>): void
+  //     - Mutates the active useProfile() mock such that subsequent renders
+  //       return { profiles: [profile], activeProfile: profile, ... }.
+  //     - Flushes microtasks (await Promise.resolve()) so the next assertion
+  //       reads the post-update state.
+  //   Typical implementation pattern in test files: a closure-scoped mutable
+  //   state object backing the useProfile mock, plus a setter exposed by the
+  //   render helper. Mirror whatever the file's existing mocks already use
+  //   for activeProfile transitions; do NOT reinvent.
   it('keeps SaveWizardGate mounted after ProfileProvider auto-activates the first profile', async () => {
     await setPreviewState({
       intent: 'self',
@@ -1528,7 +1621,16 @@ import { getPreviewState } from '../../lib/preview-onboarding-state';
 // owned by the wizard's Step-3 success path (Task 14) and by sign-out.
 ```
 
-Inside the default `AppLayout` component, after the existing profile-loading state and immediately BEFORE the `if (!activeProfile)` branch (landmark — search for that exact conditional; line numbers drift) [MEDIUM-3], introduce the preview-state probe AND a wizard-done sentinel:
+Inside the default `AppLayout` component, after the existing profile-loading state and immediately BEFORE the `if (!activeProfile)` branch (landmark — search for that exact conditional; line numbers drift) [MEDIUM-3], introduce the preview-state probe AND a wizard-done sentinel.
+
+> [CRITICAL-A3] **Precedence rules** — these are non-negotiable. The new code MUST NOT precede any of:
+> 1. `if (!isLoaded)` spinner branch (`_layout.tsx:1533-1538` evidence) — auth not loaded yet; do not render any app UI.
+> 2. `if (!isSignedIn)` redirect-to-`/sign-in` branch (`_layout.tsx:1539-1548`) — signed-OUT user must not see the wizard. Without this ordering, a session-expired user with a `present` preview key sees the wizard, taps Continue, and 401s mid-POST.
+> 3. `pendingAuthRedirect && currentAppPath !== pendingAuthRedirect` spinner branch (`_layout.tsx:1550-1576`) — the OAuth-return redirect-replay loader has its own 15s timeout. The new probe-loading spinner must NOT replace or duplicate it.
+> 4. `isProfileLoading` spinner branch (`_layout.tsx:1582-1619`) — has its own 20s timeout.
+> 5. `profileLoadError` fallback branch (`_layout.tsx:1624-1655`) — error UI is independent of preview state.
+>
+> Final ordering: `!isLoaded` → `!isSignedIn` → `pendingAuthRedirect` spinner → `isProfileLoading` → `profileLoadError` → preview-probe-loading → SaveWizardGate branch → `!activeProfile` → consent gates → Tabs.
 
 ```tsx
 const [previewProbeState, setPreviewProbeState] = React.useState<
@@ -1632,12 +1734,15 @@ NO addition to `FULL_SCREEN_ROUTES`. The Round-1 plan added `'preview'` because 
 
 - [ ] **Step 2: Write failing test for Step 1 (where-to-save selection).**
 
-> Use the `(app)/_layout.test.tsx` harness from Task 11. The wizard is mounted by the layout's gate ordering (preview state present + wizardDone false), so tests render the layout, not a standalone `<SaveWizard />`. Imports adjust accordingly: `import { setPreviewState, clearPreviewState } from '../../lib/preview-onboarding-state';` (NOT `'../../../lib/...'`).
+> [HIGH-C3] Use the `(app)/_layout.test.tsx` harness from Task 11. The wizard is mounted by the layout's gate ordering (preview state present + wizardDone false), so tests render the layout, not a standalone `<SaveWizard />`. Import depth from `apps/mobile/src/app/(app)/_layout.test.tsx`: `../../lib/...` (`_layout.test.tsx` → `(app)/` → `app/` → `src/lib/`). DO NOT use `../../../lib/...` — that depth is correct for a hypothetical `(app)/preview/save.test.tsx`, which this plan no longer creates. The snippet below is updated to the correct two-dot path.
 
 ```tsx
 import { render, screen, fireEvent } from '@testing-library/react-native';
-import { setPreviewState, clearPreviewState } from '../../../lib/preview-onboarding-state';
-import SaveWizard from './save';
+import { setPreviewState, clearPreviewState } from '../../lib/preview-onboarding-state';
+// SaveWizardGate is internal to (app)/_layout.tsx; tests reach it by
+// rendering AppLayout under conditions that mount the wizard branch.
+// Do NOT add an export-for-tests of SaveWizardGate from _layout.tsx —
+// the gate is intentionally co-located and tested via the layout.
 
 describe('SaveWizard — Step 1', () => {
   beforeEach(async () => {
@@ -1940,6 +2045,138 @@ it('child target: creates parent first, then child (sequence assertion)', async 
   });
 });
 
+// [HIGH-A3 / HIGH-B2] Adult-age gate — client-side because the server has
+// NO 18+ owner rule (apps/api/src/services/profile.ts:184-191 only enforces
+// the 11+ minimum). Without this gate, a 13-year-old could create themselves
+// as isOwner=true with a child linked underneath via the wizard.
+it('underage parent (target=child) cannot submit; Continue stays disabled', async () => {
+  await setPreviewState({
+    intent: 'child', path: 'parent_value_prop',
+    createdAt: new Date().toISOString(),
+  });
+  // Fix "now" to a known year for deterministic adult-age arithmetic.
+  jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+
+  render(<SaveWizard />);
+  fireEvent.press(await screen.findByTestId('save-wizard-step-1-continue'));
+
+  // 13-year-old parent (2026 - 13 = 2013) — computeAgeBracket returns 'child'.
+  fireEvent.changeText(screen.getByTestId('save-basics-parent-name'), 'TooYoung');
+  fireEvent.changeText(screen.getByTestId('save-basics-parent-birth-year'), '2013');
+  fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+  fireEvent.changeText(screen.getByTestId('save-basics-child-birth-year'), '2014');
+
+  const cta = screen.getByTestId('save-basics-continue');
+  expect(cta.props.accessibilityState?.disabled).toBe(true);
+
+  // Accessible error message visible (testID assertion + role).
+  expect(screen.getByTestId('save-basics-adult-required')).toBeTruthy();
+
+  jest.useRealTimers();
+});
+
+it('parent aged exactly 18 (target=child) is allowed to submit', async () => {
+  await setPreviewState({
+    intent: 'child', path: 'parent_value_prop',
+    createdAt: new Date().toISOString(),
+  });
+  jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+  mockProfilesPostSequence([
+    { profile: makeOwnerProfile({ id: 'parent-1' }) },
+    { profile: makeChildProfile({ id: 'child-1' }) },
+  ]);
+
+  render(<SaveWizard />);
+  fireEvent.press(await screen.findByTestId('save-wizard-step-1-continue'));
+
+  // computeAgeBracket(2008, 2026) === 'adult' (age 18). Boundary must pass.
+  fireEvent.changeText(screen.getByTestId('save-basics-parent-name'), 'Pat');
+  fireEvent.changeText(screen.getByTestId('save-basics-parent-birth-year'), '2008');
+  fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+  fireEvent.changeText(screen.getByTestId('save-basics-child-birth-year'), '2014');
+
+  const cta = screen.getByTestId('save-basics-continue');
+  expect(cta.props.accessibilityState?.disabled).toBe(false);
+  expect(screen.queryByTestId('save-basics-adult-required')).toBeNull();
+
+  jest.useRealTimers();
+});
+
+// [OPT-C] Flag-off path: when ADULT_OWNER_GATE_ENABLED is false, the
+// adult-age UI gate is bypassed entirely (today's behaviour). Use the
+// jest.doMock + jest.isolateModules pattern mandated by [HIGH-3] /
+// [MEDIUM-D2] — never `(FEATURE_FLAGS as any).X = false` because the
+// constant is frozen and the override survives across tests.
+it('underage parent allowed through when ADULT_OWNER_GATE_ENABLED is false [OPT-C]', async () => {
+  jest.isolateModules(() => {
+    jest.doMock('../../../lib/feature-flags', () => ({
+      FEATURE_FLAGS: {
+        PREVIEW_ONBOARDING_ENABLED: true,
+        ADULT_OWNER_GATE_ENABLED: false,
+        COACH_BAND_ENABLED: true,
+        MIC_IN_PILL_ENABLED: true,
+        I18N_ENABLED: true,
+      },
+    }));
+    // Re-require SaveWizard inside the isolated registry so its
+    // top-level `import { FEATURE_FLAGS } from ...` picks up the doMock.
+    const { SaveWizard: SaveWizardFlagOff } = require('./save');
+
+    return (async () => {
+      await setPreviewState({
+        intent: 'child', path: 'parent_value_prop',
+        createdAt: new Date().toISOString(),
+      });
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+      mockProfilesPostSequence([
+        { profile: makeOwnerProfile({ id: 'parent-1' }) },
+        { profile: makeChildProfile({ id: 'child-1' }) },
+      ]);
+
+      render(<SaveWizardFlagOff />);
+      fireEvent.press(await screen.findByTestId('save-wizard-step-1-continue'));
+
+      // 13-year-old parent — would be blocked by the gate, but the flag
+      // is off, so the existing display-name + birth-year validations
+      // are the only checks. Continue must enable and submit must fire.
+      fireEvent.changeText(screen.getByTestId('save-basics-parent-name'), 'TooYoung');
+      fireEvent.changeText(screen.getByTestId('save-basics-parent-birth-year'), '2013');
+      fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+      fireEvent.changeText(screen.getByTestId('save-basics-child-birth-year'), '2014');
+
+      const cta = screen.getByTestId('save-basics-continue');
+      expect(cta.props.accessibilityState?.disabled).toBe(false);
+      // Warning view is NOT rendered when the flag is off.
+      expect(screen.queryByTestId('save-basics-adult-required')).toBeNull();
+
+      jest.useRealTimers();
+    })();
+  });
+});
+
+it('self target skips the adult gate (any age ≥ 11 allowed)', async () => {
+  await setPreviewState({
+    intent: 'self', path: 'learner_value_prop',
+    topicText: 'algebra', createdAt: new Date().toISOString(),
+  });
+  jest.useFakeTimers().setSystemTime(new Date('2026-05-19T00:00:00Z'));
+  mockProfilesPost({ profile: makeOwnerProfile() });
+
+  render(<SaveWizard />);
+  fireEvent.press(await screen.findByTestId('save-wizard-step-1-continue'));
+
+  // 13-year-old solo learner — adult gate must NOT apply. Server's 11+ check
+  // is the only floor for target='self'.
+  fireEvent.changeText(screen.getByTestId('save-basics-display-name'), 'Solo');
+  fireEvent.changeText(screen.getByTestId('save-basics-birth-year'), '2013');
+
+  const cta = screen.getByTestId('save-basics-continue');
+  expect(cta.props.accessibilityState?.disabled).toBe(false);
+  expect(screen.queryByTestId('save-basics-adult-required')).toBeNull();
+
+  jest.useRealTimers();
+});
+
 it('child failure after parent success keeps parent and shows retry', async () => {
   await setPreviewState({
     intent: 'child', path: 'parent_value_prop',
@@ -1973,6 +2210,14 @@ import { assertOk } from '../../../lib/assert-ok';
 import { formatApiError } from '../../../lib/format-api-error';
 import { setPreviewState } from '../../../lib/preview-onboarding-state';
 import type { Profile } from '@eduagent/schemas';
+// [HIGH-A3] Adult-age gate uses the canonical age-bracket helper —
+// computeAgeBracket(year) returns 'adult' iff age >= 18. Same definition
+// the existing isAdultOwner() helper uses (packages/schemas/src/age.ts:51).
+// DO NOT reintroduce the removed personaFromBirthYear fossil
+// (persona-fossil-guard.test.ts enforces).
+import { computeAgeBracket } from '@eduagent/schemas';
+// [OPT-C] Adult-owner gate is independently flagged via ADULT_OWNER_GATE_ENABLED.
+import { FEATURE_FLAGS } from '../../../lib/feature-flags';
 
 function ProfileBasicsStep({
   target,
@@ -2004,10 +2249,33 @@ function ProfileBasicsStep({
 
   const isValidYear = (s: string) => /^\d{4}$/.test(s) && Number(s) > 1900 && Number(s) <= new Date().getFullYear();
 
+  // [HIGH-A3 / HIGH-B2] Client-side adult-age gate. Server has NO 18+ rule
+  // (apps/api/src/services/profile.ts:184-191 only enforces 11+), so without
+  // this gate a 13-year-old could complete the wizard as isOwner=true with
+  // a child linked underneath. Skipped entirely when target === 'self' —
+  // the server's 11+ floor covers that case.
+  //
+  // computeAgeBracket(birthYear) returns 'adult' iff age >= 18. Same arithmetic
+  // isAdultOwner() in @eduagent/schemas uses; consistent with the rest of the
+  // codebase (e.g. more/index.tsx:118).
+  //
+  // [OPT-C] Gated by FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED. When OFF,
+  // `adultGateRequired` is false and `adultGatePasses` is trivially true —
+  // canSubmit falls back to today's behaviour (only the field validations
+  // matter). The defense-in-depth server-side rule (Task 13b) is the
+  // parallel barrier; toggling this flag without toggling the API flag
+  // leaves the server still enforcing 403 ADULT_OWNER_REQUIRED.
+  const parentIsAdult =
+    isValidYear(ownerYear) && computeAgeBracket(Number(ownerYear)) === 'adult';
+  const adultGateRequired =
+    FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED && needsChild;
+  const adultGatePasses = !adultGateRequired || parentIsAdult;
+
   const canSubmit =
     !loading &&
     (needsOwner ? ownerName.trim().length > 0 && isValidYear(ownerYear) : true) &&
-    (needsChild ? childName.trim().length > 0 && isValidYear(childBirthYear) : true);
+    (needsChild ? childName.trim().length > 0 && isValidYear(childBirthYear) : true) &&
+    adultGatePasses;
 
   const submit = useCallback(async () => {
     setError(null);
@@ -2150,6 +2418,26 @@ function ProfileBasicsStep({
         </View>
       )}
 
+      {/* [HIGH-A3] Adult-age gate inline message. Visible only when the parent
+         has entered a valid 4-digit year that resolves to under-18, while the
+         flow needs a child profile. Empty / partial input shows nothing
+         (avoid scolding mid-typing). The Continue button stays disabled
+         independent of this message — the message is the accessible
+         explanation; canSubmit is the actual enforcement. */}
+      {adultGateRequired && isValidYear(ownerYear) && !parentIsAdult && (
+        <View
+          className="bg-warning/10 rounded-card px-4 py-3 mb-3"
+          testID="save-basics-adult-required"
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
+        >
+          <Text className="text-warning text-body-sm">
+            To set up a child&apos;s learning, the account holder must be 18 or
+            older. You can still set up your own learning instead — pick
+            &quot;My learning&quot; on the previous step.
+          </Text>
+        </View>
+      )}
       {error && (
         <View className="bg-danger/10 rounded-card px-4 py-3 mb-3" testID="save-basics-error">
           <Text className="text-danger text-body-sm">{error}</Text>
@@ -2212,6 +2500,162 @@ Add `const [created, setCreated] = useState<{ parent: Profile; child?: Profile }
 
 ---
 
+## Task 13b: Server-Side Adult-Owner Rule [OPT-C]
+
+**Size:** Small (~10-15 lines server change, ~30-40 lines tests).
+
+**Files:**
+- Modify: `apps/api/src/services/profile.ts` — extend `createProfileWithLimitCheck()` (the function that owns the owner-vs-child decision inside the advisory-locked transaction; landmark — search for `pg_advisory_xact_lock(hashtext(${accountId})` and the `isFirstProfile` branch immediately downstream of it). Insertion point is BEFORE the row insert that would create the second profile (the child), AFTER the lock acquisition and the count-rows read that determines `isFirstProfile`. Line numbers drift; cite that landmark, not a fixed line. [MEDIUM-3]
+- Modify: `apps/api/src/services/profile.test.ts` (or the integration test file that already exercises `createProfileWithLimitCheck` — find via grep for `createProfileWithLimitCheck` inside `*.test.ts`).
+- Optional: `packages/schemas/src/errors.ts` — add `AdultOwnerRequiredError` class IF the existing hierarchy (`ForbiddenError` with `apiCode` parameter, see `errors.ts:30-41`) does not already cover the case cleanly. The existing `ForbiddenError(message, apiCode)` shape with `apiCode: 'ADULT_OWNER_REQUIRED'` is the lighter-weight option; new class is only warranted if the mobile side needs an `instanceof AdultOwnerRequiredError` discrimination beyond what `error.apiCode === 'ADULT_OWNER_REQUIRED'` provides.
+
+> [OPT-C] **Why this exists.** Round 3's `[HIGH-D3]` proved the server has NO 18+ owner rule today — it only enforces the 11+ minimum (`apps/api/src/services/profile.ts:184-191`, `belowMinimumAge`). Without this rule, the client-side gate added in Task 13 is the only barrier preventing a 13-year-old from completing the wizard as `isOwner=true` with a child linked underneath. The coordinator's `[OPT-C]` decision is defense-in-depth: ship both barriers and gate each behind an independent flag.
+
+> [OPT-C] **Rule.** When `createProfileWithLimitCheck()` is about to create a profile that will be classified as a CHILD (i.e. `isFirstProfile === false`, the path that links the new profile under the existing owner), and `FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED` (API config) is true, look up the owner profile that will be the parent of the new child and verify its computed age is ≥ 18. If not, throw `ForbiddenError('Account holder must be 18 or older to add a child profile', 'ADULT_OWNER_REQUIRED')`.
+
+> [OPT-C] **Age helper.** Use `computeAgeBracket(owner.birthYear) === 'adult'` from `@eduagent/schemas` (`packages/schemas/src/age.ts:39-49`). Verified: the `'adult'` bracket exists and is the canonical "18+" definition shared with the mobile client. **Do NOT use** `isAdultOwner(profile)` from `age.ts:51-62` — that helper layers `role` / `isOwner` checks on top of the age math which are tangential here (we already know the target profile is the owner because we just resolved it from the account's existing owner row). Plain `computeAgeBracket` is the right primitive. Confirmed by reading `packages/schemas/src/age.ts` end-to-end. [MEDIUM-3]
+
+> [OPT-C] **Flag gating.** Wrap the entire rule in `if (config.ADULT_OWNER_GATE_ENABLED) { ... }` (or whatever the field name resolves to in `apps/api/src/config.ts` — match Task 1 Step 2). When the API flag is OFF, the rule is skipped entirely; behaviour reverts to today's (only 11+ enforced). This is the kill switch.
+
+> [OPT-C] **Mobile error surfacing.** When the API returns 403 with `apiCode === 'ADULT_OWNER_REQUIRED'`, the `ProfileBasicsStep` `submit()` catch block already calls `formatApiError(err)` and assigns it to `setError(...)` — which renders the existing `save-basics-error` view. That's an acceptable baseline. If the client gate is also on (the expected production configuration), the user never sees this — the gate disables Continue pre-flight. If the user bypassed the client gate (e.g. a flag-off mobile build hitting a flag-on API), they see the formatted error. No NEW screen / route changes needed.
+
+- [ ] **Step 1: Write the failing break-test (red-green regression per CLAUDE.md Fix Development Rules).**
+
+The break-test is the negative-path security test mandated by CLAUDE.md (`Security fixes require a "break test."` — every CRITICAL/HIGH security fix gets a failing test that proves the attack would succeed without the fix). Pattern: write test, watch it pass with the fix in place, revert the fix, watch it fail, restore the fix.
+
+```ts
+// apps/api/src/services/profile.test.ts (or integration test)
+import { ForbiddenError } from '@eduagent/schemas';
+
+it('rejects child creation when owner is under 18 [OPT-C / HIGH-D3]', async () => {
+  // Seed: an account whose existing owner profile has a birth year putting
+  // them at 13 in the test's "now" frame. Use whatever test factories the
+  // file already uses for profile-with-account seeding — match neighbours.
+  const accountId = 'acc-underage-owner';
+  await seedOwnerProfile(accountId, { birthYear: 2013, isOwner: true });
+
+  // Attempt to add a child under that owner. With the [OPT-C] rule, this
+  // must throw ForbiddenError with apiCode ADULT_OWNER_REQUIRED. Pre-fix,
+  // the call succeeds.
+  await expect(
+    createProfileWithLimitCheck(db, accountId, {
+      displayName: 'Child', birthYear: 2014,
+    }),
+  ).rejects.toMatchObject({
+    name: 'ForbiddenError',
+    apiCode: 'ADULT_OWNER_REQUIRED',
+  });
+});
+
+it('allows child creation when owner is exactly 18 [OPT-C boundary]', async () => {
+  const accountId = 'acc-adult-owner';
+  await seedOwnerProfile(accountId, { birthYear: 2008, isOwner: true });
+  // With test "now" fixed to 2026, owner is age 18 — must succeed.
+  await expect(
+    createProfileWithLimitCheck(db, accountId, {
+      displayName: 'Child', birthYear: 2014,
+    }),
+  ).resolves.toMatchObject({ id: expect.any(String) });
+});
+
+it('allows child creation when flag is OFF (preserves today\'s behaviour) [OPT-C flag-off]', async () => {
+  // Toggle the config flag off for this test. Use whatever pattern the
+  // test file already uses for config overrides (a Jest setup file, a
+  // helper, or jest.replaceProperty on the imported config object). DO
+  // NOT mutate process.env directly mid-test — config is parsed once at
+  // module init, mutation has no effect.
+  withConfigOverride({ ADULT_OWNER_GATE_ENABLED: false }, async () => {
+    const accountId = 'acc-flag-off';
+    await seedOwnerProfile(accountId, { birthYear: 2013, isOwner: true });
+    await expect(
+      createProfileWithLimitCheck(db, accountId, {
+        displayName: 'Child', birthYear: 2014,
+      }),
+    ).resolves.toMatchObject({ id: expect.any(String) });
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm fail.** (First two tests fail — `ForbiddenError` not thrown / not the expected shape.)
+
+- [ ] **Step 3: Implement the rule.**
+
+Inside `createProfileWithLimitCheck()`, after the existing advisory-lock + count-rows read that determines `isFirstProfile`, and BEFORE the `db.insert(profiles)` that creates the child row, insert:
+
+```ts
+// [OPT-C] Adult-owner gate. When adding a CHILD (non-first profile),
+// require the account's existing owner to be ≥18. Gated by config flag
+// so the rule can be toggled off without code changes (kill switch).
+if (
+  config.ADULT_OWNER_GATE_ENABLED &&
+  !isFirstProfile  // landmark: same boolean the existing owner-vs-child
+                   // decision uses below. Match its exact source variable.
+) {
+  const ownerRow = await txDb
+    .select({ birthYear: profiles.birthYear })
+    .from(profiles)
+    .where(and(eq(profiles.accountId, accountId), eq(profiles.isOwner, true)))
+    .limit(1);
+  const ownerBirthYear = ownerRow[0]?.birthYear;
+  if (
+    ownerBirthYear == null ||
+    computeAgeBracket(ownerBirthYear) !== 'adult'
+  ) {
+    throw new ForbiddenError(
+      'Account holder must be 18 or older to add a child profile.',
+      'ADULT_OWNER_REQUIRED',
+    );
+  }
+}
+```
+
+Add the imports at the top of the file:
+```ts
+import { computeAgeBracket, ForbiddenError } from '@eduagent/schemas';
+```
+
+- [ ] **Step 4: Run tests; confirm pass.** All three tests green.
+
+- [ ] **Step 5: Verify the break-test pattern.** Revert the implementation lines (comment out the `if` block). Re-run — the first test must FAIL with `ForbiddenError not thrown`. Restore the implementation. Re-run — green again. This is the regression-pattern proof required by CLAUDE.md for security fixes.
+
+- [ ] **Step 6: Wire the route's error responder.**
+
+Confirm the API's error middleware maps `ForbiddenError` (with `apiCode: 'ADULT_OWNER_REQUIRED'`) to a 403 response that surfaces `apiCode` in the JSON body. Grep `apps/api/src/errors.ts` (the Hono-specific helper, NOT the schemas error class file) for `ForbiddenError` and confirm the existing handler already does this — if it does, no work needed. If not, extend it (one-line addition; the apiCode field is already on the class).
+
+The mobile API client middleware classifies HTTP responses into typed errors per CLAUDE.md ("Typed error hierarchy"). Confirm `apps/mobile/src/lib/api-client.ts` (or wherever the response classifier lives — grep for `ForbiddenError`) already maps 403 with `apiCode: 'ADULT_OWNER_REQUIRED'` to the mobile-side `ForbiddenError` instance. The existing `formatApiError(err)` in `ProfileBasicsStep` then formats the message for the toast. No new screen needed.
+
+- [ ] **Step 7: Migration / rollback.**
+
+**Migration:** none. This is a pure validation rule — no schema change, no data backfill.
+
+**Rollback:** flip `config.ADULT_OWNER_GATE_ENABLED` to false (Doppler env update; no redeploy required if the config is read on every request rather than at boot — verify with the `apps/api/src/config.ts` implementation). The mobile flag `FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED` requires a mobile build/OTA flip; the API flag is the immediate kill switch.
+
+**Rollback section per CLAUDE.md Schema And Deploy Safety:** Rollback IS possible. No data is lost — the rule rejects creation, never destroys. Recovery procedure: flip flag off, request retries succeed.
+
+- [ ] **Step 8: Failure-modes addendum.** Already added in the section below (see "Underage owner attempts to link child (server)" row).
+
+- [ ] **Step 9: Commit via `/commit`.** Suggested message:
+```
+feat(api): server-side adult-owner rule for child profile creation [OPT-C]
+
+When an account adds a child profile (non-first profile), require the
+existing owner to be ≥18. Gated by config.ADULT_OWNER_GATE_ENABLED so
+the rule can be toggled off without code changes.
+
+Closes [HIGH-D3] gap: client-side gate (Task 13 / HIGH-A3) was the
+only barrier; this adds defense-in-depth at the server boundary.
+
+Tests:
+- Underage owner + child create → 403 ADULT_OWNER_REQUIRED (break test).
+- Owner aged 18 boundary → succeeds.
+- Flag OFF → succeeds (preserves today's behaviour).
+
+Plan: docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md §Task 13b
+Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
+```
+
+---
+
 ## Failure Modes Addendum (referenced from spec)
 
 | State | Trigger | User sees | Recovery |
@@ -2221,6 +2665,11 @@ Add `const [created, setCreated] = useState<{ parent: Profile; child?: Profile }
 | Child POST fails after owner POST succeeded | Network error mid-flight | Inline error banner + Retry button | Retry hits the same `submit()` — resume guard skips re-creating the owner; child POST retried. [HIGH-4] |
 | `setActive` succeeds but gate has stale preview state, user already has a profile | Sign-out → sign-in cycle with the same browser/session | Tabs render normally | `(app)/_layout.tsx` cleanup effect clears the SecureStore key when `activeProfile && profiles.length > 0`. Wizard is not reached. |
 | `pending-auth-redirect` lost on native cold-start | Process killed during OAuth round-trip | CreateProfileGate flash possible | Gate's async preview-state probe resolves `present` → `<Redirect>` to wizard. The pending-auth-redirect is a web-only optimization; native does not depend on it. [HIGH-1] |
+| Underage account-holder tries to set up a child | User enters birth year putting them at < 18 while `needsChild` (target ∈ `child` \| `both`) | Continue button disabled + inline warning at `save-basics-adult-required` explaining 18+ requirement and pointing back to the "My learning" branch | Client gate blocks submission. User can either (a) change birth year to ≥18 (only acceptable if it was a typo), or (b) go back to Step 1 and re-select target = `self`. Server has NO 18+ check ([HIGH-D3]), so the client is the only barrier. [HIGH-A3 / HIGH-B2] |
+| Wizard mounted while signed-out (token expired mid-OAuth) | Clerk session lapse between probe and mount | `<Redirect>` to `/sign-in` from the layout's `!isSignedIn` branch — wizard never reaches `useEffect` | Wizard branch sits AFTER `!isSignedIn` in gate ordering. Preview-state key survives on SecureStore through TTL, so re-signin lands back in wizard. [CRITICAL-A3] |
+| Underage owner attempts to link child (server, defense-in-depth) | Client gate bypassed (flag off on mobile, mobile build older than gate, or direct API call) — request reaches server with isFirstProfile=false and existing owner is < 18 | API returns 403 with `apiCode: ADULT_OWNER_REQUIRED`; mobile renders the existing `save-basics-error` view via `formatApiError(err)` showing "Account holder must be 18 or older to add a child profile." | User goes back to wizard Step 1 and re-selects target = `self`, OR (if the underage status is a birth-year typo) corrects it. No data created — the rule throws before insert. Server flag toggle (`config.ADULT_OWNER_GATE_ENABLED = false`) is the emergency kill switch. [OPT-C / Task 13b] |
+| Adult-owner gate flag off + underage user creates owner+child | Both `FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED` (mobile) AND `config.ADULT_OWNER_GATE_ENABLED` (API) are false | Account created with underage owner and linked child; 11+ floor still enforced. Identical to today's behaviour. | NOT a recovery — this is a configuration outcome, acceptable only when the gates are deliberately turned off (e.g. emergency rollback because the gate caused a regression). To restore protection, flip the API flag to true (takes effect immediately, no redeploy required if config is read per-request). [OPT-C] |
+| Server flag ON + client flag OFF + underage user attempts wizard | API enforces 18+; mobile build has UI gate disabled (mismatched flag state) | Client allows submission (no inline warning, Continue enabled); server rejects parent-or-child POST with 403 `ADULT_OWNER_REQUIRED`; the `save-basics-error` view surfaces "Account holder must be 18 or older to add a child profile." | User returns to wizard Step 1 and re-selects target = `self`, or corrects birth year if it was a typo. The mismatch is itself a release-coordination bug to flag — the mobile build should be brought into sync. [OPT-C] |
 
 ---
 
@@ -2230,7 +2679,10 @@ Add `const [created, setCreated] = useState<{ parent: Profile; child?: Profile }
 - Modify: `apps/mobile/src/app/(app)/preview/save.tsx`
 - Modify: `apps/mobile/src/app/(app)/preview/save.test.tsx`
 
-> **Spike outcome (fill in before starting Task 14):** [option (a) — helper at `<path>` / option (b) — defer topic prefill, CTA reads "Go to my learning"]
+> **Spike outcome (resolved 2026-05-19 in Task 0):** Dual landing keyed off the wizard's `target` flag.
+> - `target = self` (and `both` with `bothPriority = self_first`) → land in a session via the session-start helper (path: fill in once Task 0 Step 1 grep result is recorded; default expectation is `apps/mobile/src/hooks/use-create-session.ts`).
+> - `target = child` (and `both` with `bothPriority = child_first`) → `router.replace('/(app)/home')`. Saved topic surfaces as a card on home; "Add child" CTA is what closes the loop for this branch.
+> - CTA copy: `'Start lesson'` on the self-leaning branches, `'Open parent home'` on the child-leaning branches.
 
 > Hard Rule: use `router.replace` on landing so the preview stack is cleared (AC 13). Intra-wizard hops earlier are `setStep(...)` state changes, not router pushes.
 
@@ -2255,7 +2707,13 @@ it('self target: replaces history with first session route on success', async ()
   // ...drive through steps 1 + 2...
 
   await waitFor(() => {
-    expect(replace).toHaveBeenCalledWith(expect.stringMatching(/^\/\(app\)\//));
+    // [MEDIUM-D3 / Task 0 resolution] Self target lands in a session via the
+    // session-start helper. Assert the session route shape precisely — NOT
+    // a loose /(app)/ glob (would also match /home, which is the wrong
+    // branch for self).
+    expect(replace).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/\(app\)\/own-learning\/session(\/|$)/),
+    );
   });
 });
 
@@ -2325,11 +2783,30 @@ function ConfirmStep({
 
       await clearPreviewState();
 
-      if (target === 'self' || (target === 'both' && previewState.bothPriority === 'self_first')) {
-        // OPTION (A): call shared session-start helper with previewState.topicText.
-        // OPTION (B): router.replace('/(app)/home') and let the user start a session manually.
-        // FILL IN BASED ON TASK 0 SPIKE OUTCOME.
+      // [Task 0 resolution] Dual landing on wizard target flag.
+      const isSelfBranch =
+        target === 'self' ||
+        (target === 'both' && previewState.bothPriority === 'self_first');
+
+      if (isSelfBranch) {
+        // Self / kid-with-own-profile / solo-adult: land in a session for the saved topic.
+        // Helper accepts { topicText } and resolves to { sessionId } on success.
+        const result = await startSessionForTopic({
+          topicText: previewState.topicText ?? null,
+        });
+        if ('error' in result) {
+          // Session-start failure falls through to home with the error surfaced
+          // via the existing landingError UI block. Do NOT silently swallow.
+          setLandingError(result.error);
+          router.replace('/(app)/home');
+          return;
+        }
+        router.replace(`/(app)/own-learning/session/${result.sessionId}`);
       } else {
+        // Parent branch (target=child or both with child_first): the child profile
+        // does not exist yet at this point in the flow, so a session would attach
+        // to the wrong profile. Land on home where the "Add child" CTA closes
+        // the loop and the saved topic surfaces as a card.
         router.replace('/(app)/home');
       }
     } catch (err) {
@@ -2367,7 +2844,7 @@ function ConfirmStep({
 }
 ```
 
-Add imports: `clearPreviewState` from `preview-onboarding-state`, `useProfile` from `../../../lib/profile`, `formatApiError` (already imported).
+Add imports: `clearPreviewState` from `preview-onboarding-state`, `useProfile` from `../../../lib/profile`, `formatApiError` (already imported), and `startSessionForTopic` from the session-start helper resolved in Task 0 Step 1 (likely `../../../hooks/use-create-session`).
 
 - [ ] **Step 4: Run tests; confirm pass.**
 
@@ -2419,6 +2896,14 @@ Instead, the existing route tests already assert the correct method:
 - `(app)/preview/save.test.tsx` — Task 14 already asserts `replace` was called with the landing route.
 
 Sweep those tests once: confirm every navigation assertion uses the matching method (`push` for hops, `replace` for landing). If any test was written with the wrong assertion, fix it now — that is the AC-16 verification step.
+
+- [ ] **Step 2b: Telemetry gap (deferred follow-up).** [MEDIUM-C3]
+
+This plan ships ZERO funnel events. Per CLAUDE.md's `safeSend()` convention for non-core dispatches (`apps/api/src/services/safe-non-core.ts`), conversion-critical flows like trial onboarding MUST emit funnel events or the feature is unmeasurable post-launch. The shape of the follow-up:
+
+- Events: `preview_intent_seen`, `preview_intent_selected` (with `intent` payload), `preview_topic_submitted`, `preview_value_prop_seen` (with `path` payload), `preview_signup_started`, `preview_signup_completed`, `save_wizard_step_1`, `save_wizard_step_2`, `save_wizard_step_3`, `save_wizard_completed` (with `target` + `parent_profile_id` + `child_profile_id?`).
+- Discovery step: grep `apps/mobile/src/lib/` for existing analytics modules — PostHog, Amplitude, Segment, or a thin in-house dispatcher. Mirror the existing pattern; do not invent a new analytics surface.
+- Why deferred from this PR: the analytics conventions aren't grounded in this plan and the spec doesn't specify event names; this is a discovery + design follow-up, not a code follow-up. Open a Notion task immediately after merge so it doesn't fall through. Without these events the funnel-conversion measurement that justifies the feature can't be done.
 
 - [ ] **Step 3: Run full mobile test sweep for changed files.**
 

--- a/docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
+++ b/docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
@@ -2866,26 +2866,34 @@ Walk: sign-in → Try MentoMate → Me → topic "algebra" → learner value-pro
 - Re-read: `docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md` §Acceptance Criteria
 - All tests added in Tasks 1-14.
 
-- [ ] **Step 1: Map every AC to a test (or note "covered by E2E in Task 16").**
+- [x] **Step 1: Map every AC to a test (or note "covered by E2E in Task 16").**
 
-Open the spec. For each numbered AC, list the test name covering it. AC list:
+**Verified mapping (2026-05-20).** Wizard tests live in `(app)/_layout.test.tsx` because per `[CRITICAL-A2]` the wizard ships inline in the layout (not as a nested `preview/save.tsx` route — the plan's earlier wording predates the inline decision).
 
-1. Intent screen renders 4 options + no chat shell → `preview/intent.test.tsx`
-2. Self → learner value-prop with sample marker, no LLM → `value-prop.test.tsx`
-3. Child → parent value-prop, CTA copy → `value-prop.test.tsx`
-4. Auth returns to save wizard → `(app)/_layout.test.tsx` preview branch
-5. Wizard child→self override → `save.test.tsx`
-6. Wizard self→child override → `save.test.tsx`
-7. Parent lands on parent home + `isFamilyCapableProfile` true → `save.test.tsx` (parent target landing)
-8. Solo owner lands on learner home → `_layout.test.tsx` (resolveTabShape) + `save.test.tsx` (self target landing)
-9. Parent ok, child fails, no rollback → `save.test.tsx` (child failure case)
-10. 1-hour expiry → `preview-onboarding-state.test.tsx`
-11. Sign-out clears key → `sign-out-cleanup.test.ts`
-12. No preview state → CreateProfileGate unchanged → `_layout.test.tsx`
-13. `router.replace` on landing → `save.test.tsx`
-14. Back returns to topic/intent + topic preserved → manual + E2E (Task 16)
-15. Flag off: no CTA, no route, gate falls through → `sign-in.test.tsx` + `_layout.test.tsx`
-16. Navigation discipline: push for hops, replace for landing → grep assertion test (see step 2)
+| AC | What it asserts | Test (file → describe → it) | Status |
+|---|---|---|---|
+| 1 | Intent renders 4 options, no chat shell | `preview/intent.test.tsx` → `Preview IntentScreen` → 4 routing tests cover all options. The screen is a pure `View` with no chat surface; "no chat shell" is structurally guaranteed and verified by `value-prop.test.tsx`'s explicit `does not render a chat shell or any LLM-driven element`. | ✅ |
+| 2 | Me + topic → static learner value-prop, sample marker, no LLM | `preview/value-prop.test.tsx` → `learner variant renders sample dialogue marked as sample` + `does not render a chat shell or any LLM-driven element` | ✅ |
+| 3 | My child → parent value-prop + CTA copy | `preview/value-prop.test.tsx` → `parent variant renders sample weekly insight marked as sample` + `CTA routes to sign-up` | ✅ (CTA destination asserted; exact CTA copy not pinned by string — variant prop selects copy) |
+| 4 | Auth returns to save wizard, not CreateProfileGate | `(app)/_layout.test.tsx` → `AppLayout no-profile gate — preview branch` → `renders the SaveWizardGate when preview state exists and flag is on` | ✅ |
+| 5 | Wizard child→self override (only owner created) | `(app)/_layout.test.tsx` → `SaveWizard — Step 1` → `overrides intent when user picks a different target` (generic; covers both directions) | ✅ |
+| 6 | Wizard self→child override | Same generic test as AC 5 — `overrides intent when user picks a different target` | ✅ |
+| 7 | Parent lands on parent home + `isFamilyCapableProfile` true | Landing → `(app)/_layout.test.tsx` → `SaveWizard — Step 3` → `child target: replaces history with /(app)/home on CTA press`. Helper → `profile.test.ts` → `isFamilyCapableProfile` (5 cases). Composition coverage; the test does not chain these into a single assertion. | ✅ (composition) |
+| 8 | Solo owner lands on learner home | Landing → `SaveWizard — Step 3` → `self target: replaces history with session route on CTA press` lands at `/(app)/session`, and `resolveTabShape` → `returns learner for a solo owner with no linked profiles` proves the tab shape. (Self-branch lands in *session* per Task 0 resolution — stronger than the spec's "learner home" claim; tab shell remains learner.) | ✅ (composition) |
+| 9 | Parent ok, child fails, no rollback | Step 3 `switchProfile failure surfaces error in landing error block` covers landing-time failure. The specific scenario — owner POST succeeds + child POST fails mid-Step-2 with the `[HIGH-4]` resume guard skipping re-creation of the owner on retry — has implementation in `_layout.tsx` (`createdOwnerProfileId` cache check) but **no dedicated test**. | ⚠️ **Gap — see follow-up below** |
+| 10 | 1-hour TTL expiry | `preview-onboarding-state.test.ts` → `treats expired key as absent` | ✅ |
+| 11 | Sign-out clears key | `sign-out-cleanup.test.ts` → `clears mentomate_preview_intent on sign-out` | ✅ |
+| 12 | No preview state → CreateProfileGate unchanged | Pre-existing `AppLayout` describe block covers no-profile fallback to `CreateProfileGate`. The new preview branch only activates when state is present (gated by `previewProbeState === 'present'` in `_layout.tsx`), so a missing state preserves the original behaviour by construction. | ✅ (structural) |
+| 13 | `router.replace` on landing | `SaveWizard — Step 3` → both `self target …` and `child target …` tests assert `router.replace`, not `router.push` | ✅ |
+| 14 | Back returns to topic/intent + topic preserved | Deferred to E2E (Task 16). Topic preservation is exercised structurally by `preview-onboarding-state.test.ts` (`writes in-memory and to SecureStore`); the Back-button stack behaviour is platform-level and verified end-to-end. | ⏸ E2E deferred |
+| 15 | Flag off: no CTA, no route, gate falls through | `sign-in.test.tsx` → `SignInScreen — Try MentoMate CTA` → `hides the CTA when flag is off`; `(app)/_layout.test.tsx` → `falls through to CreateProfileGate when flag is off, even with stale preview state` | ✅ |
+| 16 | Navigation discipline (push for hops, replace for landing) | Hops: `preview/intent.test.tsx`, `preview/topic.test.tsx`, `preview/value-prop.test.tsx` all assert `push`. Landing: `_layout.test.tsx` Step 3 tests assert `replace`. Behavioural; no grep-over-source test. | ✅ |
+
+**Gap follow-up (AC 9 — open after this PR lands):**
+- Add a Step 2 test to `(app)/_layout.test.tsx` → `SaveWizard — Step 2 (Profile Basics)`: scenario `[HIGH-4] resumes from createdOwnerProfileId on retry after child POST fails`. Drive Step 2 once with success for the parent POST + failure for the child POST → assert error surfaced + parent profile present in cache + retry skips the re-create-parent call.
+- File: `apps/mobile/src/app/(app)/_layout.test.tsx`.
+- Estimate: ~30 min — the resume guard implementation already exists; this is test-only.
+- Why deferred from this PR: the audit caught it after wave 5b shipped; surfacing it here without ballooning Task 15's scope keeps the audit honest. Per CLAUDE.md "Sweep when you fix": this is the only gap, so a single follow-up issue (not a new lint guard) is the proportionate response.
 
 - [ ] **Step 2: Cover AC 16 behaviorally inside existing route tests.** [MEDIUM-1]
 

--- a/docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
+++ b/docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
@@ -1,0 +1,2567 @@
+# Trial Intent Save Onboarding v0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a pre-signup intent screen + post-signup save wizard that routes self / parent / both / not-sure users to the correct profile shape and landing surface, replacing today's learner-only "try it" path.
+
+**Architecture:** Three preview routes outside `(app)/` (landing → intent → topic|value-prop), state held in-memory plus a single 1-hour SecureStore key for cold-start survival across the OAuth round-trip. The post-signup save wizard is an **inline gate component** co-located inside `(app)/_layout.tsx` (mirrors the existing `CreateProfileGate` at line 640) — NOT a nested route. [CRITICAL-A2] The layout's gate ordering is: probe-loading spinner → `SaveWizardGate` (`previewProbeState === 'present' && !wizardDone`) → `CreateProfileGate` (`!activeProfile`) → consent gates → Tabs. Whole feature lives behind `PREVIEW_ONBOARDING_ENABLED`; the `isFamilyCapableProfile()` helper and the SecureStore-key entry in sign-out-cleanup ship unconditionally because the sibling Study/Family v0 spec imports them.
+
+**Tech Stack:** Expo Router (file-based routing), React Native, Clerk (auth), expo-secure-store, TanStack Query (`useProfiles` is `['profiles', userId]`-scoped), Hono RPC client, Jest co-located unit tests, Maestro E2E.
+
+**Reference spec:** `docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md`. Read it once before starting Task 0.
+
+---
+
+## Adversarial Review Round 2 — Findings Applied (2026-05-19)
+
+Second review pass after Round 1 missed two structural bugs in how the wizard mounts. Inline `[ID2]` markers below cite Round-2 findings.
+
+- **[CRITICAL-A2]** Wizard reshaped from a nested route (`(app)/preview/save.tsx`) into an **inline gate component** co-located inside `(app)/_layout.tsx`, mirroring the existing `CreateProfileGate` (line 640). Reasons:
+  - `(app)/_layout.tsx:1665-1671` no-profile branch returns `<FeedbackProvider><CreateProfileGate /></FeedbackProvider>` — it does NOT render `<Slot>`/`<Tabs>`, so any nested route under `(app)/preview/*` cannot mount. The Round-1 `<Redirect>` plan never had a destination to land on.
+  - `ProfileProvider` at `profile.ts:154-174` auto-activates the first profile the moment `profiles.length > 0`. With the wizard as a route, the Step-2 POST would cause `!activeProfile` to flip to falsy mid-wizard, ejecting the user before Step 3 renders. As an inline gate the wizard outlives that transition.
+- **[CRITICAL-B2]** The auto-cleanup effect (`if (activeProfile && profiles.length > 0) clearPreviewState()`) is REMOVED. It would wipe `createdOwnerProfileId` between the owner POST and the child POST, destroying the [HIGH-4] resume guard. Cleanup now relies on (a) TTL, (b) sign-out-cleanup, (c) the wizard's explicit `clearPreviewState()` on Step-3 success.
+- **[HIGH-A2]** Wizard takes an `onComplete` callback from the layout. On final-step success the wizard calls `onComplete()`, which flips a local layout state (`wizardDone`) so the gate falls through to normal Tabs even though `previewProbeState` is still cached as `'present'`. The gate ordering is now: probe-loading → wizard branch (`previewProbeState === 'present' && !wizardDone`) → `!activeProfile` → consent gates → Tabs.
+- **[HIGH-B2]** Adult-age gate added in Task 13: when `needsChild` (target ∈ {`child`, `both`}), the parent's birth-year input must put them at 18+ before Continue enables. Without this, a 13-year-old could complete the wizard as an `isOwner=true` profile with a child linked underneath (server allows 11+ as the floor; it does not enforce "parents must be adults").
+- **[HIGH-C2]** `sign-up-preview-redirect.ts` helper + `sign-up.tsx` edit DROPPED. With CRITICAL-A2's inline architecture, the gate handles the post-signup branch directly — no pending-auth-redirect plumbing needed. Cleaner failure mode (no race between `setActive` and the redirect-replay window in `(app)/_layout.tsx:1423-1490`). [MEDIUM-A2] follows: the Round-1 HIGH-1 description of pending-auth-redirect as web-only was inaccurate (line 17 has an in-memory fallback that works on native too), but the helper is removed entirely so the framing is moot.
+- **[MEDIUM-B2]** Deferred-sweep footnote in Task 17 expanded: `use-profiles.ts:65` (`useUpdateProfileName.onSuccess`) is the second bare-key-invalidation site alongside `create-profile.tsx:184`. Both are deferred sweeps, not blockers for this PR.
+- **[MEDIUM-C2]** `bothPriority` is hardcoded to `'child_first'` in Task 7 with no UI to flip it. Spec re-read required to confirm intent; documented as deferred-to-v0.1 if the spec assumes child-first only.
+- **[MEDIUM-D2]** Task 11 test no longer does `(FEATURE_FLAGS as any).X = false` — replaced with the `jest.doMock` + `jest.isolateModules` pattern already mandated by [HIGH-3] in Task 5.
+
+---
+
+## Adversarial Review Round 1 — Findings Applied (2026-05-19)
+
+Round-1 findings (folded in earlier in the day). Inline `[ID]` markers below cite which finding drove each change.
+
+- **[CRITICAL-1]** `forChild` body field removed — `profileCreateSchema` (`packages/schemas/src/profiles.ts:44`) does not accept it. Owner-vs-child is determined server-side by call order (`createProfileWithLimitCheck` in `apps/api/src/services/profile.ts:253`). See Task 13.
+- **[CRITICAL-2]** Manual `<Tabs.Screen name="preview/save">` registration dropped — `(app)/_layout.tsx:1715-1768` already auto-hides any route not in `visibleTabs`. The wizard route is added to `FULL_SCREEN_ROUTES` so the tab bar disappears while it is mounted. See Task 11.
+- **[CRITICAL-3]** Wizard now redirects home when `getPreviewState()` resolves null instead of rendering blank. See Task 12 + Failure Modes addendum.
+- **[CRITICAL-4]** `isFamilyCapableProfile` no longer calls `computeAgeBracket` (CLAUDE.md forbids it for feature gating). It is now `isOwner + ≥1 linked non-owner`, identical to existing `isGuardianProfile`. The new name exists only for sibling-spec readability. See Task 2.
+- **[HIGH-1]** Task 10 re-framed: the `(app)/_layout.tsx` gate is the source of truth on native; `rememberPendingAuthRedirect` is a web-only flash-avoidance optimization (`pending-auth-redirect.ts:19-27` is `window.sessionStorage`-only).
+- **[HIGH-2]** Single call site for `rememberPreviewRedirectIfNeeded` — only inside `activateCreatedSession` before `setActive` (covers both email-code and OAuth paths). The post-`prepareEmailAddressVerification` call has been removed.
+- **[HIGH-3]** Task 5 now begins with a discovery step to find the canonical flag-flip test pattern. No `jest.spyOn(...,'get')` against the `as const` literal; no `(FEATURE_FLAGS as any).X =` mutation.
+- **[HIGH-4]** Created owner profile id is persisted to the preview-state record so a wizard remount mid-flight does not create a duplicate profile. See Task 13.
+- **[MEDIUM-1]** Grep-based navigation-discipline test dropped; replaced with a behavioral assertion folded into existing tests. See Task 15.
+- **[MEDIUM-2]** `sign-up-preview-redirect` helper moved out of `app/(auth)/` to `src/lib/` to avoid Expo Router pollution.
+- **[MEDIUM-3]** Line-number references in Task 11 replaced with landmark anchors (`if (!activeProfile)`, `<Tabs screenOptions=...>`).
+- **[MEDIUM-4]** `keychainAccessible` option imported directly from `expo-secure-store`; no `as never` cast.
+- **[MEDIUM-5]** Topic max lowered from 200 → 80 chars (single-line topic) with a comment explaining the leak-surface rationale.
+- **[MEDIUM-6]** Predicate invalidation made the project standard for `['profiles']` cache; a footnote in Task 17 calls out the `create-profile.tsx` site as a deferred sweep.
+- **[LOW-1]** `seedPreviewStateForTesting(state, staleMs)` helper added in Task 3, mirroring `seedPendingAuthRedirectForTesting`. Task 16 Flow 5 now uses it.
+- **[LOW-2]** Local `state` variable in `value-prop.tsx` renamed to `previewState` to avoid module shadow.
+
+---
+
+## File Map
+
+**New files:**
+
+- `apps/mobile/src/lib/preview-onboarding-state.ts` — state module (in-memory singleton + SecureStore TTL). Also exports `seedPreviewStateForTesting` [LOW-1].
+- `apps/mobile/src/lib/preview-onboarding-state.test.ts`
+- `apps/mobile/src/app/preview/_layout.tsx` — stack layout for preview routes (hides tab bar by being outside `(app)/`).
+- `apps/mobile/src/app/preview/index.tsx` — "Try MentoMate" landing CTA.
+- `apps/mobile/src/app/preview/intent.tsx` — 4-option intent question.
+- `apps/mobile/src/app/preview/intent.test.tsx`
+- `apps/mobile/src/app/preview/topic.tsx` — topic capture.
+- `apps/mobile/src/app/preview/topic.test.tsx`
+- `apps/mobile/src/app/preview/value-prop.tsx` — static value-prop, learner|parent variant.
+- `apps/mobile/src/app/preview/value-prop.test.tsx`
+
+> [CRITICAL-A2] The post-signup save wizard is NOT a route file. It is an inline component (`SaveWizardGate`) defined inside `apps/mobile/src/app/(app)/_layout.tsx` — same pattern as the existing `CreateProfileGate` (line 640). Tests for it co-locate inside `(app)/_layout.test.tsx` (or extract to `save-wizard-gate.test.tsx` if the layout test file balloons). The previously-planned `(app)/preview/save.tsx`, `(app)/preview/_layout.tsx`, and `(app)/preview/save.test.tsx` are NOT created.
+
+**Modified files:**
+
+- `apps/mobile/src/lib/feature-flags.ts` — add `PREVIEW_ONBOARDING_ENABLED`.
+- `apps/mobile/src/lib/profile.ts` — add `isFamilyCapableProfile()` (unconditional, shared with Study/Family v0).
+- `apps/mobile/src/lib/profile.test.ts` — new test cases for `isFamilyCapableProfile()`.
+- `apps/mobile/src/lib/sign-out-cleanup.ts` — append `'mentomate_preview_intent'` to `GLOBAL_KEYS`.
+- `apps/mobile/src/lib/sign-out-cleanup.test.ts` — assert the new key is wiped.
+- `apps/mobile/src/app/(auth)/sign-in.tsx` — render "Try MentoMate" CTA when flag on.
+- `apps/mobile/src/app/(auth)/sign-in.test.tsx` (or co-located) — assert CTA rendering under both flag states.
+- `apps/mobile/src/app/(auth)/_layout.tsx` — no edit. (Read-only verification step.)
+- `apps/mobile/src/app/(app)/_layout.tsx` — (a) async preview-state probe, (b) inline `SaveWizardGate` component (CreateProfileGate-style), (c) gate ordering: probe-loading → wizard → no-profile → consent gates → Tabs. NO addition to `FULL_SCREEN_ROUTES` (no route to hide). NO `<Tabs.Screen>` registration. The auto-cleanup effect (`activeProfile && profiles.length > 0 → clearPreviewState`) is NOT added — it would destroy the [HIGH-4] resume guard [CRITICAL-B2].
+- `apps/mobile/src/app/(app)/_layout.test.tsx` — preview-state branch tests + SaveWizardGate behavior tests.
+
+> [HIGH-C2] **`sign-up.tsx` is NOT modified.** The Round-1 plan threaded `rememberPreviewRedirectIfNeeded()` into `activateCreatedSession`; with the inline-wizard architecture the gate handles the post-signup transition directly, so no pending-auth-redirect plumbing is needed for this feature. `sign-up-preview-redirect.ts` is not created. The line `import { rememberPreviewRedirectIfNeeded } from '../../lib/sign-up-preview-redirect';` is NEVER added.
+
+**Read-only (no edits expected):**
+
+- `apps/mobile/src/lib/pending-auth-redirect.ts` — NOT consumed by this feature. Round-1 framed it as web-only; Round-2 [MEDIUM-A2] notes that it has an in-memory native fallback at line 17, but neither path is wired here. With the inline-wizard architecture the gate replaces both.
+- `apps/mobile/src/app/create-profile.tsx` — the save wizard's profile-basics step reuses the same fields conceptually but does not import the screen (it's a default-export route). Extract shared field components only if duplication grows past two callsites (YAGNI — start with inline form, refactor later if needed).
+
+---
+
+## Task 0: Session-Start Helper Spike (BLOCKER, do not skip)
+
+**Why:** Spec §First Session Handoff requires a decision *before* implementation: either (a) lift the existing session-start call site into a reusable helper and add it to scope, or (b) defer the topic-prefill leg and update wizard CTA copy. This spike eliminates the "pause mid-implementation" loop.
+
+**Files:**
+- Read: `apps/mobile/src/app/(app)/home.tsx` (or whichever screen owns the "Start a new session" affordance)
+- Read: `apps/mobile/src/hooks/use-create-session.ts` (or equivalent — discover via grep)
+
+- [ ] **Step 1: Find every existing session-start entry point.**
+
+Run from repo root:
+```bash
+grep -rn "sessions.\$post\|createSession\|startSession\|session-start" apps/mobile/src --include="*.ts" --include="*.tsx" -l
+```
+Open each hit. For each, note: (a) is it a hook/util or screen-local handler? (b) does it accept a topic string param? (c) does it `router.push` to the session route after success?
+
+- [ ] **Step 2: Decide (a) or (b).**
+
+Decision tree:
+- If a reusable hook (e.g., `useCreateSession`) already accepts a topic and navigates → option (a), zero additional scope. Use it directly in Task 14.
+- If the only call site is buried in a screen component → option (b) is the default to avoid scope creep. Add a one-line decision to spec §First Session Handoff.
+
+- [ ] **Step 3: Record the decision in this plan.**
+
+Open this file and replace the line below in Task 14:
+
+> **Spike outcome (fill in before starting Task 14):** [option (a) — helper at `<path>` / option (b) — defer topic prefill, CTA reads "Go to my learning"]
+
+- [ ] **Step 4: Commit the spike decision.**
+
+```bash
+git add docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md
+git commit -m "docs(plan): record session-start spike outcome for trial v0"
+```
+
+No code shipped in Task 0.
+
+---
+
+## Task 1: Feature Flag
+
+**Files:**
+- Modify: `apps/mobile/src/lib/feature-flags.ts`
+
+- [ ] **Step 1: Add the flag.**
+
+Edit `apps/mobile/src/lib/feature-flags.ts`:
+
+```ts
+export const FEATURE_FLAGS = {
+  COACH_BAND_ENABLED: true,
+  MIC_IN_PILL_ENABLED: true,
+  I18N_ENABLED: true,
+  // Pre-signup intent + post-signup save wizard.
+  // Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
+  // When false:
+  //   - sign-in.tsx: "Try MentoMate" CTA hidden, /preview/* unreachable via UI.
+  //   - (app)/_layout.tsx: no-profile gate ignores preview state, falls through to CreateProfileGate.
+  //   - (app)/_layout.tsx: preview/save tab entry not registered (defensive; route is unreachable anyway).
+  // isFamilyCapableProfile() and the mentomate_preview_intent entry in sign-out-cleanup ship UNCONDITIONALLY.
+  PREVIEW_ONBOARDING_ENABLED: true,
+} as const;
+```
+
+- [ ] **Step 2: Typecheck.**
+
+Run:
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+Expected: passes.
+
+- [ ] **Step 3: Commit.**
+
+Use `/commit` (do NOT use raw `git commit`). Suggested message:
+```
+feat(mobile): add PREVIEW_ONBOARDING_ENABLED feature flag
+
+Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
+Gate sites listed in feature-flags.ts comment.
+```
+
+---
+
+## Task 2: `isFamilyCapableProfile()` Helper (UNCONDITIONAL)
+
+**Files:**
+- Modify: `apps/mobile/src/lib/profile.ts`
+- Modify: `apps/mobile/src/lib/profile.test.ts` (or create if absent)
+
+> CRITICAL: This helper ships independent of `PREVIEW_ONBOARDING_ENABLED`. The sibling Study/Family v0 spec imports it. Do not wrap any callsite in a flag check.
+
+> [CRITICAL-4] **Age gating REMOVED.** CLAUDE.md (Profile Shapes section) forbids using `computeAgeBracket` for feature gating. The shape of this predicate is therefore identical to the existing `isGuardianProfile` in `profile.ts:30` — `isOwner` + at least one linked non-owner. The new name exists ONLY so the sibling Study/Family v0 spec can import a name that matches its terminology. Adult-only affordances (e.g., "add child" button) keep their own checks at their own call sites; do NOT fold age gating into this predicate.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append to `apps/mobile/src/lib/profile.test.ts` (or create the file with the import boilerplate matching neighboring tests in `apps/mobile/src/lib/`):
+
+```ts
+import { isFamilyCapableProfile } from './profile';
+import type { Profile } from '@eduagent/schemas';
+
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    id: 'p1',
+    displayName: 'Test',
+    birthYear: 1985,
+    isOwner: true,
+    consentStatus: 'CONSENTED',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    linkCreatedAt: null,
+    parentEmail: null,
+    // Add any other required Profile fields by reading packages/schemas/src/profiles.ts.
+    ...overrides,
+  } as Profile;
+}
+
+describe('isFamilyCapableProfile', () => {
+  const owner = makeProfile({ id: 'p1', isOwner: true, birthYear: 1985 });
+  const child = makeProfile({ id: 'p2', isOwner: false, birthYear: 2015 });
+
+  it('returns true when owner has at least one linked non-owner', () => {
+    expect(isFamilyCapableProfile(owner, [owner, child])).toBe(true);
+  });
+
+  it('returns false when owner has no linked non-owner', () => {
+    expect(isFamilyCapableProfile(owner, [owner])).toBe(false);
+  });
+
+  it('returns false for non-owner active profile', () => {
+    expect(isFamilyCapableProfile(child, [owner, child])).toBe(false);
+  });
+
+  it('returns false when activeProfile is null', () => {
+    expect(isFamilyCapableProfile(null, [owner, child])).toBe(false);
+  });
+
+  // [CRITICAL-4] Explicit anti-test: this predicate must NOT consider age.
+  // Age-based gating ("add child" button visibility) lives at its own
+  // call sites, never inside the family-capable check.
+  it('returns true for a minor owner with a linked non-owner (age is NOT part of this predicate)', () => {
+    const minorOwner = makeProfile({ id: 'p1', isOwner: true, birthYear: 2015 });
+    expect(isFamilyCapableProfile(minorOwner, [minorOwner, child])).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; confirm they fail (function not exported).**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.test.ts --no-coverage
+```
+Expected: FAIL with "isFamilyCapableProfile is not a function" / undefined import.
+
+- [ ] **Step 3: Implement.**
+
+Open `apps/mobile/src/lib/profile.ts`. Add the helper next to `isGuardianProfile()`:
+
+```ts
+/**
+ * Family-capable profile predicate. Shared verbatim with Study/Family v0 spec.
+ * True iff active profile is an owner with at least one linked non-owner.
+ *
+ * [CRITICAL-4] Deliberately NO age check — CLAUDE.md forbids using
+ * computeAgeBracket() for feature gating. Adult-only affordances (e.g.
+ * "Add child") keep their own age checks at their own call sites.
+ *
+ * Shape is identical to isGuardianProfile() above; the alternate name
+ * exists so sibling-spec readers find the term they expect.
+ *
+ * Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md §Implementation step 1
+ * Sibling: docs/specs/2026-05-19-study-and-family-mode-navigation-v0.md §Implementation step 1
+ */
+export function isFamilyCapableProfile(
+  activeProfile: Profile | null | undefined,
+  profiles: ReadonlyArray<Profile>,
+): boolean {
+  if (!activeProfile) return false;
+  if (!activeProfile.isOwner) return false;
+  return profiles.some((p) => p.id !== activeProfile.id && !p.isOwner);
+}
+```
+
+> No `computeAgeBracket` import needed.
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/profile.test.ts --no-coverage
+```
+Expected: 5 tests pass (including the explicit "age is NOT part of this predicate" anti-test).
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+Suggested message:
+```
+feat(mobile): add isFamilyCapableProfile shared capability predicate
+
+Shared with study-and-family-mode-navigation-v0 spec.
+Owner + ≥1 linked non-owner = family-capable.
+No age check — that gates "Add child" affordance only, at its own
+call site, per CLAUDE.md "never for feature gating" rule.
+```
+
+---
+
+## Task 3: Preview Onboarding State Module
+
+**Files:**
+- Create: `apps/mobile/src/lib/preview-onboarding-state.ts`
+- Create: `apps/mobile/src/lib/preview-onboarding-state.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `apps/mobile/src/lib/preview-onboarding-state.test.ts`:
+
+```ts
+import * as SecureStore from './secure-storage';
+import {
+  getPreviewState,
+  setPreviewState,
+  clearPreviewState,
+  PREVIEW_INTENT_KEY,
+  PREVIEW_TTL_MS,
+  type PreviewOnboardingStateV0,
+} from './preview-onboarding-state';
+
+describe('preview-onboarding-state', () => {
+  beforeEach(async () => {
+    await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(() => undefined);
+    clearPreviewState();
+  });
+
+  const baseState: PreviewOnboardingStateV0 = {
+    intent: 'self',
+    path: 'learner_value_prop',
+    topicText: 'algebra basics',
+    createdAt: new Date().toISOString(),
+  };
+
+  it('returns null when no state set', async () => {
+    expect(await getPreviewState()).toBeNull();
+  });
+
+  it('writes in-memory and to SecureStore', async () => {
+    await setPreviewState(baseState);
+    expect(await getPreviewState()).toEqual(baseState);
+    const raw = await SecureStore.getItemAsync(PREVIEW_INTENT_KEY);
+    expect(raw).not.toBeNull();
+  });
+
+  it('hydrates from SecureStore when memory empty (cold-start)', async () => {
+    await setPreviewState(baseState);
+    clearPreviewState(); // simulate process restart: memory wiped, key intact
+
+    // Re-write the key directly to simulate the cold-start path
+    await SecureStore.setItemAsync(
+      PREVIEW_INTENT_KEY,
+      JSON.stringify({ ...baseState, savedAt: Date.now() }),
+    );
+
+    const result = await getPreviewState();
+    expect(result?.intent).toBe('self');
+  });
+
+  it('treats expired key as absent', async () => {
+    const stale = { ...baseState, savedAt: Date.now() - (PREVIEW_TTL_MS + 1000) };
+    await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(stale));
+    clearPreviewState();
+
+    expect(await getPreviewState()).toBeNull();
+  });
+
+  it('clearPreviewState wipes memory AND SecureStore', async () => {
+    await setPreviewState(baseState);
+    await clearPreviewState();
+
+    expect(await getPreviewState()).toBeNull();
+    expect(await SecureStore.getItemAsync(PREVIEW_INTENT_KEY)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test; confirm fail (module missing).**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/preview-onboarding-state.test.ts --no-coverage
+```
+Expected: FAIL with module resolution error.
+
+- [ ] **Step 3: Implement the module.**
+
+Create `apps/mobile/src/lib/preview-onboarding-state.ts`:
+
+```ts
+import * as SecureStore from './secure-storage';
+// [MEDIUM-4] Import the keychain-accessible constant directly from the
+// native module. The wrapper passes options through unchanged
+// (secure-storage.ts:106), so a typed value works without `as never` casts.
+import { WHEN_UNLOCKED_THIS_DEVICE_ONLY } from 'expo-secure-store';
+
+export const PREVIEW_INTENT_KEY = 'mentomate_preview_intent';
+export const PREVIEW_TTL_MS = 60 * 60_000; // 1 hour
+
+export type PreviewIntent = 'self' | 'child' | 'both' | 'not_sure';
+export type PreviewPath = 'learner_value_prop' | 'parent_value_prop';
+export type SaveTarget = 'self' | 'child' | 'both';
+
+export interface PreviewOnboardingStateV0 {
+  intent: PreviewIntent;
+  path: PreviewPath;
+  topicText?: string;
+  bothPriority?: 'child_first' | 'self_first';
+  preferredSaveTarget?: SaveTarget;
+  createdAt: string;
+  // [HIGH-4] Set inside the save wizard after the owner POST succeeds, so a
+  // wizard remount mid-flight (refresh, OOM-kill, app background) can resume
+  // without double-creating profiles. Cleared by clearPreviewState() on
+  // wizard completion or sign-out.
+  createdOwnerProfileId?: string;
+}
+
+interface StoredRecord extends PreviewOnboardingStateV0 {
+  savedAt: number;
+}
+
+let memoryState: PreviewOnboardingStateV0 | null = null;
+
+function isFresh(savedAt: number): boolean {
+  return Date.now() - savedAt < PREVIEW_TTL_MS;
+}
+
+export async function getPreviewState(): Promise<PreviewOnboardingStateV0 | null> {
+  if (memoryState) return memoryState;
+
+  try {
+    const raw = await SecureStore.getItemAsync(PREVIEW_INTENT_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<StoredRecord>;
+    if (
+      typeof parsed.savedAt !== 'number' ||
+      typeof parsed.intent !== 'string' ||
+      typeof parsed.path !== 'string' ||
+      typeof parsed.createdAt !== 'string'
+    ) {
+      await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(() => undefined);
+      return null;
+    }
+
+    if (!isFresh(parsed.savedAt)) {
+      await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(() => undefined);
+      return null;
+    }
+
+    const { savedAt: _ignored, ...state } = parsed as StoredRecord;
+    memoryState = state as PreviewOnboardingStateV0;
+    return memoryState;
+  } catch {
+    return null;
+  }
+}
+
+export async function setPreviewState(state: PreviewOnboardingStateV0): Promise<void> {
+  memoryState = state;
+  const record: StoredRecord = { ...state, savedAt: Date.now() };
+  try {
+    // [SEC] WHEN_UNLOCKED_THIS_DEVICE_ONLY excludes from iCloud Keychain sync
+    // and device-to-device backups; bounds the topic-text leak surface to
+    // the originating device. Spec §Preview State (Minimal).
+    await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
+      keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+  } catch {
+    // Non-fatal; in-memory state still survives the warm session.
+  }
+}
+
+export async function clearPreviewState(): Promise<void> {
+  memoryState = null;
+  try {
+    await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY);
+  } catch {
+    // Non-fatal.
+  }
+}
+
+/**
+ * [LOW-1] Dev/E2E only. Writes a preview-state record whose `savedAt` is
+ * artificially backdated by `staleMs` milliseconds, so Maestro flows can
+ * simulate a TTL-expired record without waiting an hour.
+ *
+ * Mirrors `seedPendingAuthRedirectForTesting` (pending-auth-redirect.ts:115).
+ * Throws in production builds or when EXPO_PUBLIC_E2E !== 'true'.
+ */
+export async function seedPreviewStateForTesting(
+  state: PreviewOnboardingStateV0,
+  staleMs: number,
+): Promise<void> {
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.EXPO_PUBLIC_E2E !== 'true'
+  ) {
+    throw new Error('seedPreviewStateForTesting is dev-only');
+  }
+  memoryState = state;
+  const record: StoredRecord = { ...state, savedAt: Date.now() - staleMs };
+  await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
+    keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/preview-onboarding-state.test.ts --no-coverage
+```
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 4: Register Preview Key in Sign-Out Cleanup
+
+**Files:**
+- Modify: `apps/mobile/src/lib/sign-out-cleanup.ts`
+- Modify: `apps/mobile/src/lib/sign-out-cleanup.test.ts` (or co-located)
+
+> This task ships UNCONDITIONALLY. Cleanup is harmless when no key exists, and keeping the entry registered means a future flag flip-on never leaves residue.
+
+- [ ] **Step 1: Write failing test.**
+
+Add to `apps/mobile/src/lib/sign-out-cleanup.test.ts` (or wherever the cleanup tests live — find via `grep -l "clearProfileSecureStorageOnSignOut" apps/mobile/src/lib`):
+
+```ts
+it('clears mentomate_preview_intent on sign-out', async () => {
+  const spy = jest.spyOn(SecureStore, 'deleteItemAsync').mockResolvedValue(undefined);
+  await clearProfileSecureStorageOnSignOut([]);
+  expect(spy).toHaveBeenCalledWith('mentomate_preview_intent');
+});
+```
+
+- [ ] **Step 2: Run test; confirm fail.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/sign-out-cleanup.ts --no-coverage
+```
+Expected: FAIL (key not in `GLOBAL_KEYS`).
+
+- [ ] **Step 3: Edit `sign-out-cleanup.ts`.**
+
+In `apps/mobile/src/lib/sign-out-cleanup.ts`, append to `GLOBAL_KEYS` (currently lines 79-88):
+
+```ts
+  'byok-waitlist-joined',
+  // preview-onboarding-state.ts — pre-signup intent + topic (1h TTL).
+  // Spec: docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md
+  'mentomate_preview_intent',
+];
+```
+
+- [ ] **Step 4: Run cleanup test + the registry meta-test.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests src/lib/sign-out-cleanup.ts src/lib/preview-onboarding-state.ts --no-coverage
+```
+Expected: pass. The companion meta-test (`sign-out-cleanup-registry.test.ts`, referenced at `sign-out-cleanup.ts:27`) must also pass — run:
+
+```bash
+cd apps/mobile && pnpm exec jest sign-out-cleanup-registry --no-coverage
+```
+Expected: pass (the new SecureStore writer is now registered).
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 5: Sign-In CTA Gate
+
+**Files:**
+- Modify: `apps/mobile/src/app/(auth)/sign-in.tsx`
+- Modify or create: `apps/mobile/src/app/(auth)/sign-in.test.tsx`
+
+- [ ] **Step 0 (Spike, BLOCKER): Discover the canonical flag-flip test pattern.** [HIGH-3]
+
+`FEATURE_FLAGS` is exported `as const` (`feature-flags.ts:1`) — a plain literal with no getter. So `jest.spyOn(FEATURE_FLAGS, 'X', 'get')` THROWS, and `(FEATURE_FLAGS as any).X = false` mutates the global module export and leaks across parallel workers. Neither is acceptable.
+
+Run:
+```bash
+grep -rn "FEATURE_FLAGS" apps/mobile/src --include "*.test.ts" --include "*.test.tsx" -l
+```
+Open each file. Identify the canonical pattern. There are three plausible answers; record which one applies before writing tests:
+
+1. **`jest.doMock` + `jest.isolateModules`** — re-mocks the module per test, scoped via `isolateModules`. Cleanest; survives parallel workers.
+2. **Top-of-file `jest.mock('../../lib/feature-flags', () => ({...}))`** — module-wide override; one flag value per test file.
+3. **No existing pattern** — then introduce option (1) and document it in the plan.
+
+Whichever applies, REPLACE the test sketch below before running it.
+
+- [ ] **Step 1: Write failing test using the canonical pattern.**
+
+Sketch (option 1 — `jest.doMock` + `isolateModules`):
+
+```tsx
+import { render, screen } from '@testing-library/react-native';
+
+describe('SignInScreen — Try MentoMate CTA', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('renders the Try MentoMate CTA when flag is on', () => {
+    jest.isolateModules(() => {
+      jest.doMock('../../lib/feature-flags', () => ({
+        FEATURE_FLAGS: {
+          COACH_BAND_ENABLED: true,
+          MIC_IN_PILL_ENABLED: true,
+          I18N_ENABLED: true,
+          PREVIEW_ONBOARDING_ENABLED: true,
+        },
+      }));
+      const SignInScreen = require('./sign-in').default;
+      render(<SignInScreen />);
+      expect(screen.getByTestId('try-mentomate-cta')).toBeTruthy();
+    });
+  });
+
+  it('hides the CTA when flag is off', () => {
+    jest.isolateModules(() => {
+      jest.doMock('../../lib/feature-flags', () => ({
+        FEATURE_FLAGS: {
+          COACH_BAND_ENABLED: true,
+          MIC_IN_PILL_ENABLED: true,
+          I18N_ENABLED: true,
+          PREVIEW_ONBOARDING_ENABLED: false,
+        },
+      }));
+      const SignInScreen = require('./sign-in').default;
+      render(<SignInScreen />);
+      expect(screen.queryByTestId('try-mentomate-cta')).toBeNull();
+    });
+  });
+});
+```
+
+> If the spike found option (2) instead, mirror it. Do NOT invent new patterns — consistency with the rest of the test suite matters more than elegance.
+
+- [ ] **Step 2: Run test; confirm fail.**
+
+- [ ] **Step 3: Edit `sign-in.tsx`.**
+
+Add import near the existing ones:
+
+```tsx
+import { FEATURE_FLAGS } from '../../lib/feature-flags';
+```
+
+Below the existing sign-in form (find the JSX in `sign-in.tsx` after primary form rendering — look for the section that renders the SSO buttons; the CTA goes just below), insert:
+
+```tsx
+{FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED && (
+  <View className="w-full mt-6 pt-6 border-t border-border">
+    <Text className="text-body-sm text-text-secondary text-center mb-3">
+      New here?
+    </Text>
+    <Pressable
+      onPress={() => router.push('/preview')}
+      className="bg-surface rounded-button py-3.5 px-8 items-center w-full"
+      testID="try-mentomate-cta"
+      accessibilityRole="button"
+      accessibilityLabel="Try MentoMate"
+    >
+      <Text className="text-body font-semibold text-primary">
+        Try MentoMate
+      </Text>
+    </Pressable>
+  </View>
+)}
+```
+
+(Adjust `Pressable` / `View` / `Text` imports — they likely already exist in sign-in.tsx.)
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 6: Preview Stack Layout + Landing
+
+**Files:**
+- Create: `apps/mobile/src/app/preview/_layout.tsx`
+- Create: `apps/mobile/src/app/preview/index.tsx`
+
+> Routes under `preview/*` are outside `(app)/`, so they render full-screen without the tab bar by default. The layout exists only to wrap the stack with theme tokens / safe-area handling consistent with other unauthenticated screens.
+
+- [ ] **Step 1: Create `_layout.tsx`.**
+
+```tsx
+import { Stack } from 'expo-router';
+
+export default function PreviewLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}
+```
+
+- [ ] **Step 2: Create `index.tsx` landing.**
+
+```tsx
+import { View, Text, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MentomateLogo } from '../../components/MentomateLogo';
+
+export default function PreviewLandingScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      className="flex-1 bg-background items-center justify-center px-6"
+      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      testID="preview-landing"
+    >
+      <MentomateLogo size={96} />
+      <Text className="text-h1 font-bold text-text-primary mt-8 mb-3 text-center">
+        Try MentoMate
+      </Text>
+      <Text className="text-body text-text-secondary mb-10 text-center">
+        See how it works — no sign-up needed yet.
+      </Text>
+      <Pressable
+        onPress={() => router.push('/preview/intent')}
+        className="bg-primary rounded-button py-3.5 px-10 items-center w-full"
+        testID="preview-landing-continue"
+        accessibilityRole="button"
+        accessibilityLabel="Continue"
+      >
+        <Text className="text-body font-semibold text-text-inverse">
+          Continue
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 4: Commit via `/commit`.**
+
+---
+
+## Task 7: Intent Screen
+
+**Files:**
+- Create: `apps/mobile/src/app/preview/intent.tsx`
+- Create: `apps/mobile/src/app/preview/intent.test.tsx`
+
+- [ ] **Step 1: Write failing test.**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import IntentScreen from './intent';
+import * as state from '../../lib/preview-onboarding-state';
+
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('Preview IntentScreen', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    push.mockReset();
+    jest.spyOn(state, 'setPreviewState').mockResolvedValue();
+  });
+
+  it('routes Me → topic with intent self', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-self'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'self', path: 'learner_value_prop' }),
+    );
+    expect(push).toHaveBeenCalledWith('/preview/topic');
+  });
+
+  it('routes My child → value-prop parent variant', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-child'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'child', path: 'parent_value_prop' }),
+    );
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/preview/value-prop',
+      params: { variant: 'parent' },
+    });
+  });
+
+  it('routes Both → topic (child-first default recorded)', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-both'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'both',
+        bothPriority: 'child_first',
+        path: 'parent_value_prop',
+      }),
+    );
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/preview/value-prop',
+      params: { variant: 'parent' },
+    });
+  });
+
+  it('routes Not sure → topic (lesson fork) with intent not_sure', async () => {
+    render(<IntentScreen />);
+    fireEvent.press(screen.getByTestId('intent-not-sure'));
+    await Promise.resolve();
+    expect(state.setPreviewState).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'not_sure' }),
+    );
+    expect(push).toHaveBeenCalledWith('/preview/topic');
+  });
+});
+```
+
+> The Not-Sure routing in the spec has a low-commitment fork ("Try a quick lesson" vs "See how parent setup works"). v0 default: route to topic (lesson fork). If product wants the explicit fork screen, add it as a follow-up — recording the intent is what matters for AC 1.
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Implement `intent.tsx`.**
+
+```tsx
+import { View, Text, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { setPreviewState, type PreviewIntent } from '../../lib/preview-onboarding-state';
+
+interface Option {
+  intent: PreviewIntent;
+  label: string;
+  description: string;
+  testID: string;
+}
+
+const OPTIONS: ReadonlyArray<Option> = [
+  { intent: 'self', label: 'Me', description: "I'm setting this up for myself.", testID: 'intent-self' },
+  { intent: 'child', label: 'My child', description: 'I want to help my child.', testID: 'intent-child' },
+  { intent: 'both', label: 'Both', description: 'For me and my child.', testID: 'intent-both' },
+  { intent: 'not_sure', label: 'Not sure', description: "Show me how it works first.", testID: 'intent-not-sure' },
+];
+
+export default function PreviewIntentScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const onSelect = async (intent: PreviewIntent) => {
+    const createdAt = new Date().toISOString();
+
+    if (intent === 'self') {
+      await setPreviewState({ intent: 'self', path: 'learner_value_prop', createdAt });
+      router.push('/preview/topic');
+      return;
+    }
+    if (intent === 'child') {
+      await setPreviewState({ intent: 'child', path: 'parent_value_prop', createdAt });
+      router.push({ pathname: '/preview/value-prop', params: { variant: 'parent' } });
+      return;
+    }
+    if (intent === 'both') {
+      await setPreviewState({
+        intent: 'both',
+        path: 'parent_value_prop',
+        bothPriority: 'child_first',
+        createdAt,
+      });
+      router.push({ pathname: '/preview/value-prop', params: { variant: 'parent' } });
+      return;
+    }
+    // not_sure → lesson fork (v0: same as self)
+    await setPreviewState({ intent: 'not_sure', path: 'learner_value_prop', createdAt });
+    router.push('/preview/topic');
+  };
+
+  return (
+    <View
+      className="flex-1 bg-background px-6"
+      style={{ paddingTop: insets.top + 32, paddingBottom: insets.bottom }}
+      testID="preview-intent"
+    >
+      <Text className="text-h1 font-bold text-text-primary mb-2 text-center">
+        Who are you setting this up for?
+      </Text>
+      <Text className="text-body text-text-secondary mb-8 text-center">
+        We&apos;ll tailor what you see next.
+      </Text>
+      {OPTIONS.map((opt) => (
+        <Pressable
+          key={opt.intent}
+          onPress={() => void onSelect(opt.intent)}
+          className="bg-surface rounded-card px-4 py-4 mb-3"
+          testID={opt.testID}
+          accessibilityRole="button"
+          accessibilityLabel={opt.label}
+        >
+          <Text className="text-body font-semibold text-text-primary mb-1">
+            {opt.label}
+          </Text>
+          <Text className="text-body-sm text-text-secondary">
+            {opt.description}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 8: Topic Screen
+
+**Files:**
+- Create: `apps/mobile/src/app/preview/topic.tsx`
+- Create: `apps/mobile/src/app/preview/topic.test.tsx`
+
+- [ ] **Step 1: Write failing test.**
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import TopicScreen from './topic';
+import * as state from '../../lib/preview-onboarding-state';
+
+jest.mock('expo-router', () => ({ useRouter: jest.fn() }));
+
+describe('Preview TopicScreen', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    push.mockReset();
+    jest.spyOn(state, 'getPreviewState').mockResolvedValue({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    jest.spyOn(state, 'setPreviewState').mockResolvedValue();
+  });
+
+  it('stores topic and navigates to value-prop learner variant', async () => {
+    render(<TopicScreen />);
+    fireEvent.changeText(screen.getByTestId('preview-topic-input'), 'algebra basics');
+    fireEvent.press(screen.getByTestId('preview-topic-continue'));
+
+    await waitFor(() => {
+      expect(state.setPreviewState).toHaveBeenCalledWith(
+        expect.objectContaining({ topicText: 'algebra basics', intent: 'self' }),
+      );
+    });
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/preview/value-prop',
+      params: { variant: 'learner' },
+    });
+  });
+
+  it('disables continue when topic is empty', () => {
+    render(<TopicScreen />);
+    const cta = screen.getByTestId('preview-topic-continue');
+    expect(cta.props.accessibilityState?.disabled).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Implement `topic.tsx`.**
+
+```tsx
+import { useEffect, useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useThemeColors } from '../../lib/theme';
+import {
+  getPreviewState,
+  setPreviewState,
+  type PreviewOnboardingStateV0,
+} from '../../lib/preview-onboarding-state';
+
+// [MEDIUM-5] Single-line topic cap. The value is persisted to SecureStore for
+// up to 1h pre-signup, so it WILL outlive the screen. Keeping the field short
+// discourages users from pasting longer free text that may contain PII (child
+// names, school names, learning disability descriptions), and the parent-vs-
+// learner branch never needs more than a couple of words to tailor copy.
+// Spec §Preview State (Minimal) accepts the truncated cap.
+const MAX_TOPIC_LEN = 80;
+
+export default function PreviewTopicScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+  const [current, setCurrent] = useState<PreviewOnboardingStateV0 | null>(null);
+  const [topic, setTopic] = useState('');
+
+  useEffect(() => {
+    void getPreviewState().then((s) => {
+      if (s) {
+        setCurrent(s);
+        if (s.topicText) setTopic(s.topicText);
+      }
+    });
+  }, []);
+
+  const trimmed = topic.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_TOPIC_LEN;
+
+  const onContinue = async () => {
+    if (!canSubmit || !current) return;
+    await setPreviewState({ ...current, topicText: trimmed });
+    router.push({ pathname: '/preview/value-prop', params: { variant: 'learner' } });
+  };
+
+  return (
+    <View
+      className="flex-1 bg-background px-6"
+      style={{ paddingTop: insets.top + 32, paddingBottom: insets.bottom + 16 }}
+      testID="preview-topic"
+    >
+      <Text className="text-h1 font-bold text-text-primary mb-2 text-center">
+        What should we help with?
+      </Text>
+      <Text className="text-body text-text-secondary mb-6 text-center">
+        A topic, a question, anything you&apos;re working on.
+      </Text>
+      <TextInput
+        value={topic}
+        onChangeText={setTopic}
+        maxLength={MAX_TOPIC_LEN}
+        placeholder="e.g. quadratic equations"
+        placeholderTextColor={colors.muted}
+        className="bg-surface text-text-primary text-body rounded-input px-4 py-3 mb-6"
+        autoFocus
+        testID="preview-topic-input"
+        accessibilityLabel="Topic"
+      />
+      <Pressable
+        onPress={() => void onContinue()}
+        disabled={!canSubmit}
+        className={`rounded-button py-3.5 items-center ${canSubmit ? 'bg-primary' : 'bg-primary/40'}`}
+        testID="preview-topic-continue"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !canSubmit }}
+        accessibilityLabel="Continue"
+      >
+        <Text className="text-body font-semibold text-text-inverse">Continue</Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 9: Value-Prop Screen (Learner + Parent Variants)
+
+**Files:**
+- Create: `apps/mobile/src/app/preview/value-prop.tsx`
+- Create: `apps/mobile/src/app/preview/value-prop.test.tsx`
+
+> Hard Rules 1, 2, 3, 6: no LLM call, no "I will remember this" / "Saving your progress" copy, no "profile" word, sample data marked as sample.
+
+- [ ] **Step 1: Write failing tests.**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import ValuePropScreen from './value-prop';
+import * as state from '../../lib/preview-onboarding-state';
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+describe('Preview ValuePropScreen', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    push.mockReset();
+    jest.spyOn(state, 'getPreviewState').mockResolvedValue({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 'algebra',
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+  it('learner variant renders sample dialogue marked as sample', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'learner' });
+    render(<ValuePropScreen />);
+    expect(screen.getByTestId('preview-value-prop-learner')).toBeTruthy();
+    expect(screen.getByTestId('preview-sample-marker')).toBeTruthy();
+  });
+
+  it('parent variant renders sample weekly insight marked as sample', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'parent' });
+    render(<ValuePropScreen />);
+    expect(screen.getByTestId('preview-value-prop-parent')).toBeTruthy();
+    expect(screen.getByTestId('preview-sample-marker')).toBeTruthy();
+  });
+
+  it('does not render a chat shell or any LLM-driven element', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'learner' });
+    render(<ValuePropScreen />);
+    expect(screen.queryByTestId('chat-shell')).toBeNull();
+    expect(screen.queryByTestId('message-input')).toBeNull();
+  });
+
+  it('CTA routes to sign-up', () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ variant: 'learner' });
+    render(<ValuePropScreen />);
+    fireEvent.press(screen.getByTestId('preview-signup-cta'));
+    expect(push).toHaveBeenCalledWith('/sign-up');
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Implement `value-prop.tsx`.**
+
+```tsx
+import { useEffect, useState } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  getPreviewState,
+  type PreviewOnboardingStateV0,
+} from '../../lib/preview-onboarding-state';
+
+type Variant = 'learner' | 'parent';
+
+export default function ValuePropScreen() {
+  const params = useLocalSearchParams<{ variant?: Variant }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  // [LOW-2] Named `previewState` (not `state`) to avoid shadowing the
+  // `import * as state from '../../lib/preview-onboarding-state'` pattern
+  // used in tests, and to match save.tsx conventions.
+  const [previewState, setPreviewStateLocal] = useState<PreviewOnboardingStateV0 | null>(null);
+
+  useEffect(() => {
+    void getPreviewState().then(setPreviewStateLocal);
+  }, []);
+
+  const variant: Variant = params.variant === 'parent' ? 'parent' : 'learner';
+  const topic = previewState?.topicText ?? '';
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{
+        paddingTop: insets.top + 24,
+        paddingBottom: insets.bottom + 24,
+        paddingHorizontal: 24,
+      }}
+      testID={variant === 'learner' ? 'preview-value-prop-learner' : 'preview-value-prop-parent'}
+    >
+      {variant === 'learner' ? (
+        <LearnerVariant topic={topic} />
+      ) : (
+        <ParentVariant />
+      )}
+      <Pressable
+        onPress={() => router.push('/sign-up')}
+        className="bg-primary rounded-button py-3.5 px-8 items-center w-full mt-8"
+        testID="preview-signup-cta"
+        accessibilityRole="button"
+      >
+        <Text className="text-body font-semibold text-text-inverse">
+          {variant === 'learner'
+            ? topic
+              ? `Sign up to start your first lesson on ${topic}`
+              : 'Sign up to start your first lesson'
+            : 'Sign up to set up your child'}
+        </Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function SampleMarker() {
+  return (
+    <View
+      className="self-start bg-surface rounded-full px-3 py-1 mb-4"
+      testID="preview-sample-marker"
+    >
+      <Text className="text-caption text-text-muted uppercase tracking-wider">
+        Sample
+      </Text>
+    </View>
+  );
+}
+
+function LearnerVariant({ topic }: { topic: string }) {
+  return (
+    <View>
+      <Text className="text-h1 font-bold text-text-primary mb-3">
+        Here&apos;s how MentoMate teaches
+      </Text>
+      <Text className="text-body text-text-secondary mb-6">
+        A back-and-forth conversation that follows what you actually need —
+        not a fixed lesson plan.
+      </Text>
+      <SampleMarker />
+      <View className="bg-surface rounded-card p-4 mb-3 self-start max-w-[85%]">
+        <Text className="text-body-sm text-text-primary">
+          {topic
+            ? `Let's work on ${topic}. What part is tripping you up?`
+            : "What are you working on today?"}
+        </Text>
+      </View>
+      <View className="bg-primary/10 rounded-card p-4 mb-3 self-end max-w-[85%]">
+        <Text className="text-body-sm text-text-primary">
+          I get the formula but I don&apos;t know when to use it.
+        </Text>
+      </View>
+      <View className="bg-surface rounded-card p-4 self-start max-w-[85%]">
+        <Text className="text-body-sm text-text-primary">
+          Good — that&apos;s the most useful question. Let me show you with a
+          concrete example…
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function ParentVariant() {
+  return (
+    <View>
+      <Text className="text-h1 font-bold text-text-primary mb-3">
+        Here&apos;s how MentoMate helps families
+      </Text>
+      <Text className="text-body text-text-secondary mb-6">
+        You set up your child, they learn, and you get a short weekly read on
+        what they&apos;re working on. No surveillance, just signal.
+      </Text>
+      <SampleMarker />
+      <View className="bg-surface rounded-card p-5 mb-3">
+        <Text className="text-body font-semibold text-text-primary mb-2">
+          Weekly highlight
+        </Text>
+        <Text className="text-body-sm text-text-secondary mb-3">
+          Practiced quadratic equations for 45 minutes across three sessions.
+          Getting comfortable with factoring; working on completing the square.
+        </Text>
+        <Text className="text-caption text-text-muted">
+          Sample data — your child&apos;s real insights appear after their first
+          session.
+        </Text>
+      </View>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 10: ~~Sign-Up Integration — Remember Pending Redirect~~ — SKIPPED [HIGH-C2]
+
+> [CRITICAL-A2 / HIGH-C2] **This task is no longer needed.** With the inline-wizard architecture (Task 11 / Task 12 below), the `(app)/_layout.tsx` gate detects preview state on mount and renders the wizard directly. There is no destination route to push to from sign-up.tsx, so no pending-auth-redirect plumbing is required.
+>
+> What this means concretely:
+> - `apps/mobile/src/lib/sign-up-preview-redirect.ts` is NOT created.
+> - `apps/mobile/src/app/(auth)/sign-up.tsx` is NOT modified.
+> - No tests are added for "sign-up records preview-wizard redirect" — the integration is implicit (sign-up completes → setActive fires → root layout admits user into `(app)/` → AppLayout mounts → preview probe sees state → SaveWizardGate renders).
+>
+> Round-1 framed pending-auth-redirect as load-bearing on web; verify in dev that the web path also renders the wizard without flashing CreateProfileGate. If a web-only flash IS observed (a few hundred ms between `setActive` resolving and `getPreviewState()` resolving), the layout's `previewProbeState === 'loading'` branch (Task 11) already covers it by rendering a spinner instead of falling through to CreateProfileGate.
+
+The remainder of this section is intentionally left as historical context; all checkboxes below should be considered no-ops.
+
+### Historical (do not implement)
+
+- [ ] **Step 1: Write failing test.**
+
+```tsx
+import { rememberPendingAuthRedirect, clearPendingAuthRedirect, peekPendingAuthRedirect } from '../../lib/pending-auth-redirect';
+import { setPreviewState, clearPreviewState } from '../../lib/preview-onboarding-state';
+
+describe('sign-up preview redirect integration', () => {
+  beforeEach(() => {
+    clearPendingAuthRedirect();
+    void clearPreviewState();
+  });
+
+  it('records save-wizard redirect when preview state is set', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    // Simulate the integration point: in sign-up, before calling setActive,
+    // we check preview state and remember the redirect. Test that the
+    // helper is wired by running the real branch.
+    // (Component-level integration test: render SignUpScreen and drive
+    //  through email verify. Pattern depends on existing sign-up test setup;
+    //  if no existing test exists, this can be a lightweight unit test of
+    //  the small helper function extracted in step 3.)
+
+    // Recommended: extract the conditional into a small helper for testability.
+    const { rememberPreviewRedirectIfNeeded } = await import('../../lib/sign-up-preview-redirect');
+    await rememberPreviewRedirectIfNeeded();
+
+    expect(peekPendingAuthRedirect()).toBe('/(app)/preview/save');
+  });
+
+  it('is a no-op when preview state is absent', async () => {
+    const { rememberPreviewRedirectIfNeeded } = await import('../../lib/sign-up-preview-redirect');
+    await rememberPreviewRedirectIfNeeded();
+    expect(peekPendingAuthRedirect()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Create helper in `lib/` (NOT under `app/(auth)/`).** [MEDIUM-2]
+
+Create `apps/mobile/src/lib/sign-up-preview-redirect.ts`:
+
+```ts
+import { FEATURE_FLAGS } from './feature-flags';
+import { rememberPendingAuthRedirect } from './pending-auth-redirect';
+import { getPreviewState } from './preview-onboarding-state';
+
+const SAVE_WIZARD_PATH = '/(app)/preview/save';
+
+export async function rememberPreviewRedirectIfNeeded(): Promise<void> {
+  if (!FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED) return;
+  const state = await getPreviewState();
+  if (!state) return;
+  rememberPendingAuthRedirect(SAVE_WIZARD_PATH);
+}
+```
+
+> Helper is in `lib/`, NOT under `app/(auth)/`. Expo Router treats unknown `.ts` files inside routed groups as routes (memory: `project_expo_router_pollution.md`).
+
+- [ ] **Step 4: Wire the single chokepoint in `sign-up.tsx`.** [HIGH-2]
+
+Add import:
+```ts
+import { rememberPreviewRedirectIfNeeded } from '../../lib/sign-up-preview-redirect';
+```
+
+Inside `activateCreatedSession`, immediately before `await setActive({ session: sessionId });`:
+
+```ts
+await rememberPreviewRedirectIfNeeded();
+await setActive({ session: sessionId });
+```
+
+That is the ONLY edit to `sign-up.tsx`. Do not add a call after `prepareEmailAddressVerification`. Both the email-code verification and OAuth paths flow through `activateCreatedSession`.
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 11: AppLayout — Probe + Inline SaveWizardGate Branch [CRITICAL-A2 / CRITICAL-B2]
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx`
+- Modify: `apps/mobile/src/app/(app)/_layout.test.tsx`
+
+> Critical: async resolution. The gate must hold a loading state until preview-state resolution settles. Without this, `CreateProfileGate` mount effects could fire a transient POST and cause a visible flash. Spec §Implementation step 5.
+
+> [CRITICAL-A2] **Architecture:** the wizard is rendered INLINE as a gate component (mirrors `CreateProfileGate` at `_layout.tsx:640`). The gate ordering is:
+>
+> 1. `previewProbeState === 'loading'` → spinner
+> 2. `previewProbeState === 'present' && !wizardDone` → `<SaveWizardGate onComplete={() => setWizardDone(true)} />` (defined in Task 12)
+> 3. `!activeProfile` → `<CreateProfileGate />` (existing)
+> 4. consent gates / Tabs (existing)
+>
+> The wizard branch sits ABOVE `!activeProfile` so the wizard stays mounted across the profile-creation transition (ProfileProvider auto-activates the first profile via `profile.ts:154-174` — without the ordering above, the wizard would unmount mid-flow before Step 3).
+>
+> [CRITICAL-B2] **The auto-cleanup effect (`activeProfile && profiles.length > 0 → clearPreviewState()`) is NOT added.** It would race the wizard's owner POST → child POST sequence and wipe `createdOwnerProfileId` from SecureStore between the two calls, breaking the [HIGH-4] resume guard. Cleanup is owned by (a) TTL inside `getPreviewState`, (b) sign-out-cleanup (Task 4), (c) the wizard's explicit `clearPreviewState()` call on Step-3 success (Task 14).
+
+- [ ] **Step 1: Write failing tests.**
+
+Find the existing `_layout.test.tsx` (or create alongside `_layout.tsx`). Add:
+
+```tsx
+import { setPreviewState, clearPreviewState } from '../../lib/preview-onboarding-state';
+import { FEATURE_FLAGS } from '../../lib/feature-flags';
+
+describe('AppLayout no-profile gate — preview branch', () => {
+  beforeEach(async () => {
+    await clearPreviewState();
+  });
+
+  it('renders the SaveWizardGate when preview state exists and flag is on', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+
+    // Render AppLayout under mocked auth (isSignedIn=true) and ProfileProvider
+    // with profiles=[], activeProfile=null. Pattern: copy the harness used by
+    // the existing _layout test for CreateProfileGate flashes.
+    const { findByTestId, queryByTestId } = renderAppLayoutWithNoProfile();
+
+    // The async probe should resolve before either gate or wizard renders.
+    // [CRITICAL-A2] The wizard is INLINE — no route navigation; assert the
+    // SaveWizardGate testID is present in the same render tree.
+    expect(await findByTestId('save-wizard-gate')).toBeTruthy();
+    expect(queryByTestId('create-profile-gate')).toBeNull();
+  });
+
+  // [MEDIUM-D2] Use jest.doMock + jest.isolateModules, NOT
+  // `(FEATURE_FLAGS as any).X = false` (which leaks across parallel workers).
+  // Mirrors the canonical pattern picked up by Task 5's spike step.
+  it('falls through to CreateProfileGate when flag is off, even with stale preview state', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('../../lib/feature-flags', () => ({
+        FEATURE_FLAGS: {
+          COACH_BAND_ENABLED: true,
+          MIC_IN_PILL_ENABLED: true,
+          I18N_ENABLED: true,
+          PREVIEW_ONBOARDING_ENABLED: false,
+        },
+      }));
+      const { renderAppLayoutWithNoProfile } = await import('./__test-harness');
+      const { findByTestId, queryByTestId } = renderAppLayoutWithNoProfile();
+      expect(await findByTestId('create-profile-gate')).toBeTruthy();
+      expect(queryByTestId('save-wizard-gate')).toBeNull();
+    });
+  });
+
+  it('renders loading state during preview-state async probe', () => {
+    // Spy getPreviewState to return a pending promise. Assert loading testID
+    // is rendered; assert neither gate nor wizard is in the tree.
+    let resolve!: (v: null) => void;
+    jest.spyOn(require('../../lib/preview-onboarding-state'), 'getPreviewState').mockReturnValue(
+      new Promise<null>((r) => { resolve = r; }),
+    );
+
+    const { getByTestId, queryByTestId } = renderAppLayoutWithNoProfile();
+    expect(getByTestId('preview-state-loading')).toBeTruthy();
+    expect(queryByTestId('create-profile-gate')).toBeNull();
+    expect(queryByTestId('save-wizard-gate')).toBeNull();
+
+    resolve(null);
+  });
+
+  // [CRITICAL-A2 / HIGH-A2] Wizard outlives the auto-activation transition.
+  // First-profile POST flips profiles to non-empty; ProfileProvider auto-sets
+  // activeProfile (profile.ts:154-174). The wizard branch must remain above
+  // !activeProfile in the gate ordering so the wizard stays mounted.
+  it('keeps SaveWizardGate mounted after ProfileProvider auto-activates the first profile', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    const { findByTestId, simulateProfileCreated } = renderAppLayoutWithNoProfile();
+    await findByTestId('save-wizard-gate');
+    // Drive the harness to inject a created profile and let the provider
+    // auto-activate it (mirrors what happens at runtime after the owner POST
+    // resolves and the cache is updated).
+    simulateProfileCreated({ id: 'p1', isOwner: true });
+    // Wizard MUST still be mounted; we have NOT signalled wizardDone yet.
+    expect(await findByTestId('save-wizard-gate')).toBeTruthy();
+  });
+
+  // [CRITICAL-B2] Verify the layout does NOT install the auto-cleanup effect.
+  it('does NOT clear preview state automatically when activeProfile becomes truthy', async () => {
+    await setPreviewState({
+      intent: 'self', path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    renderAppLayoutWithActiveProfile();
+    await Promise.resolve();
+    const { getPreviewState } = await import('../../lib/preview-onboarding-state');
+    // Round-1 plan would have expected null here. Round-2: the layout must
+    // leave the key intact; cleanup is the wizard's job (or TTL/sign-out).
+    expect(await getPreviewState()).not.toBeNull();
+  });
+});
+```
+
+> `renderAppLayoutWithNoProfile` / `renderAppLayoutWithActiveProfile` — adapt from existing test harnesses in the file. If none exist, this is the right time to extract a small helper since multiple tests need it.
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Edit `(app)/_layout.tsx`.**
+
+Add imports:
+
+```ts
+import { FEATURE_FLAGS } from '../../lib/feature-flags';
+import { getPreviewState } from '../../lib/preview-onboarding-state';
+// Note: clearPreviewState is NOT imported here. [CRITICAL-B2] cleanup is
+// owned by the wizard's Step-3 success path (Task 14) and by sign-out.
+```
+
+Inside the default `AppLayout` component, after the existing profile-loading state and immediately BEFORE the `if (!activeProfile)` branch (landmark — search for that exact conditional; line numbers drift) [MEDIUM-3], introduce the preview-state probe AND a wizard-done sentinel:
+
+```tsx
+const [previewProbeState, setPreviewProbeState] = React.useState<
+  'loading' | 'present' | 'absent'
+>('loading');
+// [HIGH-A2] Wizard signals completion via onComplete → setWizardDone(true).
+// Required because previewProbeState alone never flips back to 'absent'
+// (we don't re-probe after mount, and clearPreviewState() inside the wizard
+// only affects future mounts).
+const [wizardDone, setWizardDone] = React.useState(false);
+
+React.useEffect(() => {
+  if (!FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED) {
+    setPreviewProbeState('absent');
+    return;
+  }
+  let cancelled = false;
+  void getPreviewState().then((s) => {
+    if (cancelled) return;
+    setPreviewProbeState(s ? 'present' : 'absent');
+  });
+  return () => {
+    cancelled = true;
+  };
+}, []);
+
+// [CRITICAL-B2] DELIBERATELY no auto-cleanup effect here. Round-1 had
+//   useEffect(() => { if (activeProfile && profiles.length > 0) clearPreviewState() })
+// — that would race the wizard's owner-POST → child-POST sequence and wipe
+// `createdOwnerProfileId` between the calls, destroying the [HIGH-4] resume
+// guard. Cleanup is owned by:
+//   (a) TTL inside getPreviewState (1h)
+//   (b) sign-out-cleanup (Task 4)
+//   (c) wizard's explicit clearPreviewState() on Step-3 success (Task 14)
+```
+
+Then INSERT the wizard branch ABOVE the `!activeProfile` branch (NOT inside it):
+
+```tsx
+// [CRITICAL-A2] Wizard gate sits ABOVE !activeProfile so it stays mounted
+// when ProfileProvider auto-activates the first profile mid-wizard
+// (profile.ts:154-174). Without this ordering, the wizard would unmount
+// after Step 2's POST succeeds.
+if (
+  FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED &&
+  previewProbeState === 'loading'
+) {
+  return (
+    <View
+      className="flex-1 bg-background items-center justify-center"
+      testID="preview-state-loading"
+    >
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
+if (
+  FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED &&
+  previewProbeState === 'present' &&
+  !wizardDone
+) {
+  return (
+    <FeedbackProvider>
+      <SaveWizardGate onComplete={() => setWizardDone(true)} />
+    </FeedbackProvider>
+  );
+}
+
+// Existing branch — unchanged shape.
+if (!activeProfile) {
+  return (
+    <FeedbackProvider>
+      <CreateProfileGate />
+    </FeedbackProvider>
+  );
+}
+```
+
+`SaveWizardGate` is defined in this same file (see Task 12), alongside `CreateProfileGate` at line 640.
+
+- [ ] **Tab-bar handling.** [CRITICAL-A2]
+
+NO addition to `FULL_SCREEN_ROUTES`. The Round-1 plan added `'preview'` because the wizard was a nested route; the inline-gate architecture replaces the entire layout body during the wizard's life (the gate `return`s before the `<Tabs>` JSX is reached), so there's no tab bar to hide. Leave `FULL_SCREEN_ROUTES` untouched.
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 12: SaveWizardGate Component — Skeleton + Step 1 (Where to Save) [CRITICAL-A2]
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/_layout.tsx` — add inline `SaveWizardGate` component (NOT a route file).
+- Modify: `apps/mobile/src/app/(app)/_layout.test.tsx` — co-located wizard tests.
+
+> [CRITICAL-A2] **No `(app)/preview/save.tsx`, no `(app)/preview/_layout.tsx`, no `(app)/preview/save.test.tsx`.** The Round-1 route-based plan does not work — see the architecture section at the top. `SaveWizardGate` is defined in the same file as `CreateProfileGate` (line 640), takes an `onComplete` callback, and is rendered by the gate-ordering block introduced in Task 11.
+
+- [ ] **Step 1: ~~`_layout.tsx` for `(app)/preview/`~~ — SKIPPED.** No route file is created.
+
+- [ ] **Step 2: Write failing test for Step 1 (where-to-save selection).**
+
+> Use the `(app)/_layout.test.tsx` harness from Task 11. The wizard is mounted by the layout's gate ordering (preview state present + wizardDone false), so tests render the layout, not a standalone `<SaveWizard />`. Imports adjust accordingly: `import { setPreviewState, clearPreviewState } from '../../lib/preview-onboarding-state';` (NOT `'../../../lib/...'`).
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { setPreviewState, clearPreviewState } from '../../../lib/preview-onboarding-state';
+import SaveWizard from './save';
+
+describe('SaveWizard — Step 1', () => {
+  beforeEach(async () => {
+    await clearPreviewState();
+  });
+
+  // [CRITICAL-3] No dead-end on empty state.
+  it('redirects to /(app)/home when no preview state exists', async () => {
+    const replace = jest.fn();
+    (require('expo-router').useRouter as jest.Mock).mockReturnValue({ replace, push: jest.fn() });
+    render(<SaveWizard />);
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/(app)/home');
+    });
+    expect(screen.queryByTestId('save-wizard-step-1')).toBeNull();
+  });
+
+  it('preselects "My learning" when intent was self', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      topicText: 't',
+      createdAt: new Date().toISOString(),
+    });
+    render(<SaveWizard />);
+    await screen.findByTestId('save-wizard-step-1');
+    expect(screen.getByTestId('save-target-self').props.accessibilityState?.selected).toBe(true);
+  });
+
+  it('preselects "My child" when intent was child', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    render(<SaveWizard />);
+    await screen.findByTestId('save-wizard-step-1');
+    expect(screen.getByTestId('save-target-child').props.accessibilityState?.selected).toBe(true);
+  });
+
+  it('overrides intent when user picks a different target', async () => {
+    await setPreviewState({
+      intent: 'child',
+      path: 'parent_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    render(<SaveWizard />);
+    await screen.findByTestId('save-wizard-step-1');
+    fireEvent.press(screen.getByTestId('save-target-self'));
+    expect(screen.getByTestId('save-target-self').props.accessibilityState?.selected).toBe(true);
+    expect(screen.getByTestId('save-target-child').props.accessibilityState?.selected).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run; confirm fail.**
+
+- [ ] **Step 4: Implement Step 1 inside `(app)/_layout.tsx`.** [CRITICAL-A2]
+
+> Co-locate next to `CreateProfileGate` (line 640). The component is named `SaveWizardGate` to mirror that convention. Imports use the same `../../lib/...` depth as the surrounding layout file, NOT `../../../lib/...`.
+
+```tsx
+// At the top of (app)/_layout.tsx — only the new imports.
+import {
+  getPreviewState,
+  clearPreviewState,
+  type PreviewOnboardingStateV0,
+  type SaveTarget,
+} from '../../lib/preview-onboarding-state';
+
+type Step = 1 | 2 | 3;
+
+interface TargetOption {
+  target: SaveTarget;
+  label: string;
+  testID: string;
+}
+
+const TARGETS: ReadonlyArray<TargetOption> = [
+  { target: 'self', label: 'My learning', testID: 'save-target-self' },
+  { target: 'child', label: "My child's learning", testID: 'save-target-child' },
+  { target: 'both', label: 'Both', testID: 'save-target-both' },
+];
+
+function defaultTargetFor(state: PreviewOnboardingStateV0 | null): SaveTarget | null {
+  if (!state) return null;
+  switch (state.intent) {
+    case 'self':
+      return 'self';
+    case 'child':
+      return 'child';
+    case 'both':
+      return 'both';
+    case 'not_sure':
+      return null; // ask explicitly per spec Routing And Landing Rules
+  }
+}
+
+// [CRITICAL-A2] Co-located component, NOT a default export, NOT a route.
+// Imported by AppLayout's gate ordering (Task 11).
+function SaveWizardGate({ onComplete }: { onComplete: () => void }) {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const [previewState, setPreviewStateLocal] = useState<PreviewOnboardingStateV0 | null>(null);
+  const [probeDone, setProbeDone] = useState(false);
+  const [target, setTarget] = useState<SaveTarget | null>(null);
+  const [step, setStep] = useState<Step>(1);
+
+  useEffect(() => {
+    void getPreviewState().then((s) => {
+      setPreviewStateLocal(s);
+      setTarget(defaultTargetFor(s));
+      setProbeDone(true);
+    });
+  }, []);
+
+  // [CRITICAL-3] Recovery path for "wizard mounted with no state" — happens
+  // when the 1h TTL expires between the layout's initial probe and the
+  // wizard's second probe inside this component, or when SecureStore is
+  // wiped externally (sign-out raced with mount). Without this, the wizard
+  // would render `null` and trap the user.
+  // [HIGH-A2] Signal completion to the layout BEFORE navigating, so the
+  // wizard branch in AppLayout exits cleanly and the next render falls
+  // through to CreateProfileGate / Tabs / consent gates as appropriate.
+  useEffect(() => {
+    if (probeDone && !previewState) {
+      onComplete();
+      router.replace('/(app)/home');
+    }
+  }, [probeDone, previewState, router, onComplete]);
+
+  if (!previewState) {
+    return (
+      <View testID="save-wizard-gate" className="flex-1 bg-background" />
+    );
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{
+        paddingTop: insets.top + 24,
+        paddingBottom: insets.bottom + 24,
+        paddingHorizontal: 24,
+      }}
+      testID="save-wizard-gate"  /* [CRITICAL-A2] outer gate identity */
+    >
+      <View testID={`save-wizard-step-${step}`} />
+      <Text className="text-h1 font-bold text-text-primary mb-2">
+        Great, let&apos;s save this and get you started.
+      </Text>
+
+      {step === 1 && (
+        <View>
+          <Text className="text-body text-text-secondary mb-6">
+            Where should we save this?
+          </Text>
+          {TARGETS.map((opt) => {
+            const selected = target === opt.target;
+            return (
+              <Pressable
+                key={opt.target}
+                onPress={() => setTarget(opt.target)}
+                className={`rounded-card px-4 py-4 mb-3 ${selected ? 'bg-primary/10 border border-primary' : 'bg-surface'}`}
+                testID={opt.testID}
+                accessibilityRole="radio"
+                accessibilityState={{ selected }}
+              >
+                <Text className="text-body font-semibold text-text-primary">
+                  {opt.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+          <Pressable
+            onPress={() => target && setStep(2)}
+            disabled={!target}
+            className={`rounded-button py-3.5 items-center mt-4 ${target ? 'bg-primary' : 'bg-primary/40'}`}
+            testID="save-wizard-step-1-continue"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !target }}
+          >
+            <Text className="text-body font-semibold text-text-inverse">
+              Continue
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {step === 2 && (
+        <ProfileBasicsStep
+          target={target!}
+          previewState={previewState}
+          onComplete={() => setStep(3)}
+        />
+      )}
+
+      {step === 3 && (
+        <ConfirmStep
+          target={target!}
+          previewState={previewState}
+          router={router}
+          onComplete={onComplete}  /* [HIGH-A2] forwarded from layout */
+        />
+      )}
+    </ScrollView>
+  );
+}
+
+function ProfileBasicsStep(_props: {
+  target: SaveTarget;
+  previewState: PreviewOnboardingStateV0;
+  onComplete: (created: { parent: Profile; child?: Profile }) => void;
+}) {
+  // Implemented in Task 13.
+  return <Text>TODO step 2</Text>;
+}
+
+function ConfirmStep(_props: {
+  target: SaveTarget;
+  previewState: PreviewOnboardingStateV0;
+  router: ReturnType<typeof useRouter>;
+  onComplete: () => void;  /* [HIGH-A2] layout-level wizard-done signal */
+}) {
+  // Implemented in Task 14.
+  return <Text>TODO step 3</Text>;
+}
+```
+
+- [ ] **Step 5: Run tests; confirm pass.**
+
+- [ ] **Step 6: Commit via `/commit`.**
+
+---
+
+## Task 13: Save Wizard — Step 2 (Profile Basics)
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/preview/save.tsx`
+- Modify: `apps/mobile/src/app/(app)/preview/save.test.tsx`
+
+> Step 2 collects owner basics, then conditional child basics. v0 inlines a minimal form rather than importing `create-profile.tsx` (a default-export route). If the form duplicates more than ~30 LOC of create-profile field components, extract to a shared component then; not now.
+
+> [CRITICAL-1] **Request body is `{ displayName, birthYear }` only.** `profileCreateSchema` (`packages/schemas/src/profiles.ts:44`) does NOT accept `forChild` and Hono's typed RPC body will reject any extra fields at the TypeScript layer. The server determines owner-vs-child purely from "is this the first profile on the account?" — `createProfileWithLimitCheck` in `apps/api/src/services/profile.ts:253-317`. So for a `target='child'` or `target='both'` flow we POST `/profiles` TWICE in sequence: first call creates the owner, second call (with the child's name + birthYear) is auto-classified as a child because the owner now exists.
+
+> [HIGH-4] **Persist `createdOwnerProfileId` to the preview-state record before issuing the second POST.** Without this, a wizard remount mid-flight (app backgrounded, refresh, OOM-kill) re-runs the form and double-creates: the second mount's "owner" POST becomes a child, the "child" POST becomes a second child — net result, 1 owner + 2 children for one expected flow. Resume logic: if the persisted id is non-null AND maps to an already-fetched profile, skip the owner POST.
+
+- [ ] **Step 1: Write failing tests.**
+
+```tsx
+it('self target: collects display name + birth year and creates owner profile', async () => {
+  await setPreviewState({
+    intent: 'self', path: 'learner_value_prop',
+    topicText: 'algebra', createdAt: new Date().toISOString(),
+  });
+  // Mock API client profiles.$post to resolve with a fake owner profile.
+  const apiSpy = mockProfilesPost({ profile: makeOwnerProfile() });
+
+  render(<SaveWizard />);
+  fireEvent.press(await screen.findByTestId('save-wizard-step-1-continue'));
+
+  fireEvent.changeText(screen.getByTestId('save-basics-display-name'), 'Alex');
+  fireEvent.changeText(screen.getByTestId('save-basics-birth-year'), '1990');
+  fireEvent.press(screen.getByTestId('save-basics-continue'));
+
+  await waitFor(() => {
+    expect(apiSpy).toHaveBeenCalledWith({
+      json: { displayName: 'Alex', birthYear: 1990 },
+    });
+  });
+});
+
+it('child target: creates parent first, then child (sequence assertion)', async () => {
+  await setPreviewState({
+    intent: 'child', path: 'parent_value_prop',
+    createdAt: new Date().toISOString(),
+  });
+  const apiSpy = mockProfilesPostSequence([
+    { profile: makeOwnerProfile({ id: 'parent-1' }) },
+    { profile: makeChildProfile({ id: 'child-1' }) },
+  ]);
+
+  render(<SaveWizard />);
+  fireEvent.press(await screen.findByTestId('save-wizard-step-1-continue'));
+
+  // Parent basics
+  fireEvent.changeText(screen.getByTestId('save-basics-parent-name'), 'Pat');
+  fireEvent.changeText(screen.getByTestId('save-basics-parent-birth-year'), '1985');
+  // Child basics on same step (per spec)
+  fireEvent.changeText(screen.getByTestId('save-basics-child-name'), 'Sam');
+  fireEvent.changeText(screen.getByTestId('save-basics-child-birth-year'), '2014');
+  fireEvent.press(screen.getByTestId('save-basics-continue'));
+
+  // [CRITICAL-1] Assert call ORDER and bodies. Server derives owner-vs-child
+  // from call position; the body must NOT include forChild (schema rejects it).
+  await waitFor(() => {
+    expect(apiSpy.mock.calls[0]?.[0].json).toEqual({ displayName: 'Pat', birthYear: 1985 });
+    expect(apiSpy.mock.calls[1]?.[0].json).toEqual({ displayName: 'Sam', birthYear: 2014 });
+    expect(apiSpy.mock.calls.length).toBe(2);
+  });
+});
+
+it('child failure after parent success keeps parent and shows retry', async () => {
+  await setPreviewState({
+    intent: 'child', path: 'parent_value_prop',
+    createdAt: new Date().toISOString(),
+  });
+  mockProfilesPostSequence([
+    { profile: makeOwnerProfile({ id: 'parent-1' }) },
+    new Error('NetworkError'),
+  ]);
+  render(<SaveWizard />);
+  // Drive through step 1 + step 2; assert:
+  // - error toast / inline error visible (testID="save-basics-child-error")
+  // - retry button visible (testID="save-basics-retry-child")
+  // - parent profile creation NOT rolled back (no DELETE call).
+  // ...
+});
+```
+
+> Adapt the `mockProfilesPost` / sequence helpers to whatever pattern the codebase already uses for `client.profiles.$post`. Check existing tests for `apps/mobile/src/app/create-profile.test.tsx` if present, or `apps/mobile/src/lib/api-client.test.ts` for the canonical mock pattern.
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Replace `ProfileBasicsStep` in `save.tsx`.**
+
+```tsx
+import { useState, useCallback } from 'react';
+import { TextInput, ActivityIndicator } from 'react-native';
+import { useApiClient } from '../../../lib/api-client';
+import { useQueryClient } from '@tanstack/react-query';
+import { assertOk } from '../../../lib/assert-ok';
+import { formatApiError } from '../../../lib/format-api-error';
+import { setPreviewState } from '../../../lib/preview-onboarding-state';
+import type { Profile } from '@eduagent/schemas';
+
+function ProfileBasicsStep({
+  target,
+  previewState,
+  onComplete,
+}: {
+  target: SaveTarget;
+  previewState: PreviewOnboardingStateV0;
+  onComplete: (created: { parent: Profile; child?: Profile }) => void;
+}) {
+  const client = useApiClient();
+  const queryClient = useQueryClient();
+
+  const [parentName, setParentName] = useState('');
+  const [parentBirthYear, setParentBirthYear] = useState('');
+  const [childName, setChildName] = useState('');
+  const [childBirthYear, setChildBirthYear] = useState('');
+
+  const [createdParent, setCreatedParent] = useState<Profile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [childError, setChildError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const needsChild = target === 'child' || target === 'both';
+  const needsOwner = target === 'self' || target === 'child' || target === 'both';
+
+  const ownerName = target === 'self' ? parentName : parentName; // both branches share the owner-basics
+  const ownerYear = target === 'self' ? parentBirthYear : parentBirthYear;
+
+  const isValidYear = (s: string) => /^\d{4}$/.test(s) && Number(s) > 1900 && Number(s) <= new Date().getFullYear();
+
+  const canSubmit =
+    !loading &&
+    (needsOwner ? ownerName.trim().length > 0 && isValidYear(ownerYear) : true) &&
+    (needsChild ? childName.trim().length > 0 && isValidYear(childBirthYear) : true);
+
+  const submit = useCallback(async () => {
+    setError(null);
+    setChildError(null);
+    setLoading(true);
+    try {
+      let parent = createdParent;
+
+      // [HIGH-4] Resume guard: if the preview state already records a created
+      // owner profile id (set on a prior submit that crashed mid-flight), and
+      // that profile exists in the current cache, skip the owner POST and
+      // continue with that profile as the parent. Prevents duplicate creation.
+      if (!parent && needsOwner && previewState.createdOwnerProfileId) {
+        const cached = queryClient.getQueriesData<Profile[]>({
+          predicate: (q) => String(q.queryKey[0]) === 'profiles',
+        });
+        for (const [, list] of cached) {
+          const match = list?.find((p) => p.id === previewState.createdOwnerProfileId);
+          if (match) {
+            parent = match;
+            setCreatedParent(match);
+            break;
+          }
+        }
+      }
+
+      if (!parent && needsOwner) {
+        const res = await client.profiles.$post({
+          json: { displayName: ownerName.trim(), birthYear: Number(ownerYear) },
+        });
+        await assertOk(res);
+        const data = (await res.json()) as { profile: Profile };
+        parent = data.profile;
+        setCreatedParent(parent);
+
+        // [HIGH-4] Persist the new owner id BEFORE issuing the second POST.
+        // If we crash between this line and the child POST succeeding, the
+        // resume guard above will pick up the parent and not double-create.
+        await setPreviewState({ ...previewState, createdOwnerProfileId: parent.id });
+
+        queryClient.setQueriesData<Profile[]>(
+          { predicate: (q) => String(q.queryKey[0]) === 'profiles' },
+          (old) => (old ? [...old, parent!] : [parent!]),
+        );
+      }
+
+      let child: Profile | undefined;
+      if (needsChild) {
+        try {
+          // [CRITICAL-1] No `forChild` field. profileCreateSchema rejects it;
+          // server auto-classifies non-first POST as child via
+          // createProfileWithLimitCheck (apps/api/src/services/profile.ts:253).
+          const res = await client.profiles.$post({
+            json: {
+              displayName: childName.trim(),
+              birthYear: Number(childBirthYear),
+            },
+          });
+          await assertOk(res);
+          const data = (await res.json()) as { profile: Profile };
+          child = data.profile;
+
+          queryClient.setQueriesData<Profile[]>(
+            { predicate: (q) => String(q.queryKey[0]) === 'profiles' },
+            (old) => (old ? [...old, child!] : [child!]),
+          );
+        } catch (childErr) {
+          // [AC 9] Keep parent. Surface retryable child error inline.
+          setChildError(formatApiError(childErr));
+          setLoading(false);
+          return;
+        }
+      }
+
+      // Predicate-invalidate (spec: ['profiles'] is userId-scoped).
+      await queryClient.invalidateQueries({
+        predicate: (q) => String(q.queryKey[0]) === 'profiles',
+      });
+
+      if (parent) {
+        onComplete({ parent, child });
+      }
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    client, queryClient, createdParent, needsOwner, needsChild,
+    ownerName, ownerYear, childName, childBirthYear, onComplete,
+  ]);
+
+  return (
+    <View>
+      {needsOwner && (
+        <View className="mb-6">
+          <Text className="text-h3 font-semibold text-text-primary mb-3">
+            {target === 'self' ? 'Tell us about you' : 'About you (the parent)'}
+          </Text>
+          <TextInput
+            placeholder="Your name"
+            value={parentName}
+            onChangeText={setParentName}
+            className="bg-surface text-text-primary rounded-input px-4 py-3 mb-3"
+            testID={target === 'self' ? 'save-basics-display-name' : 'save-basics-parent-name'}
+          />
+          <TextInput
+            placeholder="Birth year (e.g. 1985)"
+            value={parentBirthYear}
+            onChangeText={setParentBirthYear}
+            keyboardType="number-pad"
+            maxLength={4}
+            className="bg-surface text-text-primary rounded-input px-4 py-3"
+            testID={target === 'self' ? 'save-basics-birth-year' : 'save-basics-parent-birth-year'}
+          />
+        </View>
+      )}
+
+      {needsChild && (
+        <View className="mb-6">
+          <Text className="text-h3 font-semibold text-text-primary mb-3">
+            About your child
+          </Text>
+          <TextInput
+            placeholder="Their name or nickname"
+            value={childName}
+            onChangeText={setChildName}
+            className="bg-surface text-text-primary rounded-input px-4 py-3 mb-3"
+            testID="save-basics-child-name"
+          />
+          <TextInput
+            placeholder="Birth year"
+            value={childBirthYear}
+            onChangeText={setChildBirthYear}
+            keyboardType="number-pad"
+            maxLength={4}
+            className="bg-surface text-text-primary rounded-input px-4 py-3"
+            testID="save-basics-child-birth-year"
+          />
+        </View>
+      )}
+
+      {error && (
+        <View className="bg-danger/10 rounded-card px-4 py-3 mb-3" testID="save-basics-error">
+          <Text className="text-danger text-body-sm">{error}</Text>
+        </View>
+      )}
+      {childError && (
+        <View className="bg-danger/10 rounded-card px-4 py-3 mb-3" testID="save-basics-child-error">
+          <Text className="text-danger text-body-sm mb-2">
+            We saved your account, but couldn&apos;t add your child yet: {childError}
+          </Text>
+          <Pressable
+            onPress={() => void submit()}
+            testID="save-basics-retry-child"
+            accessibilityRole="button"
+          >
+            <Text className="text-primary font-semibold">Retry</Text>
+          </Pressable>
+        </View>
+      )}
+
+      <Pressable
+        onPress={() => void submit()}
+        disabled={!canSubmit}
+        className={`rounded-button py-3.5 items-center ${canSubmit ? 'bg-primary' : 'bg-primary/40'}`}
+        testID="save-basics-continue"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !canSubmit }}
+      >
+        {loading ? <ActivityIndicator color="white" /> : (
+          <Text className="text-body font-semibold text-text-inverse">Continue</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+```
+
+> [CRITICAL-1] Schema is verified: `POST /profiles` accepts `{ displayName, birthYear, avatarUrl?, location?, conversationLanguage?, pronouns? }` only (`packages/schemas/src/profiles.ts:44`). Server determines owner-vs-child via `createProfileWithLimitCheck`'s `isFirstProfile` check (`apps/api/src/services/profile.ts:253-317`). Do NOT add a `forChild`/`addingChild` field; do NOT invent route params.
+
+- [ ] **Step 4: Update `SaveWizardScreen` to pass `onComplete` typed correctly + advance to Step 3.**
+
+```tsx
+{step === 2 && target && (
+  <ProfileBasicsStep
+    target={target}
+    previewState={previewState}
+    onComplete={(created) => {
+      setCreated(created);
+      setStep(3);
+    }}
+  />
+)}
+```
+
+Add `const [created, setCreated] = useState<{ parent: Profile; child?: Profile } | null>(null);` to parent state.
+
+- [ ] **Step 5: Run tests; confirm pass.**
+
+- [ ] **Step 6: Commit via `/commit`.**
+
+---
+
+## Failure Modes Addendum (referenced from spec)
+
+| State | Trigger | User sees | Recovery |
+|---|---|---|---|
+| Wizard mounted with empty preview state | TTL expired between auth and gate render; cleanup race; manual deep-link | Brief blank frame (~1 RAF) | `useEffect` redirects `router.replace('/(app)/home')`. [CRITICAL-3] |
+| Wizard remount after owner POST succeeded, child POST never fired | App OOM-killed, force-close, or refresh after parent created | Form re-prefills with cached entries | Resume guard reads `previewState.createdOwnerProfileId`, finds match in `['profiles']` cache, skips owner POST and proceeds to child POST. [HIGH-4] |
+| Child POST fails after owner POST succeeded | Network error mid-flight | Inline error banner + Retry button | Retry hits the same `submit()` — resume guard skips re-creating the owner; child POST retried. [HIGH-4] |
+| `setActive` succeeds but gate has stale preview state, user already has a profile | Sign-out → sign-in cycle with the same browser/session | Tabs render normally | `(app)/_layout.tsx` cleanup effect clears the SecureStore key when `activeProfile && profiles.length > 0`. Wizard is not reached. |
+| `pending-auth-redirect` lost on native cold-start | Process killed during OAuth round-trip | CreateProfileGate flash possible | Gate's async preview-state probe resolves `present` → `<Redirect>` to wizard. The pending-auth-redirect is a web-only optimization; native does not depend on it. [HIGH-1] |
+
+---
+
+## Task 14: Save Wizard — Step 3 (Confirm + Landing + First Session Handoff)
+
+**Files:**
+- Modify: `apps/mobile/src/app/(app)/preview/save.tsx`
+- Modify: `apps/mobile/src/app/(app)/preview/save.test.tsx`
+
+> **Spike outcome (fill in before starting Task 14):** [option (a) — helper at `<path>` / option (b) — defer topic prefill, CTA reads "Go to my learning"]
+
+> Hard Rule: use `router.replace` on landing so the preview stack is cleared (AC 13). Intra-wizard hops earlier are `setStep(...)` state changes, not router pushes.
+
+- [ ] **Step 1: Write failing tests.**
+
+```tsx
+it('self target: replaces history with first session route on success', async () => {
+  // After step 2 completes for self target, step 3 fires:
+  //   - switchProfile(parent.id)
+  //   - clearPreviewState
+  //   - start session with topicText (per spike outcome)
+  //   - router.replace(sessionRoute)
+  // OR (option b): router.replace('/(app)/own-learning' or wherever) + topic dropped.
+
+  const replace = jest.fn();
+  (useRouter as jest.Mock).mockReturnValue({ replace, push: jest.fn() });
+  await setPreviewState({
+    intent: 'self', path: 'learner_value_prop',
+    topicText: 'algebra', createdAt: new Date().toISOString(),
+  });
+  mockProfilesPost({ profile: makeOwnerProfile({ id: 'p1' }) });
+  // ...drive through steps 1 + 2...
+
+  await waitFor(() => {
+    expect(replace).toHaveBeenCalledWith(expect.stringMatching(/^\/\(app\)\//));
+  });
+});
+
+it('parent target: replaces history with parent home', async () => {
+  const replace = jest.fn();
+  (useRouter as jest.Mock).mockReturnValue({ replace, push: jest.fn() });
+  await setPreviewState({
+    intent: 'child', path: 'parent_value_prop',
+    createdAt: new Date().toISOString(),
+  });
+  // ...drive to step 3...
+  await waitFor(() => {
+    expect(replace).toHaveBeenCalledWith('/(app)/home');
+  });
+});
+
+it('clears preview state on save completion', async () => {
+  await setPreviewState({ intent: 'self', path: 'learner_value_prop', createdAt: new Date().toISOString() });
+  // ...drive to landing...
+  await waitFor(async () => {
+    const { getPreviewState } = await import('../../../lib/preview-onboarding-state');
+    expect(await getPreviewState()).toBeNull();
+  });
+});
+
+it('session-start failure falls through to home with error surfaced', async () => {
+  // Only meaningful in option (a). Skip if option (b) was chosen.
+  // ...
+});
+```
+
+- [ ] **Step 2: Run; confirm fail.**
+
+- [ ] **Step 3: Implement `ConfirmStep`.**
+
+Pseudocode for option (a) — adjust to actual helper:
+
+```tsx
+function ConfirmStep({
+  target,
+  previewState,
+  created,
+  router,
+}: {
+  target: SaveTarget;
+  previewState: PreviewOnboardingStateV0;
+  created: { parent: Profile; child?: Profile };
+  router: ReturnType<typeof useRouter>;
+}) {
+  const { switchProfile } = useProfile();
+  const [landing, setLanding] = useState(false);
+  const [landingError, setLandingError] = useState<string | null>(null);
+
+  const cta = target === 'self' || (target === 'both' && previewState.bothPriority === 'self_first')
+    ? 'Start lesson'
+    : 'Open parent home';
+
+  const onLand = useCallback(async () => {
+    if (landing) return;
+    setLanding(true);
+    try {
+      const sw = await switchProfile(created.parent.id);
+      if (!sw.success) {
+        setLandingError(sw.error ?? 'Could not switch profile.');
+        return;
+      }
+
+      await clearPreviewState();
+
+      if (target === 'self' || (target === 'both' && previewState.bothPriority === 'self_first')) {
+        // OPTION (A): call shared session-start helper with previewState.topicText.
+        // OPTION (B): router.replace('/(app)/home') and let the user start a session manually.
+        // FILL IN BASED ON TASK 0 SPIKE OUTCOME.
+      } else {
+        router.replace('/(app)/home');
+      }
+    } catch (err) {
+      setLandingError(formatApiError(err));
+    } finally {
+      setLanding(false);
+    }
+  }, [landing, switchProfile, created.parent.id, target, previewState, router]);
+
+  return (
+    <View>
+      <Text className="text-h3 font-semibold text-text-primary mb-2">
+        {target === 'self' || target === 'both'
+          ? `Your first lesson is ready${previewState.topicText ? `: ${previewState.topicText}` : ''}.`
+          : "Your child's profile is set up. Let's open parent home."}
+      </Text>
+      {landingError && (
+        <View className="bg-danger/10 rounded-card px-4 py-3 mb-3">
+          <Text className="text-danger text-body-sm">{landingError}</Text>
+        </View>
+      )}
+      <Pressable
+        onPress={() => void onLand()}
+        disabled={landing}
+        className={`rounded-button py-3.5 items-center ${landing ? 'bg-primary/40' : 'bg-primary'}`}
+        testID="save-confirm-land"
+        accessibilityRole="button"
+      >
+        {landing ? <ActivityIndicator color="white" /> : (
+          <Text className="text-body font-semibold text-text-inverse">{cta}</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+```
+
+Add imports: `clearPreviewState` from `preview-onboarding-state`, `useProfile` from `../../../lib/profile`, `formatApiError` (already imported).
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+- [ ] **Step 5: Manual smoke (one of the two paths in the Expo web preview).**
+
+```bash
+cd apps/mobile && pnpm run dev:web   # or whatever the project's dev command is
+```
+
+Walk: sign-in → Try MentoMate → Me → topic "algebra" → learner value-prop → Sign up → verify → save wizard → name + year → Continue → confirm → Start lesson. Assert lands on session/home appropriately.
+
+- [ ] **Step 6: Commit via `/commit`.**
+
+---
+
+## Task 15: Wire All Acceptance Criteria With a Coverage Sweep
+
+**Files:**
+- Re-read: `docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md` §Acceptance Criteria
+- All tests added in Tasks 1-14.
+
+- [ ] **Step 1: Map every AC to a test (or note "covered by E2E in Task 16").**
+
+Open the spec. For each numbered AC, list the test name covering it. AC list:
+
+1. Intent screen renders 4 options + no chat shell → `preview/intent.test.tsx`
+2. Self → learner value-prop with sample marker, no LLM → `value-prop.test.tsx`
+3. Child → parent value-prop, CTA copy → `value-prop.test.tsx`
+4. Auth returns to save wizard → `(app)/_layout.test.tsx` preview branch
+5. Wizard child→self override → `save.test.tsx`
+6. Wizard self→child override → `save.test.tsx`
+7. Parent lands on parent home + `isFamilyCapableProfile` true → `save.test.tsx` (parent target landing)
+8. Solo owner lands on learner home → `_layout.test.tsx` (resolveTabShape) + `save.test.tsx` (self target landing)
+9. Parent ok, child fails, no rollback → `save.test.tsx` (child failure case)
+10. 1-hour expiry → `preview-onboarding-state.test.tsx`
+11. Sign-out clears key → `sign-out-cleanup.test.ts`
+12. No preview state → CreateProfileGate unchanged → `_layout.test.tsx`
+13. `router.replace` on landing → `save.test.tsx`
+14. Back returns to topic/intent + topic preserved → manual + E2E (Task 16)
+15. Flag off: no CTA, no route, gate falls through → `sign-in.test.tsx` + `_layout.test.tsx`
+16. Navigation discipline: push for hops, replace for landing → grep assertion test (see step 2)
+
+- [ ] **Step 2: Cover AC 16 behaviorally inside existing route tests.** [MEDIUM-1]
+
+NO grep-over-source test. Source-scanning tests are fragile under different Jest CWDs, over-enforce (block any future legitimate `router.replace` in retry/recovery branches), and add no behavioral signal beyond what the existing render tests already cover.
+
+Instead, the existing route tests already assert the correct method:
+- `preview/intent.test.tsx`, `preview/topic.test.tsx`, `preview/value-prop.test.tsx` — all assert `push` was called with the expected target (added in Tasks 7, 8, 9).
+- `(app)/preview/save.test.tsx` — Task 14 already asserts `replace` was called with the landing route.
+
+Sweep those tests once: confirm every navigation assertion uses the matching method (`push` for hops, `replace` for landing). If any test was written with the wrong assertion, fix it now — that is the AC-16 verification step.
+
+- [ ] **Step 3: Run full mobile test sweep for changed files.**
+
+```bash
+cd apps/mobile && pnpm exec jest --findRelatedTests \
+  src/lib/feature-flags.ts \
+  src/lib/profile.ts \
+  src/lib/preview-onboarding-state.ts \
+  src/lib/sign-out-cleanup.ts \
+  src/app/preview/index.tsx \
+  src/app/preview/intent.tsx \
+  src/app/preview/topic.tsx \
+  src/app/preview/value-prop.tsx \
+  'src/app/(auth)/sign-up.tsx' \
+  'src/app/(auth)/sign-in.tsx' \
+  'src/app/(app)/_layout.tsx' \
+  'src/app/(app)/preview/save.tsx' \
+  --no-coverage
+```
+Expected: all pass.
+
+- [ ] **Step 4: Typecheck + lint.**
+
+```bash
+cd apps/mobile && pnpm exec tsc --noEmit
+pnpm exec nx lint mobile
+```
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 16: E2E Smoke Flows (Maestro)
+
+**Files:**
+- Create: `apps/mobile/e2e/preview-self.yaml`
+- Create: `apps/mobile/e2e/preview-parent.yaml`
+- Create: `apps/mobile/e2e/preview-both-child-first.yaml`
+- Create: `apps/mobile/e2e/preview-override-target.yaml`
+- Create: `apps/mobile/e2e/preview-expired-state.yaml`
+
+> If the E2E directory layout differs, find existing flows via `ls apps/mobile/e2e` or wherever `.yaml` Maestro flows live. Mirror their structure (waitForAnimationToEnd, testID selectors, adb reverse setup) rather than copying from this plan literally.
+
+- [ ] **Step 1: Bring up E2E infra.**
+
+Memory pointer: `project_e2e_emulator_infra.md` / `feedback_agent_owns_e2e_infra.md`. Agent owns emulator + Metro + proxy + adb-reverse. Start the device, install the app, point at the staging API as configured in existing E2E flows.
+
+- [ ] **Step 2: Write each flow.**
+
+Flow 1 — Self learner:
+- Launch app
+- Tap testID `try-mentomate-cta`
+- Tap testID `preview-landing-continue`
+- Tap testID `intent-self`
+- Input "algebra basics" into testID `preview-topic-input`
+- Tap testID `preview-topic-continue`
+- Assert testID `preview-value-prop-learner` visible
+- Assert testID `preview-sample-marker` visible
+- Tap testID `preview-signup-cta`
+- Drive Clerk signup with a fresh email seeded via test helper
+- After auth, assert testID `save-wizard-step-1`
+- Assert testID `save-target-self` is selected
+- Tap testID `save-wizard-step-1-continue`
+- Input name + birth year
+- Tap testID `save-basics-continue`
+- Tap testID `save-confirm-land`
+- Assert lands on the session route (whatever the topic-prefill spike resolved to) OR `/(app)/home` per option (b).
+
+Flow 2 — Parent:
+- ...intent-child, value-prop parent variant, signup, save wizard with `save-target-child` preselected, parent + child basics, lands on `/(app)/home` rendered as parent home.
+
+Flow 3 — Both child-first: as spec §User Flow → Both.
+
+Flow 4 — Save target overrides intent: pick `child` pre-signup, switch to `save-target-self` in wizard, assert only owner profile created (query API or assert UI shows learner home + no children).
+
+Flow 5 — Expired state: requires a dev/E2E-only seed mechanism. [LOW-1] Use `seedPreviewStateForTesting(state, staleMs)` from Task 3 (mirrors the existing `seedPendingAuthRedirectForTesting` pattern, gated by `EXPO_PUBLIC_E2E === 'true'`). Expose it through a debug-only screen or RN dev-menu hook so a Maestro flow can trigger it; then launch app, assert lands at intent screen (key deleted lazily on read).
+
+- [ ] **Step 3: Run smoke locally.**
+
+```bash
+# Use the project's Maestro invocation — check existing scripts.
+# Example shape:
+# maestro test apps/mobile/e2e/preview-self.yaml
+```
+
+- [ ] **Step 4: Fix selector mismatches and stabilization issues.**
+
+Common: missing `waitForAnimationToEnd`, missing testIDs (add them to source if forgotten). Do not loosen assertions — fix the code or the selector chain.
+
+- [ ] **Step 5: Commit via `/commit`.**
+
+---
+
+## Task 17: Run Required Validation
+
+> CLAUDE.md "Required Validation": integration tests when changing auth/profile scoping. Pre-commit hooks cover lint/typecheck/surgical tests automatically.
+
+- [ ] **Step 1: Run API integration tests (auth/profile-scoping changed via new flow that hits `POST /profiles`).**
+
+```bash
+pnpm exec nx run api:test -- --testPathPattern integration
+```
+Expected: pass (no API changes, but the flow exercises the existing route).
+
+- [ ] **Step 2: Run cross-package integration tests.**
+
+```bash
+pnpm exec nx run-many -t test -- --testPathPattern integration --no-coverage
+```
+Expected: pass.
+
+- [ ] **Step 3: Run `bash scripts/check-change-class.sh --run --fast`.**
+
+```bash
+bash scripts/check-change-class.sh --run --fast
+```
+Expected: clean.
+
+- [ ] **Step 4: Self-review the diff.**
+
+```bash
+git diff main..HEAD --stat
+```
+
+For each non-trivial file in the diff, open it and verify:
+- No `eslint-disable` snuck in.
+- No `jest.mock('./...')` of internal modules (GC1 / GC6).
+- No bare `['profiles']` invalidations — must use predicate (`q.queryKey[0] === 'profiles'`). [MEDIUM-6] Note: `apps/mobile/src/app/create-profile.tsx:184` currently uses a bare-key invalidation; it works because the `useProfiles` query key is currently `['profiles', userId]` and the bare key still matches a prefix. This plan adopts the predicate convention for new code. The existing site is a deferred sweep, not blocked by this PR.
+- No `key={themeKey}` on root layouts.
+- No persona checks or hardcoded hex colors in shared components.
+
+- [ ] **Step 5: Final commit (if any review fixes needed) via `/commit`.**
+
+---
+
+## Done Criteria
+
+- All Tasks 1-17 boxes ticked.
+- Spec ACs 1-16 each have a passing test (unit or E2E).
+- `PREVIEW_ONBOARDING_ENABLED = false` flip verified: CTA gone, save wizard not reachable, `CreateProfileGate` unchanged.
+- Sibling Study/Family v0 spec can import `isFamilyCapableProfile` without code changes.
+- No new `jest.mock('./...')` (GC1 ratchet).
+- Pre-commit + pre-push hooks pass on every commit (do NOT use `--no-verify`).
+
+Do NOT open a PR unless the user explicitly asks (memory: `feedback_no_pr_unless_asked.md`).
+Do NOT push an OTA update (memory: `feedback_no_ota_unless_asked.md`).


### PR DESCRIPTION
## Summary

Ships the pre-signup intent + post-signup save-wizard flow per `docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md` and `docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md`. New users can preview MentoMate (intent → topic → value-prop) before signup, then complete a 3-step save wizard that creates their owner profile (and optionally a child profile), gated by a flag and landing in either a session or parent home depending on target.

## What's in this PR

**Tasks 1-14 + 15 from the plan** (Task 10 SKIPPED per plan; Task 16 E2E deferred to a separate session because it needs emulator infra).

| Wave | Scope |
|---|---|
| 1 | Feature flags (mobile + API), `isFamilyCapableProfile()` helper, preview-onboarding-state lib, SecureStore mock upgrade |
| 2 | Sign-out cleanup, sign-in CTA, preview stack layout, server-side adult-owner rule + apiCode wiring |
| 3 | Intent / topic / value-prop preview screens |
| 4 | AppLayout probe + inline SaveWizardGate branch |
| 5a-c | SaveWizardGate steps 1-3 (target select, ProfileBasics with adult-age gate, ConfirmStep with dual landing per Task 0) |
| 15 | AC coverage audit (mapping table in plan; 14/16 ✅, 1 ⏸ deferred to E2E, 1 ⚠️ gap documented) |

## OPT-C: Adult-Owner Gate (defense in depth, behind kill switch)

Two independent feature flags both default ON, both can be toggled OFF to restore today's behaviour:
- **Mobile:** `FEATURE_FLAGS.ADULT_OWNER_GATE_ENABLED` — client-side pre-flight UX (inline warning + disabled Continue when an under-18 user tries to set up a child profile).
- **API:** `config.ADULT_OWNER_GATE_ENABLED` — server-side authoritative rule (`createProfileWithLimitCheck` throws `ForbiddenError('Account holder must be 18 or older to add a child profile.', 'ADULT_OWNER_REQUIRED')`).

Combination matrix in plan §Task 1. Both OFF = today's behaviour verbatim. Includes red-green break test verification (revert→fail→restore→pass) per CLAUDE.md security-fix rule.

## Task 0 resolution: dual landing keyed off wizard target

After save completes:
- `target = self` (solo adult OR any under-18 with own profile) → land in `/(app)/session` for the saved topic (momentum).
- `target = child` (adult parent, child profile not yet linked) → land on `/(app)/home` (orient + Add Child).

## Validation

- ✅ Mobile typecheck clean
- ✅ Mobile lint clean
- ✅ `pnpm exec jest --findRelatedTests` across all touched mobile source: **138 suites / 2104 tests pass**
- ✅ API targeted tests (`profile.integration.test.ts`, `profiles.test.ts`): **42 tests pass**
- ✅ Adult-owner rule break-test verified red-green (Task 13b)

## Open follow-ups (deferred, NOT blocking this PR)

1. **Task 16 — E2E Maestro smoke flows.** Needs emulator infra; not autonomous.
2. **AC 9 gap — parent-ok-child-fails resume test.** Implementation has the resume guard (`createdOwnerProfileId` cache check); test-only follow-up (~30 min). Documented in plan §Task 15.
3. **Telemetry funnel events.** Plan ships zero analytics events; 10 funnel events specified in plan §Task 15 Step 2b. Notion ticket to be opened.
4. **Spec amendment.** Spec line "no client-side pre-validation in v0" is overridden by OPT-C client gate; spec doc to be amended in a follow-up PR.

## Plan + spec references

- Spec: \`docs/specs/2026-05-18-trial-intent-save-onboarding-v0.md\`
- Plan: \`docs/plans/2026-05-19-trial-intent-save-onboarding-v0.md\` (3026 lines after 3 rounds of adversarial review + OPT-C + Task 0 resolution + Task 15 audit)

🤖 Generated with Claude Code