### PR TITLE
Fix preview onboarding guard gaps

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.test.tsx
+++ b/apps/mobile/src/app/(app)/_layout.test.tsx
@@ -1029,15 +1029,36 @@ describe('AppLayout no-profile gate — preview branch', () => {
     expect(await findByTestId('save-wizard-gate')).toBeTruthy();
   });
 
-  // [CRITICAL-B2] Verify the layout does NOT install the auto-cleanup effect.
-  it('does NOT clear preview state automatically when activeProfile becomes truthy', async () => {
+  it('ignores and clears stale preview state for an already-profiled account', async () => {
     await setPreviewState({
       intent: 'self',
       path: 'learner_value_prop',
       createdAt: new Date().toISOString(),
     });
-    renderAppLayoutWithActiveProfile();
-    await Promise.resolve();
+
+    const { queryByTestId } = renderAppLayoutWithActiveProfile();
+
+    await waitFor(() => {
+      expect(queryByTestId('save-wizard-gate')).toBeNull();
+    });
+    await waitFor(async () => {
+      expect(await getPreviewState()).toBeNull();
+    });
+  });
+
+  // [CRITICAL-B2] Once the wizard has genuinely started, the layout must not
+  // clear preview state when ProfileProvider auto-activates the first profile.
+  it('does NOT clear preview state after the wizard has started and activeProfile becomes truthy', async () => {
+    await setPreviewState({
+      intent: 'self',
+      path: 'learner_value_prop',
+      createdAt: new Date().toISOString(),
+    });
+    const { findByTestId, simulateProfileCreated } =
+      renderAppLayoutWithNoProfile();
+    await findByTestId('save-wizard-gate');
+    simulateProfileCreated({ id: 'p1', isOwner: true });
+
     // The layout must leave the key intact; cleanup is the wizard's job (or TTL/sign-out).
     expect(await getPreviewState()).not.toBeNull();
   });

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -48,6 +48,7 @@ import { platformAlert } from '../../lib/platform-alert';
 import { FeedbackProvider } from '../../components/feedback/FeedbackProvider';
 import { ErrorFallback, GateContent } from '../../components/common';
 import { goBackOrReplace } from '../../lib/navigation';
+import { track } from '../../lib/analytics';
 import { useSubjects } from '../../hooks/use-subjects';
 import { useParentProxy } from '../../hooks/use-parent-proxy';
 import {
@@ -1113,6 +1114,12 @@ function ConfirmStep({
       }
 
       await clearPreviewState();
+      track('save_wizard_completed', {
+        target,
+        intent: previewState.intent,
+        childCreated: Boolean(created.child),
+        landing: isSelfBranch ? 'session' : 'home',
+      });
       onComplete(); // [HIGH-A2] signal wizard done before navigating
 
       if (isSelfBranch) {
@@ -1140,6 +1147,9 @@ function ConfirmStep({
     landing,
     switchProfile,
     created.parent.id,
+    created.child,
+    target,
+    previewState.intent,
     isSelfBranch,
     previewState.topicText,
     onComplete,
@@ -1189,8 +1199,10 @@ function ConfirmStep({
  */
 function SaveWizardGate({
   onComplete,
+  onStart,
 }: {
   onComplete: () => void;
+  onStart: () => void;
 }): React.ReactElement {
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -1205,12 +1217,22 @@ function SaveWizardGate({
   } | null>(null);
 
   React.useEffect(() => {
+    onStart();
     void getPreviewState().then((s) => {
       setLocalPreviewState(s);
       setTarget(defaultTargetFor(s));
       setProbeDone(true);
     });
-  }, []);
+  }, [onStart]);
+
+  React.useEffect(() => {
+    if (!previewState) return;
+    track('save_wizard_step_started', {
+      step,
+      target: target ?? 'unset',
+      intent: previewState.intent,
+    });
+  }, [step, target, previewState]);
 
   // [CRITICAL-3] Recovery path for "wizard mounted with no state" — happens
   // when the 1h TTL expires between the layout's initial probe and this
@@ -2135,6 +2157,10 @@ export default function AppLayout() {
   // [HIGH-A2] Wizard completion sentinel. previewProbeState alone never flips
   // back to 'absent' after mount; the wizard signals completion via onComplete.
   const [wizardDone, setWizardDone] = React.useState(false);
+  // The preview wizard may outlive first-profile auto-activation once it has
+  // actually started, but stale preview state must not hijack existing users
+  // who already have an active profile when the layout first loads.
+  const [wizardStarted, setWizardStarted] = React.useState(false);
 
   React.useEffect(() => {
     if (!FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED) {
@@ -2160,6 +2186,28 @@ export default function AppLayout() {
   //   (a) TTL inside getPreviewState (1h)
   //   (b) sign-out-cleanup (Task 4)
   //   (c) wizard's explicit clearPreviewState() on Step-3 success (Task 14)
+
+  React.useEffect(() => {
+    if (
+      !FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED ||
+      previewProbeState !== 'present' ||
+      !activeProfile ||
+      wizardStarted ||
+      wizardDone
+    ) {
+      return;
+    }
+    setPreviewProbeState('absent');
+    void clearPreviewState();
+  }, [activeProfile, previewProbeState, wizardDone, wizardStarted]);
+
+  const markWizardStarted = React.useCallback(() => {
+    setWizardStarted(true);
+  }, []);
+
+  const markWizardDone = React.useCallback(() => {
+    setWizardDone(true);
+  }, []);
 
   if (!isLoaded)
     return (
@@ -2325,11 +2373,15 @@ export default function AppLayout() {
   if (
     FEATURE_FLAGS.PREVIEW_ONBOARDING_ENABLED &&
     previewProbeState === 'present' &&
-    !wizardDone
+    !wizardDone &&
+    (!activeProfile || wizardStarted)
   ) {
     return (
       <FeedbackProvider>
-        <SaveWizardGate onComplete={() => setWizardDone(true)} />
+        <SaveWizardGate
+          onStart={markWizardStarted}
+          onComplete={markWizardDone}
+        />
       </FeedbackProvider>
     );
   }

--- a/apps/mobile/src/app/preview/_layout.test.tsx
+++ b/apps/mobile/src/app/preview/_layout.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react-native';
+import { useAuth } from '@clerk/clerk-expo';
+
+const mockReplace = jest.fn();
+
+jest.mock('expo-router', () => ({
+  Stack: ({ children }: { children?: React.ReactNode }) => {
+    const { View } = require('react-native');
+    return <View testID="stack">{children}</View>;
+  },
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock('@clerk/clerk-expo', () => ({
+  useAuth: jest.fn(),
+}));
+
+const PreviewLayout = require('./_layout').default;
+
+describe('PreviewLayout auth guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReplace.mockReset();
+  });
+
+  it('renders nothing while Clerk is still loading', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: false,
+      isSignedIn: undefined,
+    });
+
+    const { toJSON } = render(<PreviewLayout />);
+
+    expect(toJSON()).toBeNull();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('renders the preview Stack when the user is signed out', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: false,
+    });
+
+    render(<PreviewLayout />);
+
+    screen.getByTestId('stack');
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects signed-in users away from preview routes', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+
+    render(<PreviewLayout />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/(app)/home');
+    expect(screen.queryByTestId('stack')).toBeNull();
+  });
+
+  it('redirects when isSignedIn flips false to true mid-flow', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: false,
+    });
+
+    const { rerender } = render(<PreviewLayout />);
+    screen.getByTestId('stack');
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+    });
+    rerender(<PreviewLayout />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/(app)/home');
+    expect(screen.queryByTestId('stack')).toBeNull();
+  });
+});

--- a/apps/mobile/src/app/preview/_layout.tsx
+++ b/apps/mobile/src/app/preview/_layout.tsx
@@ -1,5 +1,23 @@
-import { Stack } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { Stack, useRouter } from 'expo-router';
+import { useAuth } from '@clerk/clerk-expo';
 
 export default function PreviewLayout() {
+  const { isLoaded, isSignedIn } = useAuth();
+  const router = useRouter();
+  const didRedirectRef = useRef(false);
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn) {
+      didRedirectRef.current = false;
+      return;
+    }
+    if (didRedirectRef.current) return;
+    didRedirectRef.current = true;
+    router.replace('/(app)/home');
+  }, [isLoaded, isSignedIn, router]);
+
+  if (!isLoaded || isSignedIn) return null;
+
   return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/apps/mobile/src/app/preview/intent.tsx
+++ b/apps/mobile/src/app/preview/intent.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -6,6 +7,7 @@ import {
   type PreviewIntent,
 } from '../../lib/preview-onboarding-state';
 import { goBackOrReplace } from '../../lib/navigation';
+import { track } from '../../lib/analytics';
 
 interface Option {
   intent: PreviewIntent;
@@ -45,8 +47,13 @@ export default function PreviewIntentScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
+  useEffect(() => {
+    track('preview_intent_seen');
+  }, []);
+
   const onSelect = async (intent: PreviewIntent) => {
     const createdAt = new Date().toISOString();
+    track('preview_intent_selected', { intent });
 
     if (intent === 'self') {
       await setPreviewState({

--- a/apps/mobile/src/app/preview/topic.tsx
+++ b/apps/mobile/src/app/preview/topic.tsx
@@ -9,6 +9,7 @@ import {
   type PreviewOnboardingStateV0,
 } from '../../lib/preview-onboarding-state';
 import { goBackOrReplace } from '../../lib/navigation';
+import { track } from '../../lib/analytics';
 
 // [MEDIUM-5] Single-line topic cap. The value is persisted to SecureStore for
 // up to 1h pre-signup, so it WILL outlive the screen. Keeping the field short
@@ -43,6 +44,11 @@ export default function PreviewTopicScreen() {
     const s = current ?? (await getPreviewState());
     if (!s) return;
     await setPreviewState({ ...s, topicText: trimmed });
+    track('preview_topic_submitted', {
+      intent: s.intent,
+      path: s.path,
+      topicLength: trimmed.length,
+    });
     router.push({
       pathname: '/preview/value-prop',
       params: { variant: 'learner' },

--- a/apps/mobile/src/app/preview/value-prop.tsx
+++ b/apps/mobile/src/app/preview/value-prop.tsx
@@ -7,6 +7,7 @@ import {
   type PreviewOnboardingStateV0,
 } from '../../lib/preview-onboarding-state';
 import { goBackOrReplace } from '../../lib/navigation';
+import { track } from '../../lib/analytics';
 
 type Variant = 'learner' | 'parent';
 
@@ -26,6 +27,14 @@ export default function ValuePropScreen() {
 
   const variant: Variant = params.variant === 'parent' ? 'parent' : 'learner';
   const topic = previewState?.topicText ?? '';
+
+  useEffect(() => {
+    track('preview_value_prop_shown', {
+      variant,
+      intent: previewState?.intent,
+      hasTopic: Boolean(previewState?.topicText),
+    });
+  }, [variant, previewState?.intent, previewState?.topicText]);
 
   return (
     <ScrollView
@@ -58,7 +67,14 @@ export default function ValuePropScreen() {
         <ParentVariant />
       )}
       <Pressable
-        onPress={() => router.push('/sign-up')}
+        onPress={() => {
+          track('preview_signup_cta_tapped', {
+            variant,
+            intent: previewState?.intent,
+            hasTopic: Boolean(previewState?.topicText),
+          });
+          router.push('/sign-up');
+        }}
         className="bg-primary rounded-button py-3.5 px-8 items-center w-full mt-8"
         testID="preview-signup-cta"
         accessibilityRole="button"

--- a/apps/mobile/src/lib/preview-onboarding-state.test.ts
+++ b/apps/mobile/src/lib/preview-onboarding-state.test.ts
@@ -59,11 +59,26 @@ describe('preview-onboarding-state', () => {
     expect(await getPreviewState()).toBeNull();
   });
 
+  it('treats warm in-memory state as expired after the TTL', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-20T12:00:00.000Z'));
+    await setPreviewState(baseState);
+
+    jest.setSystemTime(Date.now() + PREVIEW_TTL_MS + 1000);
+
+    await expect(getPreviewState()).resolves.toBeNull();
+    expect(await SecureStore.getItemAsync(PREVIEW_INTENT_KEY)).toBeNull();
+  });
+
   it('clearPreviewState wipes memory AND SecureStore', async () => {
     await setPreviewState(baseState);
     await clearPreviewState();
 
     expect(await getPreviewState()).toBeNull();
     expect(await SecureStore.getItemAsync(PREVIEW_INTENT_KEY)).toBeNull();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 });

--- a/apps/mobile/src/lib/preview-onboarding-state.ts
+++ b/apps/mobile/src/lib/preview-onboarding-state.ts
@@ -25,14 +25,24 @@ interface StoredRecord extends PreviewOnboardingStateV0 {
   savedAt: number;
 }
 
-let memoryState: PreviewOnboardingStateV0 | null = null;
+let memoryRecord: StoredRecord | null = null;
 
 function isFresh(savedAt: number): boolean {
   return Date.now() - savedAt < PREVIEW_TTL_MS;
 }
 
 export async function getPreviewState(): Promise<PreviewOnboardingStateV0 | null> {
-  if (memoryState) return memoryState;
+  if (memoryRecord) {
+    if (isFresh(memoryRecord.savedAt)) {
+      const { savedAt: _ignored, ...state } = memoryRecord;
+      return state;
+    }
+    memoryRecord = null;
+    await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY).catch(
+      () => undefined,
+    );
+    return null;
+  }
 
   try {
     const raw = await SecureStore.getItemAsync(PREVIEW_INTENT_KEY);
@@ -59,8 +69,8 @@ export async function getPreviewState(): Promise<PreviewOnboardingStateV0 | null
     }
 
     const { savedAt: _ignored, ...state } = parsed as StoredRecord;
-    memoryState = state as PreviewOnboardingStateV0;
-    return memoryState;
+    memoryRecord = parsed as StoredRecord;
+    return state as PreviewOnboardingStateV0;
   } catch {
     return null;
   }
@@ -69,8 +79,8 @@ export async function getPreviewState(): Promise<PreviewOnboardingStateV0 | null
 export async function setPreviewState(
   state: PreviewOnboardingStateV0,
 ): Promise<void> {
-  memoryState = state;
   const record: StoredRecord = { ...state, savedAt: Date.now() };
+  memoryRecord = record;
   try {
     // [SEC] WHEN_UNLOCKED_THIS_DEVICE_ONLY excludes from iCloud Keychain sync
     // and device-to-device backups; bounds the topic-text leak surface to
@@ -84,7 +94,7 @@ export async function setPreviewState(
 }
 
 export async function clearPreviewState(): Promise<void> {
-  memoryState = null;
+  memoryRecord = null;
   try {
     await SecureStore.deleteItemAsync(PREVIEW_INTENT_KEY);
   } catch {
@@ -110,8 +120,8 @@ export async function seedPreviewStateForTesting(
   ) {
     throw new Error('seedPreviewStateForTesting is dev-only');
   }
-  memoryState = state;
   const record: StoredRecord = { ...state, savedAt: Date.now() - staleMs };
+  memoryRecord = record;
   await SecureStore.setItemAsync(PREVIEW_INTENT_KEY, JSON.stringify(record), {
     keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
   });


### PR DESCRIPTION
## Summary
- guard signed-in users out of `/preview/*` routes before they can rewrite preview state
- prevent stale preview state from hijacking already-profiled accounts while preserving the in-progress save wizard across first-profile activation
- enforce the 1-hour TTL for warm in-memory preview state, not only SecureStore hydration
- add preview/save-wizard funnel breadcrumbs for the missing onboarding analytics path

## Validation
- `cd apps/mobile; pnpm exec jest --findRelatedTests src/lib/preview-onboarding-state.ts src/app/preview/_layout.tsx 'src/app/(app)/_layout.tsx' --no-coverage` — 7 suites / 84 tests passed
- touched-file ESLint — 0 errors; existing warnings only
- pre-commit hook — lint-staged, incremental `tsc --build`, related Jest passed
- pre-push hook — incremental `tsc --build`, related Jest, i18n checks passed