### PR TITLE
Harden preview seed route

### DIFF
--- a/apps/mobile/src/app/dev-only/seed-preview-state.test.tsx
+++ b/apps/mobile/src/app/dev-only/seed-preview-state.test.tsx
@@ -20,6 +20,7 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ replace: mockReplace }),
 }));
 
+const previousE2E = process.env.EXPO_PUBLIC_E2E;
 process.env.EXPO_PUBLIC_E2E = 'true';
 
 const SeedPreviewStateScreen = require('./seed-preview-state')
@@ -39,6 +40,14 @@ describe('SeedPreviewStateScreen', () => {
 
   afterEach(async () => {
     await clearPreviewState();
+  });
+
+  afterAll(() => {
+    if (previousE2E === undefined) {
+      delete process.env.EXPO_PUBLIC_E2E;
+      return;
+    }
+    process.env.EXPO_PUBLIC_E2E = previousE2E;
   });
 
   it('seeds fresh preview state and returns to the preview intent screen', async () => {
@@ -68,6 +77,28 @@ describe('SeedPreviewStateScreen', () => {
 
     await waitFor(async () => {
       await expect(getPreviewState()).resolves.toBeNull();
+    });
+    expect(mockReplace).toHaveBeenCalledWith('/preview/intent');
+  });
+
+  it('falls back to the intent default when the requested path is invalid', async () => {
+    mockUseLocalSearchParams.mockReturnValue({
+      intent: 'child',
+      path: 'not_a_preview_path',
+      topicText: 'geometry',
+      staleMs: '0',
+    });
+
+    render(<SeedPreviewStateScreen />);
+
+    await waitFor(async () => {
+      await expect(getPreviewState()).resolves.toEqual(
+        expect.objectContaining({
+          intent: 'child',
+          path: 'parent_value_prop',
+          topicText: 'geometry',
+        }),
+      );
     });
     expect(mockReplace).toHaveBeenCalledWith('/preview/intent');
   });

--- a/apps/mobile/src/app/dev-only/seed-preview-state.tsx
+++ b/apps/mobile/src/app/dev-only/seed-preview-state.tsx
@@ -27,6 +27,11 @@ const VALID_INTENTS = new Set<PreviewIntent>([
   'not_sure',
 ]);
 
+const VALID_PATHS = new Set<PreviewPath>([
+  'learner_value_prop',
+  'parent_value_prop',
+]);
+
 function parseIntent(value: string | undefined): PreviewIntent {
   return value && VALID_INTENTS.has(value as PreviewIntent)
     ? (value as PreviewIntent)
@@ -37,6 +42,15 @@ function defaultPathForIntent(intent: PreviewIntent): PreviewPath {
   return intent === 'child' || intent === 'both'
     ? 'parent_value_prop'
     : 'learner_value_prop';
+}
+
+function parsePath(
+  value: string | undefined,
+  intent: PreviewIntent,
+): PreviewPath {
+  return value && VALID_PATHS.has(value as PreviewPath)
+    ? (value as PreviewPath)
+    : defaultPathForIntent(intent);
 }
 
 export default function SeedPreviewStateScreen(): React.ReactElement | null {
@@ -54,13 +68,12 @@ export default function SeedPreviewStateScreen(): React.ReactElement | null {
 
     const run = async () => {
       const parsedIntent = parseIntent(intent);
+      const parsedPath = parsePath(path, parsedIntent);
       const parsedStaleMs = parseInt(staleMs ?? '0', 10);
       await seedPreviewStateForTesting(
         {
           intent: parsedIntent,
-          path:
-            (path as PreviewPath | undefined) ??
-            defaultPathForIntent(parsedIntent),
+          path: parsedPath,
           topicText,
           bothPriority: parsedIntent === 'both' ? 'child_first' : undefined,
           createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- follow up on CodeRabbit comments from #351 after it merged
- restore `EXPO_PUBLIC_E2E` after the dev-only preview seed route test
- validate the preview seed `path` query parameter before using it, with fallback coverage

## Validation

- `apps/mobile`: `jest --findRelatedTests src/app/dev-only/seed-preview-state.tsx --no-coverage` passed
- `apps/mobile`: focused ESLint for preview seed route/test passed
- `apps/mobile`: `pnpm exec tsc --noEmit` passed
- pre-push hook passed