### PR TITLE
chore(i18n): centralize local staleness guard

### DIFF
--- a/docs/change-classes.md
+++ b/docs/change-classes.md
@@ -24,7 +24,7 @@ scripts/check-change-class.sh --branch     # check all changes vs main
 | **api-services** | `apps/api/src/services/**` (non-prompt) | `test:api:unit` | — | |
 | **mobile-routes** | `apps/mobile/src/app/**` | `test:mobile:unit` | — | `unstable_settings`; push ancestor chain |
 | **mobile-src** | `apps/mobile/src/**` (non-route, non-i18n) | `test:mobile:unit` | — | |
-| **i18n** | `apps/mobile/src/i18n/**` | `check:i18n`, `check:i18n:orphans` | — | Pre-commit enforces en.json staleness |
+| **i18n** | `apps/mobile/src/i18n/**`, `apps/mobile/src/**/*.{ts,tsx}` | `check:i18n:orphans`, `check:i18n` | — | Shared detector catches new `t()` calls outside locale files |
 | **shared-schemas** | `packages/schemas/src/**` | `test:api:unit`, `test:mobile:unit` | `test:api:integration`, `test:integration` | Never redefine types locally |
 | **shared-database** | `packages/database/src/**` (non-schema) | `test:api:unit` | `test:api:integration` | |
 | **security-sensitive** | `**/billing/**`, `**/auth/**`, `**/clerk*` | — | `test:api:integration` | Break tests required; no silent recovery |
@@ -65,7 +65,7 @@ The hook (`scripts/pre-push-tests.sh` + `.husky/pre-push`) runs automatically on
 - **tsc --build** — incremental typecheck on push delta (catches cross-commit type breakage)
 - **Surgical jest** — `--findRelatedTests` per project on the delta (same pattern as pre-commit, but on the cumulative push range)
 - **eval:llm** — when prompt files or eval harness code are in the delta
-- **check:i18n** — when i18n files are in the delta
+- **check:i18n:orphans** + **check:i18n** — when mobile source or i18n files are in the delta, using `scripts/lib/i18n-change-detection.sh`
 
 Skip with `git push --no-verify` or `SKIP_PRE_PUSH=1`. Skipped automatically on protected branches (`main` by default; configure via `PREPUSH_SKIP_BRANCHES`).
 

--- a/scripts/check-change-class.sh
+++ b/scripts/check-change-class.sh
@@ -14,6 +14,9 @@
 
 set -euo pipefail
 
+WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"
+source "$WORKSPACE_ROOT/scripts/lib/i18n-change-detection.sh"
+
 # ── Config ───────────────────────────────────────────────────────────────
 MODE="advisory"
 SOURCE="auto"
@@ -205,11 +208,11 @@ if [[ -n "$MOBILE_SRC" ]]; then
 fi
 
 # ── i18n ─────────────────────────────────────────────────────────────────
-if hit '^apps/mobile/src/i18n/'; then
+if i18n_delta_needs_checks "$FILES"; then
   CLASSES+=("i18n")
-  add_cmd fast  "pnpm check:i18n"            "i18n staleness check"
   add_cmd fast  "pnpm check:i18n:orphans"    "Orphan i18n key check"
-  note "i18n: Pre-commit enforces en.json staleness automatically"
+  add_cmd fast  "pnpm check:i18n"            "i18n staleness check"
+  note "i18n: Runs for mobile source changes because new t() calls can stale locale files"
 fi
 
 # ── Shared Schemas (@eduagent/schemas) ───────────────────────────────────

--- a/scripts/lib/i18n-change-detection.sh
+++ b/scripts/lib/i18n-change-detection.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Shared detection for changes that can introduce stale or missing i18n keys.
+# Accepts a newline-delimited file list as the first argument.
+i18n_delta_needs_checks() {
+  local files="${1:-}"
+
+  [[ -n "$files" ]] || return 1
+
+  echo "$files" | grep -Eq '^apps/mobile/src/(i18n/|.*\.(ts|tsx)$)'
+}

--- a/scripts/pre-push-tests.sh
+++ b/scripts/pre-push-tests.sh
@@ -22,6 +22,7 @@
 set -euo pipefail
 
 WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"
+source "$WORKSPACE_ROOT/scripts/lib/i18n-change-detection.sh"
 
 # ── Configuration ───────────────────────────────────────────────────────
 PREPUSH_SKIP_BRANCHES="${PREPUSH_SKIP_BRANCHES:-main}"
@@ -256,10 +257,15 @@ if [[ -n "$EVAL_CODE" ]] && [[ "$EVAL_RAN" -eq 0 ]]; then
   fi
 fi
 
-# check:i18n — i18n files changed
-if echo "$FILES" | grep -qE '^apps/mobile/src/i18n/'; then
+# check:i18n — mobile source or locale files changed
+if i18n_delta_needs_checks "$FILES"; then
   echo ""
-  echo "── check:i18n (i18n files in delta) ───────────────────────────"
+  echo "── check:i18n (mobile source or i18n files in delta) ───────────"
+  if ! pnpm check:i18n:orphans; then
+    echo ""
+    echo "pre-push: FAILED — orphan i18n key check failed"
+    exit 1
+  fi
   if ! pnpm check:i18n; then
     echo ""
     echo "pre-push: FAILED — i18n staleness check failed"


### PR DESCRIPTION
## Summary
- add a shared i18n change detector for local validation scripts
- run orphan-key and staleness checks when mobile source changes, not only locale files
- update the change-class docs to describe the centralized trigger

## Validation
- `pnpm check:i18n` passed
- `pnpm check:i18n:orphans` currently fails only because unrelated untracked local Challenge Round files contain missing keys; those files are not part of this PR
- Git Bash syntax checks passed for `scripts/lib/i18n-change-detection.sh`, `scripts/pre-push-tests.sh`, and `scripts/check-change-class.sh`
- helper detector manually verified for mobile source positive and API source negative cases
- pre-push hook passed on the 4-file push delta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified i18n change class detection scope and pre-push hook behavior in developer documentation.

* **Chores**
  * Expanded i18n change detection to include mobile source files (`ts`/`tsx`) in addition to locale files.
  * Enhanced pre-push validation to run comprehensive i18n checks when mobile source or i18n files are modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cognoco/eduagent-build/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->